### PR TITLE
Chapter 15 review fixes: bicycle LOS equations, Exhibit 15-11 vertical class, REVIEW_NOTES #1/#3/#8/#15

### DIFF
--- a/docs/hcm/REVIEW_NOTES.md
+++ b/docs/hcm/REVIEW_NOTES.md
@@ -4,14 +4,14 @@ Code-level findings surfaced by the documentation pass (independent agents readi
 
 ## Likely bugs (recommend fixing before or during branch review)
 
-1. **PyO3 `SubSegment` docstring says length is in miles; the engine treats it as feet** (÷5280). A Python caller following the docstring gets a 5,280x error. This is the historical Ch 15 unit footgun, now printed in the bindings docs. `src/copython/chapter15.rs` (feat/hcm-restructure).
+1. ~~FIXED (feat/hcm-ch15-review-fixes)~~ **PyO3 `SubSegment` docstring says length is in miles; the engine treats it as feet** (÷5280). A Python caller following the docstring gets a 5,280x error. This is the historical Ch 15 unit footgun, now printed in the bindings docs. `src/copython/chapter15.rs` (feat/hcm-restructure).
 2. **`todo!()` panics reachable in `adjustment_heavy_vehicle_factor`** for grade/length PCE combos outside the transcribed grid, and its `length == 0.125` fallback clobbers previously computed `e_t`. Library code should never panic on valid-ish input. `src/hcm/chapter12/basicfreeways.rs` (feat/hcm-ch12-14-completion).
-3. **`determine_vertical_alignment` missing length bucket**: upgrade branch jumps from `<= 0.5` to `> 0.6` mi, so 0.5–0.6 mi segments fall through to the catch-all thresholds. `src/hcm/chapter15/twolanehighways.rs` (feat/hcm-restructure).
+3. ~~FIXED (feat/hcm-ch15-review-fixes; also fixed: missing 0.7-0.8 mi bucket, and the downgrade branch negated LENGTH instead of GRADE so every downgrade returned class 1)~~ **`determine_vertical_alignment` missing length bucket**: upgrade branch jumps from `<= 0.5` to `> 0.6` mi, so 0.5–0.6 mi segments fall through to the catch-all thresholds. `src/hcm/chapter15/twolanehighways.rs` (feat/hcm-restructure).
 4. **Divide-by-zero at g/C = 1.0** in `progression_factor`/`uniform_delay`; guard posture inconsistent with `initial_queue_delay`. `src/hcm/common/delay.rs` (feat/hcm-shared-infra).
 5. **Major-merge LOS inconsistency**: `RampSegment::determine_los` returns `LevelOfService::E` while setting `self.los = None` (HCM defines no LOS there). Callers using the return value get a fabricated letter. `src/hcm/chapter14/merge_diverge.rs` (feat/hcm-ch12-14-completion).
 6. **8-lane P_FM can go negative** for v_R above ~1,742 pc/h — no clamp. `merge_diverge.rs` (feat/hcm-ch12-14-completion).
 7. **Oversaturated managed lane silently reports demand-based results**: `ml_dc_ratio` is computed but never routes the ML lane group through the oversaturated engine. Consistent with the documented Eq 25-35/36 deferral but should hard-error or warn instead of silently passing demand. `src/hcm/chapter10/managed_lanes.rs` (feat/hcm-ch10-managed-lanes).
-8. **`tests/common/mod.rs::load_test_data_files()` reads `src/ExampleCases/...` which does not exist** — `case_study1.json` is silently excluded from all Rust tests (feat/hcm-restructure).
+8. ~~FIXED (feat/hcm-ch15-review-fixes)~~ **`tests/common/mod.rs::load_test_data_files()` reads `src/ExampleCases/...` which does not exist** — `case_study1.json` is silently excluded from all Rust tests (feat/hcm-restructure).
 
 ## Inconsistencies / dead code (fix opportunistically)
 
@@ -21,7 +21,7 @@ Code-level findings surfaced by the documentation pass (independent agents readi
 12. `queue_end_of_period` has an unreachable `else` arm in its t_A selection (feat/hcm-reliability-enhancements).
 13. Stale milestone-1 comment on `step_10_queue_storage` says ADP "is a milestone-2 item" though the code now consumes the ADP result (feat/hcm-ch19-actuated).
 14. `DEFAULT_BFFS_FREEWAY` (75.4) declared, never used (chapter12). Dead duplicate branch in Ch 15 `determine_demand_flow` (pt==2, 5<=phv<10 assigns 1500 in both arms). Live author-doubt comment in `calc_speed` (`// Should be ST instead of S?`).
-15. `TwoLaneHighways.apd` doc comment says default 0; code uses `unwrap_or(5.0)` (feat/hcm-restructure).
+15. ~~FIXED (doc updated to match code, feat/hcm-ch15-review-fixes)~~ `TwoLaneHighways.apd` doc comment says default 0; code uses `unwrap_or(5.0)` (feat/hcm-restructure).
 16. `planning.rs` module doc cites Exhibit 25-17 for LOS but the code reuses `los_freeway_facility` (Exhibit 10-6); EP6 letters pass, so the tables likely agree — one-time check against the book (feat/hcm-ch10-managed-lanes).
 17. Two overlapping validation systems: `support/constraints.rs` vs the SF-001..005 semantic firewall in `common/mod.rs` — candidates for unification (feat/hcm-restructure).
 18. `TurnType::UTurn` never receives a NEMA number despite the doc comment referencing the Ch 20 1U/4U convention (feat/hcm-shared-infra).

--- a/src/copython/chapter15.rs
+++ b/src/copython/chapter15.rs
@@ -19,7 +19,7 @@ impl SubSegment {
     /// Create a new SubSegment.
     ///
     /// Args:
-    ///     length: Length of the sub-segment in miles (default: 0.0)
+    ///     length: Length of the sub-segment in FEET (default: 0.0). Note: unlike Segment.length (miles), sub-segment lengths are in feet; the engine divides by 5,280 internally.
     ///     avg_speed: Average travel speed in mph (default: 0.0)
     ///     hor_class: Horizontal alignment class (1-5, default: 1)
     ///     design_rad: Design radius in feet (default: 0.0)
@@ -50,7 +50,7 @@ impl SubSegment {
         }
     }
 
-    /// Get the length of the sub-segment in miles.
+    /// Get the length of the sub-segment in feet.
     #[getter]
     pub fn get_length(&self) -> f64 {
         self.inner.get_length()
@@ -102,7 +102,7 @@ impl SubSegment {
     /// Detailed string representation.
     pub fn __str__(&self) -> String {
         format!(
-            "SubSegment: {:.2} miles, {:.1} mph average speed, horizontal class {}",
+            "SubSegment: {:.2} ft, {:.1} mph average speed, horizontal class {}",
             self.get_length(),
             self.get_avg_speed(),
             self.get_hor_class()

--- a/src/hcm/chapter15/twolanehighways.rs
+++ b/src/hcm/chapter15/twolanehighways.rs
@@ -537,7 +537,7 @@ impl TwoLaneHighways {
     /// * `segments` - Vector of highway segments (must be contiguous and in order)
     /// * `lane_width` - Lane width in feet (default: 12 ft if None)
     /// * `shoulder_width` - Paved shoulder width in feet (default: 6 ft if None)
-    /// * `apd` - Access point density in points/mile (default: 0 if None)
+    /// * `apd` - Access point density in points/mile (defaults to 5.0 if None)
     /// * `pmhvfl` - Proportion of heavy vehicles in faster lane for PL segments
     /// * `l_de` - Effective distance from passing lane (computed if None)
     ///
@@ -747,7 +747,7 @@ impl TwoLaneHighways {
     /// - Upgrades and downgrades have different classification thresholds
     /// - If the computed class differs from stored value, it updates and re-runs Step 1
     pub fn determine_vertical_alignment(&mut self, seg_num: usize) -> i32 {
-        let mut seg_length = self.segments[seg_num].get_length();
+        let seg_length = self.segments[seg_num].get_length();
         let seg_grade = self.segments[seg_num].get_grade();
 
         let ver_align: i32;
@@ -796,6 +796,17 @@ impl TwoLaneHighways {
                     ver_align = 1
                 } else if seg_grade <= 4.0 {
                     ver_align = 2
+                } else if seg_grade <= 5.0 {
+                    ver_align = 3
+                } else if seg_grade <= 6.0 {
+                    ver_align = 4
+                } else {
+                    ver_align = 5
+                };
+            } else if seg_length > 0.5 && seg_length <= 0.6 {
+                // HCM Exhibit 15-11 row >0.5-0.6 mi (upgrades)
+                if seg_grade <= 2.0 {
+                    ver_align = 1
                 } else if seg_grade <= 3.0 {
                     ver_align = 2
                 } else if seg_grade <= 5.0 {
@@ -817,7 +828,9 @@ impl TwoLaneHighways {
                 } else {
                     ver_align = 5
                 };
-            } else if seg_length > 0.8 && seg_length <= 1.1 {
+            } else if seg_length > 0.7 && seg_length <= 1.1 {
+                // HCM Exhibit 15-11 rows >0.7-0.8 through >1.0-1.1 mi share these
+                // upgrade thresholds; the previous chain skipped >0.7-0.8 entirely.
                 if seg_grade <= 2.0 {
                     ver_align = 1
                 } else if seg_grade <= 3.0 {
@@ -841,7 +854,11 @@ impl TwoLaneHighways {
                 };
             }
         } else {
-            seg_length = -1.0 * seg_length;
+            // Downgrades: Exhibit 15-11 parenthesized values, looked up with the
+            // grade magnitude. (Previously the LENGTH was negated instead, which
+            // sent every downgrade into the first length bucket with an
+            // always-true grade test, so all downgrades returned class 1.)
+            let seg_grade = -1.0 * seg_grade;
             if seg_length <= 0.1 {
                 if seg_grade <= 8.0 {
                     ver_align = 1
@@ -2383,37 +2400,35 @@ impl BicycleLOS {
         self.hourly_volume / (self.phf * self.num_lanes as f64)
     }
 
-    /// Calculate effective width as a function of traffic volume (Equations 15-44, 15-45)
+    /// Calculate effective width as a function of traffic volume (Equations 15-44, 15-45).
+    /// HCM defines V here as the hourly directional volume per lane (veh/h).
     fn calculate_wv(&self) -> f64 {
-        if self.hourly_volume > 160.0 {
-            // Equation 15-44
-            self.lane_width
-        } else {
-            // Equation 15-45
+        let v = self.hourly_volume / self.num_lanes as f64;
+        if v > 160.0 {
+            // HCM Equation 15-44: Wv = W_OL + Ws
             self.lane_width + self.shoulder_width
+        } else {
+            // HCM Equation 15-45: Wv = (W_OL + Ws) * (2 - 0.005 * V)
+            (self.lane_width + self.shoulder_width) * (2.0 - 0.005 * v)
         }
     }
 
     /// Step 3: Calculate the effective width (Equations 15-41 to 15-45)
     pub fn calculate_effective_width(&self) -> f64 {
         let ws = self.shoulder_width;
-        let wol = self.lane_width;
         let wv = self.calculate_wv();
         let pct_ohp = self.pct_on_highway_parking;
 
-        let we = if ws >= 8.0 {
-            // Equation 15-41: Ws >= 8 ft
-            wol + ws - 20.0 * pct_ohp
+        if ws >= 8.0 {
+            // HCM Equation 15-41: Ws >= 8 ft
+            wv + ws - pct_ohp * 10.0
         } else if ws >= 4.0 {
-            // Equation 15-42: 4 ft <= Ws < 8 ft
-            wol + ws - 20.0 * pct_ohp
+            // HCM Equation 15-42: 4 ft <= Ws < 8 ft
+            wv + ws - 2.0 * (pct_ohp * (2.0 + ws))
         } else {
-            // Equation 15-43: Ws < 4 ft
-            wv + ws * (1.0 - 2.0 * pct_ohp)
-        };
-
-        // Ensure effective width is positive
-        we.max(1.0)
+            // HCM Equation 15-43: Ws < 4 ft
+            wv - pct_ohp * (2.0 + ws)
+        }
     }
 
     /// Step 4: Calculate the effective speed factor (Equation 15-46)
@@ -2423,14 +2438,14 @@ impl BicycleLOS {
     }
 
     /// Step 5: Calculate the BLOS score (Equation 15-47)
-    /// BLOS = 0.507 * ln(v_OL) + 0.199 * St * (1 + 10.38 * HV)^2 + 7.066 * (1/P)^2 - 0.005 * We^2 + 0.760
+    /// BLOS = 0.507 * ln(v_OL) + 0.1999 * St * (1 + 10.38 * HV)^2 + 7.066 * (1/P)^2 - 0.005 * We^2 + 0.760
     pub fn calculate_blos_score(&self) -> f64 {
         let v_ol = self.calculate_flow_rate_outside_lane();
         let st = self.calculate_effective_speed_factor();
         let we = self.calculate_effective_width();
         let p = self.pavement_condition;
 
-        // For low volumes (V < 200 veh/h), HV should be limited to max 0.5
+        // HCM Eq 15-47 note: if V < 200 veh/h, HV is limited to a maximum of 0.5
         let hv = if self.hourly_volume < 200.0 {
             self.heavy_vehicle_pct.min(0.5)
         } else {
@@ -2440,9 +2455,9 @@ impl BicycleLOS {
         // Handle edge case where v_OL is very small or zero
         let ln_v_ol = if v_ol > 0.0 { f64::ln(v_ol) } else { 0.0 };
 
-        // Equation 15-47
+        // HCM Equation 15-47
         0.507 * ln_v_ol
-            + 0.199 * st * (1.0 + 10.38 * hv).powi(2)
+            + 0.1999 * st * (1.0 + 10.38 * hv).powi(2)
             + 7.066 * (1.0 / p).powi(2)
             - 0.005 * we.powi(2)
             + 0.760

--- a/tests/ExampleCases/hcm/TwoLaneHighways/bicycle_widening.json
+++ b/tests/ExampleCases/hcm/TwoLaneHighways/bicycle_widening.json
@@ -1,0 +1,36 @@
+{
+    "description": "HCM Ch 26 two-lane highway example: widening/repaving project evaluated for bicycle LOS in the peak direction. Expected values are the published worked-example results (BLOS 5.90/F current, 3.58/D proposed). Note the BLOS method's input set differs from the motorized method: pavement rating and on-highway parking matter, segment length does not.",
+    "current": {
+        "lane_width": 12.0,
+        "shoulder_width": 2.0,
+        "speed_limit": 50.0,
+        "num_lanes": 1,
+        "pavement_condition": 3.0,
+        "hourly_volume": 500.0,
+        "phf": 0.90,
+        "heavy_vehicle_pct": 0.05,
+        "pct_on_highway_parking": 0.0
+    },
+    "proposed": {
+        "lane_width": 12.0,
+        "shoulder_width": 6.0,
+        "speed_limit": 55.0,
+        "num_lanes": 1,
+        "pavement_condition": 5.0,
+        "hourly_volume": 500.0,
+        "phf": 0.90,
+        "heavy_vehicle_pct": 0.05,
+        "pct_on_highway_parking": 0.0
+    },
+    "expected": {
+        "flow_rate_outside_lane": 555.6,
+        "current_effective_width": 14.0,
+        "proposed_effective_width": 24.0,
+        "current_effective_speed_factor": 4.62,
+        "proposed_effective_speed_factor": 4.79,
+        "current_blos_score": 5.90,
+        "proposed_blos_score": 3.58,
+        "current_los": "F",
+        "proposed_los": "D"
+    }
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -188,7 +188,7 @@ pub fn create_suburban_highway() -> TwoLaneHighways {
 
 /// Load test data files if they exist
 pub fn load_test_data_files() -> Vec<String> {
-    let test_dir = "src/ExampleCases/hcm/TwoLaneHighways/";
+    let test_dir = "tests/ExampleCases/hcm/TwoLaneHighways/";
     if std::path::Path::new(test_dir).exists() {
         let paths = fs::read_dir(test_dir).expect("Unable to read test directory");
         let mut files: Vec<String> = paths

--- a/tests/twolanehighways_test.rs
+++ b/tests/twolanehighways_test.rs
@@ -1,3 +1,4 @@
+use assert_approx_eq::assert_approx_eq;
 use transportations_library::math;
 use transportations_library::twolanehighways::{BicycleLOS, Segment, SubSegment, TwoLaneHighways};
 
@@ -12,10 +13,15 @@ fn read_test_files() -> Vec<String> {
     let mut setting_files: Vec<String> = Vec::new();
 
     for path in paths {
-        let path_str = path.unwrap().path().display().to_string();
-        // Only include case1.json through case4.json (exclude case_study files)
-        if path_str.contains("case") && !path_str.contains("case_study") {
-            setting_files.push(path_str);
+        let path = path.unwrap().path();
+        // Only include the motorized-methodology fixtures caseN.json; other
+        // fixtures in this directory (case_study*, bicycle_*) have different shapes.
+        let name = path.file_name().unwrap().to_string_lossy().to_string();
+        if name.starts_with("case")
+            && !name.contains("case_study")
+            && name[4..name.len() - 5].chars().all(|c| c.is_ascii_digit())
+        {
+            setting_files.push(path.display().to_string());
         }
     }
 
@@ -482,4 +488,42 @@ fn bicycle_los_test() {
     let bike_los_default = BicycleLOS::default();
     let result_default = bike_los_default.analyze();
     assert!(result_default.blos_score > 0.0, "Default BLOS should work");
+}
+
+/// HCM worked example (Chapter 26 two-lane highway example problems): a segment is evaluated for
+/// widening, realigning, and repaving; the BLOS in the peak direction is compared between the
+/// current roadway and the proposed design. Fixture: bicycle_widening.json. Published results:
+/// current BLOS 5.90 (LOS F), proposed BLOS 3.58 (LOS D). Tolerances ±0.01 on scores (book rounds
+/// intermediates to two decimals), LOS letters exact.
+#[test]
+fn bicycle_los_widening_example_test() {
+    let mut fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    fixture.push("tests/ExampleCases/hcm/TwoLaneHighways/bicycle_widening.json");
+    let f = File::open(fixture).expect("Unable to open bicycle_widening.json");
+    let json: serde_json::Value =
+        serde_json::from_reader(BufReader::new(f)).expect("Failed to parse JSON");
+
+    let load = |key: &str| -> BicycleLOS {
+        serde_json::from_value(json[key].clone()).expect("Failed to parse BicycleLOS inputs")
+    };
+
+    let current = load("current").analyze();
+    let proposed = load("proposed").analyze();
+
+    // Step 2: vOL = 500 / (0.90 * 1) = 556 veh/h (both designs)
+    assert_approx_eq!(current.flow_rate_outside_lane, 555.6, 0.1);
+
+    // Step 3: We = 14 ft current (Eqs 15-43/15-44), 24 ft proposed (Eqs 15-42/15-44)
+    assert_approx_eq!(current.effective_width, 14.0, 0.01);
+    assert_approx_eq!(proposed.effective_width, 24.0, 0.01);
+
+    // Step 4: St = 4.62 current (Spl 50), 4.79 proposed (Spl 55) per Eq 15-46
+    assert_approx_eq!(current.effective_speed_factor, 4.62, 0.01);
+    assert_approx_eq!(proposed.effective_speed_factor, 4.79, 0.01);
+
+    // Step 5: BLOS 5.90 -> F current, 3.58 -> D proposed (Eq 15-47, Exhibit 15-7)
+    assert_approx_eq!(current.blos_score, 5.90, 0.01);
+    assert_approx_eq!(proposed.blos_score, 3.58, 0.01);
+    assert_eq!(current.los, 'F');
+    assert_eq!(proposed.los, 'D');
 }


### PR DESCRIPTION
## What

Fixes surfaced by the review of item 1 (restructure/Chapter 15), verified against the EPUB.

### Bicycle LOS (Eqs 15-40..15-47)
Reproduces the HCM Ch 26 widening worked example exactly: current BLOS **5.90 / LOS F**, proposed **3.58 / LOS D** (fixture `bicycle_widening.json`, test `bicycle_los_widening_example_test`).

- Eq 15-44/15-45 `Wv` branches were **inverted** (bare lane width for V>160) and the `(2−0.005V)` low-volume form was missing
- Eq 15-41: `We = Wv + Ws − %OHP·10` (was `WOL + Ws − 20·%OHP`)
- Eq 15-42: `We = Wv + Ws − 2·[%OHP(2+Ws)]` (same wrong form as above)
- Eq 15-43: `We = Wv − %OHP(2+Ws)` (was `Wv + Ws(1−2·%OHP)`)
- Eq 15-47: coefficient 0.199 → **0.1999**; removed the non-HCM 1-ft floor on We
- Note per your observation: the BLOS input set is the standalone `BicycleLOS` struct (pavement rating, %OHP, no segment length) — the fixture uses it directly rather than the motorized `TwoLaneHighways` shape; the motorized fixture glob is tightened to `caseN.json` so both shapes can share the directory

### Exhibit 15-11 vertical class (REVIEW_NOTES #3, expanded)
- Missing `>0.5–0.6` mi upgrade bucket inserted (≤2→1, ≤3→2, ≤5→3, ≤6→4, else 5)
- Missing `>0.7–0.8` mi coverage: extended the 0.8–1.1 arm to 0.7–1.1 (exhibit rows share thresholds)
- Dead `≤3.0` branch removed from the 0.4–0.5 arm
- **New bug found: the downgrade branch negated LENGTH instead of GRADE**, so every downgrade segment resolved to vertical class 1; now negates grade per the exhibit's parenthesized values
- The `>1.1` mi else-arm skips class 3 (≤2→1, ≤3→2, ≤5→4) — left as-is pending your check of what the chapter prescribes beyond the exhibit's 1.1-mi limit

### REVIEW_NOTES items
- **#1**: SubSegment binding docstrings now say FEET with the ÷5,280 note
- **#8**: `tests/common/mod.rs` fixture path fixed to `tests/ExampleCases/...`
- **#15**: `apd` doc matches the `unwrap_or(5.0)` behavior

All 581 tests green. REVIEW_NOTES.md items marked fixed.