### PR TITLE
docs: full equation reference in every chapter procedure walkthrough

### DIFF
--- a/docs/hcm/procedures/chapter10-managed-lanes.md
+++ b/docs/hcm/procedures/chapter10-managed-lanes.md
@@ -1,6 +1,6 @@
 # HCM Chapter 10: Managed-Lane Facilities and the Chapter 25 Planning-Level Method
 
-This document walks a reviewer through two extensions to the Chapter 10 core freeway facility methodology implemented on this branch. The first is the managed-lane (ML) facility extension of HCM 7th Edition Chapter 10 Section 4 / Chapter 25 Section 2 (Steps A-9, A-13, A-14, A-17): the lane-group concept pairing each general-purpose (GP) analysis segment with an optional parallel ML segment, the Step A-9 cross-weave friction effect on GP capacity (Chapter 13 Equations 13-24/13-25), the Step A-13 adjacent-friction speed effect on the ML (Chapter 12 Equations 12-18/12-19, via the Chapter 12 ML segment engine), and lane-group plus combined facility aggregation. The second is the Chapter 25 Section 6 planning-level methodology, a section-based screening method that runs from directional AADT and a K-factor over four fixed 15-min analysis periods (Equations 25-40 through 25-52, Exhibits 25-15 through 25-17). The code lives in `src/hcm/chapter10/managed_lanes.rs` and `src/hcm/chapter10/planning.rs`; both build on the core engine in `src/hcm/chapter10/freeway_facilities.rs` (documented in `docs/hcm/procedures/chapter10.md`). Book discrepancies found during implementation are catalogued in `docs/hcm/VERIFICATION.md` under "Chapter 10/25 managed lanes + planning (feat/hcm-ch10-managed-lanes)" (items 1-7); this walkthrough cites those items by number rather than restating them.
+This document walks a reviewer through two extensions to the Chapter 10 core freeway facility methodology implemented on this branch. The first is the managed-lane (ML) facility extension of HCM 7th Edition Chapter 10 Section 4 / Chapter 25 Section 2 (Steps A-9, A-13, A-14, A-17): the lane-group concept pairing each general-purpose (GP) analysis segment with an optional parallel ML segment, the Step A-9 cross-weave friction effect on GP capacity (Chapter 13 Equations 13-24/13-25), the Step A-13 adjacent-friction speed effect on the ML (Chapter 12 Equations 12-18/12-19, via the Chapter 12 ML segment engine), and lane-group plus combined facility aggregation. The second is the Chapter 25 Section 6 planning-level methodology, a section-based screening method that runs from directional AADT and a K-factor over four fixed 15-min analysis periods (Equations 25-40 through 25-52, Exhibits 25-15 through 25-17). The code lives in `src/hcm/freeway_facilities/managed_lanes.rs` and `src/hcm/freeway_facilities/planning.rs`; both build on the core engine in `src/hcm/freeway_facilities/freeway_facilities.rs` (documented in `docs/hcm/procedures/chapter10.md`). Book discrepancies found during implementation are catalogued in `docs/hcm/VERIFICATION.md` under "Chapter 10/25 managed lanes + planning (feat/hcm-ch10-managed-lanes)" (items 1-7); this walkthrough cites those items by number rather than restating them.
 
 ## Part 1: Managed-lane facilities (`managed_lanes.rs`)
 
@@ -12,23 +12,103 @@ This document walks a reviewer through two extensions to the Chapter 10 core fre
 
 | Item | Equations | Rust location |
 |---|---|---|
-| Cross-weave capacity reduction factor CRF | Eq 13-24 | `managed_lanes.rs::cross_weave_crf` |
-| Cross-weave CAF = 1 - CRF | Eq 13-25 | `managed_lanes.rs::cross_weave_caf` |
-| Application to GP segment capacity | Step A-9 | `managed_lanes.rs::ManagedLaneFacility::apply_cross_weave`, `CrossWeave::caf` |
+| Cross-weave capacity reduction factor CRF | Eq 13-24 | `freeway_facilities/managed_lanes.rs::cross_weave_crf` |
+| Cross-weave CAF = 1 - CRF | Eq 13-25 | `freeway_facilities/managed_lanes.rs::cross_weave_caf` |
+| Application to GP segment capacity | Step A-9 | `freeway_facilities/managed_lanes.rs::ManagedLaneFacility::apply_cross_weave`, `CrossWeave::caf` |
 
-`cross_weave_crf(cw_demand_pc, l_cw_min_ft, n_gp_lanes)` implements Equation 13-24 exactly as printed (`CRF = -0.0897 + 0.0252 ln(CW) - 0.00001453 L_cw-min + 0.002967 N_GP`), with inputs cross-weave demand CW in pc/h, minimum cross-weave length in ft, and GP lane count; the result is clamped to `[0, 1]` and zero demand short-circuits to zero reduction. `apply_cross_weave` folds `base_caf * cross_weave_caf(...)` into the affected GP segment's `caf_schedule` per period (the cross-weave demand is a per-period vector, so a schedule rather than a scalar CAF is installed) before the GP analysis runs, so the reduction flows through `FreewayFacility::compute_capacities` unmodified. Note that no published HCM example exercises the cross-weave CAF (Example Problem 5 has none); coverage is equation-level unit testing plus a capacity-reduction integration check only — VERIFICATION.md item 7.
+`cross_weave_crf(cw_demand_pc, l_cw_min_ft, n_gp_lanes)` implements Equation 13-24 exactly as printed (`CRF = -0.0897 + 0.0252 ln(CW) - 0.00001453 L_cw-min + 0.002967 N_GP`), with inputs cross-weave demand CW in pc/h, minimum cross-weave length in ft, and GP lane count; the result is clamped to `[0, 1]` and zero demand short-circuits to zero reduction. `apply_cross_weave` folds `base_caf * cross_weave_caf(...)` into the affected GP segment's `caf_schedule` per period (the cross-weave demand is a per-period vector, so a schedule rather than a scalar CAF is installed) before the GP analysis runs, so the reduction flows through `FreewayFacility::compute_capacities` unmodified. Note that no published HCM example exercises the cross-weave CAF (Example Problem 5 has none); coverage is equation-level unit testing plus a capacity-reduction integration check only — VERIFICATION.md item 7. Note also that the cross-weave equations live entirely in `freeway_facilities/managed_lanes.rs`; `weaving/weaving.rs` (the Chapter 13 basic weaving-segment engine) does not implement or reference Eq 13-24/13-25 at all — confirmed by inspection, no cross-weave symbols appear there.
+
+```
+Equation 13-24:  CRF = -0.0897 + 0.0252*ln(CW) - 0.00001453*L_cw-min + 0.002967*N_GP     [decimal, clamped to 0..1]
+  CRF        = capacity reduction factor                                                 [decimal]
+  CW         = cross-weave demand flow rate (GP ramp flow crossing to/from the ML access) [pc/h]
+  L_cw-min   = minimum cross-weave length (gore to start of the ML access opening)        [ft]
+  N_GP       = number of general-purpose lanes crossed                                    [ln]
+  Non-positive CW short-circuits to CRF = 0 (no reduction); result otherwise clamped to [0, 1].
+Implemented in: freeway_facilities/managed_lanes.rs::cross_weave_crf
+
+Equation 13-25:  CAF = 1 - CRF                        [decimal]
+                 c_GPA = c_GP x CAF                    [veh/h]
+  CAF   = capacity adjustment factor applied to the GP segment                            [decimal]
+  c_GPA = adjusted capacity of the general-purpose lanes                                  [veh/h]
+  c_GP  = unadjusted GP capacity (Chapter 12 basic freeway procedures)                     [veh/h]
+Implemented in: freeway_facilities/managed_lanes.rs::cross_weave_caf (CAF); ManagedLaneFacility::apply_cross_weave folds base_caf * CAF into the GP segment's per-period caf_schedule, so c_GPA is realized inside FreewayFacility::compute_capacities using the existing GP capacity engine as c_GP.
+```
 
 ### ML demand and capacity
 
-`compute_ml_demands` mirrors the GP Step A-4 accumulation: it walks segments upstream to downstream carrying `ml_entry_demand[p]`, adding `on_ramp_demand[p]` and subtracting `off_ramp_demand[p]` at each segment that has an `MlSegmentInput`. Units are veh/h. `compute_ml_capacities` instantiates the Chapter 12 `ManagedLaneSegment` engine (from `src/hcm/chapter12/managed_lanes.rs`) per ML segment, applies the calibration CAF/SAF, calls `calculate_ffs_adj()` and `calculate_capacity()` to get the adjusted per-lane capacity in pc/h/ln, and converts to veh/h as `cap_pc * lanes * f_HV` using the GP facility's heavy-vehicle factor (the ML shares the facility f_HV; there is no separate ML heavy-vehicle percentage input). ML capacity is constant across periods for a given segment.
+`compute_ml_demands` mirrors the GP Step A-4 accumulation: it walks segments upstream to downstream carrying `ml_entry_demand[p]`, adding `on_ramp_demand[p]` and subtracting `off_ramp_demand[p]` at each segment that has an `MlSegmentInput`. Units are veh/h. `compute_ml_capacities` instantiates the Chapter 12 `ManagedLaneSegment` engine (from `src/hcm/basicfreeways/managed_lanes.rs`) per ML segment, applies the calibration CAF/SAF, calls `calculate_ffs_adj()` and `calculate_capacity()` to get the adjusted per-lane capacity in pc/h/ln, and converts to veh/h as `cap_pc * lanes * f_HV` using the GP facility's heavy-vehicle factor (the ML shares the facility f_HV; there is no separate ML heavy-vehicle percentage input). ML capacity is constant across periods for a given segment.
+
+```
+ML demand accumulation (no HCM equation number; mirrors the Ch10 Step A-4 GP demand-accumulation logic for the ML lane group):
+  ml_demand[i][p] = ml_demand[i-1][p] + on_ramp_demand[i][p] - off_ramp_demand[i][p]     [veh/h]
+  with ml_demand[-1][p] := ml_entry_demand[p]                                             [veh/h]
+  ml_entry_demand[p]    = ML volume entering the facility upstream of segment 0, period p  [veh/h]
+  on_ramp_demand[i][p]  = ML on-ramp (merge/access) demand added at segment i, period p    [veh/h]
+  off_ramp_demand[i][p] = ML off-ramp (diverge/access) demand removed at segment i, period p [veh/h]
+Implemented in: freeway_facilities/managed_lanes.rs::ManagedLaneFacility::compute_ml_demands
+
+ML segment capacity (Chapter 12 Eq 12-14 c_adj, converted to veh/h; no separate Ch10/25 equation number):
+  cap_pc  = CAF * (c_75 - lambda_c * (75 - FFS_adj))          [pc/h/ln]   (Chapter 12 Equation 12-14, via ManagedLaneSegment::calculate_capacity)
+  cap_veh = cap_pc * lanes * f_HV                              [veh/h]
+  CAF        = ML calibration capacity adjustment factor                  [decimal]
+  c_75       = base capacity at FFS = 75 mi/h (Exhibit 12-30, by lane type) [pc/h/ln]
+  lambda_c   = rate of change in capacity per unit change in FFS (Exhibit 12-30) [pc/h/ln per mi/h]
+  FFS_adj    = FFS * SAF (ML free-flow speed adjusted by the calibration speed factor) [mi/h]
+  lanes      = number of managed lanes in the segment                     [ln]
+  f_HV       = GP facility heavy-vehicle adjustment factor (shared with the ML; no separate ML truck %) [decimal]
+Implemented in: freeway_facilities/managed_lanes.rs::ManagedLaneFacility::compute_ml_capacities (drives basicfreeways/managed_lanes.rs::ManagedLaneSegment::calculate_capacity for cap_pc)
+
+ML demand-to-capacity ratio (no HCM equation number, analogous to the GP d/c):
+  ml_dc_ratio[i][p] = ml_demand[i][p] / ml_capacity[i][p]        [decimal] (0 if capacity is 0)
+Implemented in: freeway_facilities/managed_lanes.rs::ManagedLaneFacility::run_analysis (inline)
+```
 
 ### Steps A-11/A-13: ML segment evaluation with adjacent friction
 
 `evaluate_ml_segments` evaluates each ML segment per period through `ml_engine`, which converts the served ML volume (assumed equal to demand — see the deferral note on oversaturated ML operation below) to per-lane passenger-car flow `v_p = volume / (lanes * f_HV * PHF)` (pc/h/ln) and hands the Chapter 12 engine the adjacent GP segment's density in pc/mi/ln (`self.gp.density_pc[i][p]`) via `set_gp_density`. The Chapter 12 engine internally switches on the Equation 12-18/12-19 friction speed drop when that density exceeds 35 pc/mi/ln (`ADJACENT_FRICTION_THRESHOLD_PC`, declared in `managed_lanes.rs`); the boolean reported in `ml_friction_active[i][p]` additionally requires the lane type to be friction-capable (`ContinuousAccess` or `Buffer1` only, per Exhibit 12-9 — barrier-separated types never experience adjacent friction). Outputs per cell are `ml_speed` (mi/h), `ml_density_pc` (pc/mi/ln, direct from the engine), `ml_density_veh` (= density_pc x f_HV, veh/mi/ln), and `ml_los` (density-based, Exhibit 12-15 thresholds, from the Chapter 12 engine; `None` maps to F). One published cell is not reproducible — Example Problem 5 Segment 10 / Period 2 prints 58.1 mi/h while the adjacent GP density (34.2 pc/mi/ln) is below the 35 threshold, so the implementation computes the friction-free 58.9 mi/h; VERIFICATION.md item 2 documents this, and the `VERIFY-HCM` comment sits directly in `evaluate_ml_segments`.
 
+```
+Equation 12-18:  I_c = 0  if K_GP <= 35 pc/mi/ln, or segment type is Buffer2/Barrier1/Barrier2
+                 I_c = 1  otherwise                                                       [indicator, 0 or 1]
+  I_c   = friction indicator (whether the adjacent-friction speed drop applies)            [0 or 1]
+  K_GP  = density of the adjacent general-purpose lane                                     [pc/mi/ln]
+  Threshold constant declared as ADJACENT_FRICTION_THRESHOLD_PC = 35.0 pc/mi/ln.
+Implemented in: freeway_facilities/managed_lanes.rs::ADJACENT_FRICTION_THRESHOLD_PC (the 35 pc/mi/ln threshold, cited in Step A-13); basicfreeways/managed_lanes.rs::ManagedLaneSegment::calculate_friction_indicator (the I_c switch, restricted to ContinuousAccess/Buffer1); the reported flag is freeway_facilities/managed_lanes.rs::ManagedLaneFacility::evaluate_ml_segments (ml_friction_active[i][p])
+
+Equation 12-19:  S3 = [(c_adj / K_cnf) - (c_adj / K_cf)] * ((v_p - BP) / (c_adj - BP))^2   [mi/h, additional speed drop]
+  S3     = additional speed drop in the curvilinear portion due to GP-lane friction         [mi/h]
+  c_adj  = adjusted basic ML segment capacity (Chapter 12 Equation 12-14)                   [pc/h/ln]
+  K_cnf  = density at capacity without the GP-friction effect (Exhibit 12-30, by lane type)  [pc/mi/ln]
+  K_cf   = density at capacity with the GP-friction effect (Exhibit 12-30; ContinuousAccess/Buffer1 only) [pc/mi/ln]
+  v_p    = 15-min average ML flow rate                                                      [pc/h/ln]
+  BP     = breakpoint in the ML speed-flow curve (Chapter 12 Equation 12-13)                 [pc/h/ln]
+  S3 = 0 when v_p <= BP or I_c = 0 (no friction, or demand still in the linear portion).
+Implemented in: basicfreeways/managed_lanes.rs::ManagedLaneSegment::calculate_s3; applied as S_ML = S1 - S2 - I_c*S3 (Equation 12-12) in ::calculate_speed, called from freeway_facilities/managed_lanes.rs::ManagedLaneFacility::evaluate_ml_segments via ml_engine()/ManagedLaneSegment::run_analysis. v_p is computed there as v_p = volume_veh / (lanes * f_HV * PHF), and K_GP is set via set_gp_density(self.gp.density_pc[i][p]) — the paired GP segment's Step A-13 density input.
+```
+
 ### Steps A-14/A-17: lane-group and combined aggregation
 
 `aggregate_performance` computes three parallel result sets per period. The GP lane group (`gp_group_performance`) and ML lane group (`ml_group_performance`) each get `LaneGroupPerformance` records — space mean speed (Equation 25-2, `exhibits::facility_space_mean_speed`), average density in veh/mi/ln and pc/mi/ln (Equation 10-1, `exhibits::facility_density`, length-and-lane weighted), and LOS (Exhibit 10-6 via `los_freeway_facility`, forced to F if any of that group's segments has vd/c > 1.0). The ML group aggregates only over segments carrying a managed lane. The combined facility (`facility_performance`, a `PeriodPerformance` shared with the core module) concatenates both groups' flow/length/speed/density/lane vectors and applies the same Equation 10-1/25-2 formulas, plus VMT/VHT/VHD summed across both groups at 0.25-h period duration (ML volume served is taken as ML demand, so ML `vmt_served == vmt_demand` per cell). The combined density carries the VERIFY-HCM flag in `aggregate_performance`: the lane-mile-weighted Equation 10-1 combination of the book's own Exhibit 25-86 group densities gives 28.3 veh/mi/ln for Example Problem 5 Period 3, but Exhibit 25-87 prints 29.1, which is not reproducible from the book's own inputs — VERIFICATION.md item 1 (LOS unaffected).
+
+```
+Equation 10-1:  D_F = Sum_i(D_i * L_i * N_i) / Sum_i(L_i * N_i)      [pc/mi/ln or veh/mi/ln, matching the D_i unit]
+  D_F  = average density for the facility (or lane group) in one 15-min analysis period      [pc/mi/ln]
+  D_i  = density of segment i                                                                 [pc/mi/ln]
+  L_i  = length of segment i                                                                  [mi]
+  N_i  = number of lanes in segment i                                                         [ln]
+  n    = number of segments in the group being aggregated
+Implemented in: freeway_facilities/exhibits.rs::facility_density (length- and lane-weighted average, called once per lane group and once for the combined facility in aggregate_performance)
+
+Equation 25-2:  SMS(NS,p) = Sum_i(SF(i,p)*L(i)) / Sum_i(SF(i,p)*L(i)/U(i,p))     [mi/h]
+  SMS(NS,p) = facility (or lane group) space mean speed in analysis period p                  [mi/h]
+  SF(i,p)   = flow rate on segment i in period p                                              [veh/h]
+  L(i)      = length of segment i                                                              [mi]
+  U(i,p)    = space mean speed of segment i in period p                                        [mi/h]
+  NS        = number of segments in the group being aggregated
+  Segments with U(i,p) <= 0 are excluded from the denominator sum (facility_space_mean_speed filters s > 0.0).
+Implemented in: freeway_facilities/exhibits.rs::facility_space_mean_speed (called for the GP group, ML group, and combined facility in aggregate_performance)
+```
 
 ## Part 2: Planning-level method (`planning.rs`)
 
@@ -38,16 +118,112 @@ This document walks a reviewer through two extensions to the Chapter 10 core fre
 
 | HCM item | Equations / Exhibits | Rust location | Units |
 |---|---|---|---|
-| Period demand flow rates from AADT | Eq 25-40 | `planning.rs::PlanningFacility::run_analysis` (`boundary`, `mult`) | AADT veh/day -> pc/h via `k_factor * growth_factor * f_HV` |
-| Heavy-vehicle factor | Eq 25-42 | `planning.rs::PlanningFacility::f_hv` | decimal; uses `Terrain::pce()` (Exhibit 12-25) |
-| Demand accumulation with vertical-queue carryover | Eq 25-43/25-44 | `run_analysis` (`demand`, `carryover`, `next_carryover`) | pc/h; carryover in pc |
-| Basic section capacity | Eq 25-45 | `planning.rs::basic_section_capacity_pc` | pc/h/ln; `2200 + 10 (min(70, FFS) - 50)` |
-| Weaving-section CAF | Eq 25-46 | `planning.rs::weave_caf` | decimal; `min(0.884 - 0.0752 V_r + 0.0000243 L_s(ft), 1)` |
-| Ramp-section CAF | Ch 25 text default | `planning.rs::DEFAULT_RAMP_CAF` (0.9) | decimal |
-| Undersaturated delay rate | Eq 25-47 + Exhibit 25-16 | `planning.rs::undersaturated_delay_rate`, `undersaturated_params` | s/mi (see VERIFICATION.md item 4 on the printed "min/mi" label) |
-| Oversaturated delay rate | Eq 25-48 | `planning.rs::oversaturated_delay_rate` | s/mi; public helper, unused in reported results (VERIFICATION.md item 3) |
-| Travel rate / time / speed / density | Eq 25-49 through 25-52 | `run_analysis` (inline) | s/mi, s, mi/h, pc/mi/ln |
-| Facility aggregation and LOS | Exhibits 25-96 / 25-17 | `planning.rs::PlanningFacility::aggregate_facility` | length-weighted density (VERIFICATION.md item 5) |
+| Period demand flow rates from AADT | Eq 25-40 | `freeway_facilities/planning.rs::PlanningFacility::run_analysis` (`boundary`, `mult`) | AADT veh/day -> pc/h via `k_factor * growth_factor * f_HV` |
+| Heavy-vehicle factor | Eq 25-42 | `freeway_facilities/planning.rs::PlanningFacility::f_hv` | decimal; uses `Terrain::pce()` (Exhibit 12-25) |
+| Demand accumulation with vertical-queue carryover | Eq 25-43/25-44 | `freeway_facilities/planning.rs::PlanningFacility::run_analysis` (`demand`, `carryover`, `next_carryover`) | pc/h; carryover in pc |
+| Basic section capacity | Eq 25-45 | `freeway_facilities/planning.rs::basic_section_capacity_pc` | pc/h/ln; `2200 + 10 (min(70, FFS) - 50)` |
+| Weaving-section CAF | Eq 25-46 | `freeway_facilities/planning.rs::weave_caf` | decimal; `min(0.884 - 0.0752 V_r + 0.0000243 L_s(ft), 1)` |
+| Ramp-section CAF | Ch 25 text default | `freeway_facilities/planning.rs::DEFAULT_RAMP_CAF` (0.9) | decimal |
+| Undersaturated delay rate | Eq 25-47 + Exhibit 25-16 | `freeway_facilities/planning.rs::undersaturated_delay_rate`, `undersaturated_params` | s/mi (see VERIFICATION.md item 4 on the printed "min/mi" label) |
+| Oversaturated delay rate | Eq 25-48 | `freeway_facilities/planning.rs::oversaturated_delay_rate` | s/mi; public helper, unused in reported results (VERIFICATION.md item 3) |
+| Travel rate / time / speed / density | Eq 25-49 through 25-52 | `freeway_facilities/planning.rs::PlanningFacility::run_analysis` (inline) | s/mi, s, mi/h, pc/mi/ln |
+| Facility aggregation and LOS | Exhibits 25-96 / 25-17 | `freeway_facilities/planning.rs::PlanningFacility::aggregate_facility` | length-weighted density (VERIFICATION.md item 5) |
+
+```
+Equation 25-40:  V_i,t = AADT_i * k * f_tg                       for t = 1, 3     [veh/h]
+                 V_i,t = AADT_i * k * (1/PHF) * f_tg              for t = 2        [veh/h]
+                 V_i,t = AADT_i * k * (2 - 1/PHF) * f_tg          for t = 4        [veh/h]
+  V_i,t  = demand inflow/outflow volume for section i, analysis period t          [veh/h]
+  AADT_i = directional average annual daily traffic entering/leaving at section i's boundary [veh/day]
+  k      = K-factor (peak-hour proportion of AADT)                                [decimal]
+  f_tg   = traffic growth factor                                                  [decimal]
+  PHF    = peak hour factor                                                       [decimal]
+Implemented in: freeway_facilities/planning.rs::PlanningFacility::period_multipliers (the [1, 1/PHF, 1, 2-1/PHF] vector `mult`) and ::run_analysis (`boundary[i] * mult[p]`)
+
+Equation 25-41:  q_i,t = V_i,t / f_HV                                              [pc/h]
+  q_i,t = demand flow rate converted to passenger-car-equivalent units            [pc/h]
+  f_HV  = heavy-vehicle adjustment factor (Equation 25-42)                         [decimal]
+Implemented in: freeway_facilities/planning.rs::PlanningFacility::run_analysis
+
+**DISCREPANCY (not in VERIFICATION.md items 1-7):** `run_analysis` computes `base_factor = k_factor * growth_factor * f_hv` and multiplies the AADT-derived boundary flow by `f_hv` directly, rather than dividing by it as Equation 25-41 requires (`q = V / f_HV`). Since `f_HV = 1/(1+P_T(E_T-1)) <= 1`, dividing by it (the printed Eq 25-41, correctly converting veh to the larger pc-equivalent count when heavy vehicles are present) increases the flow, while the code's multiplication decreases it — the opposite direction, and inconsistent with this same codebase's convention elsewhere for the reverse (pc -> veh) conversion (e.g. `freeway_facilities.rs::compute_capacities` and `managed_lanes.rs::compute_ml_capacities` both multiply a pc-based quantity by `f_HV` to obtain veh/h). This is numerically invisible in the only planning fixture (`tests/ExampleCases/hcm/FreewayFacilities/planning_case1.json`, Example Problem 6), which sets `pct_sut = pct_tt = 0.0` so `f_HV = 1.0`; it would understate demand-to-capacity ratios, delay, and oversaturation risk for any facility analyzed with a nonzero truck percentage. Located in `freeway_facilities/planning.rs::PlanningFacility::run_analysis` (`base_factor`).
+
+Equation 25-42:  f_HV = 1 / (1 + P_T*(E_T - 1))                                   [decimal]
+  f_HV = heavy-vehicle adjustment factor                                          [decimal]
+  P_T  = combined SUT + TT proportion (pct_sut + pct_tt)                          [decimal]
+  E_T  = passenger-car equivalent of one heavy vehicle (Exhibit 12-25: 2.0 level, 3.0 rolling/mountainous) [PCE]
+Implemented in: freeway_facilities/planning.rs::PlanningFacility::f_hv
+
+Equation 25-43:  d_i,p = d_(i-1),p + (q_i,p)_in - (q_i,p)_out + d'_i,(p-1)         [pc/h]
+  d_i,p       = demand level on section i in analysis period p                    [pc/h]
+  d_(i-1),p   = demand level on the upstream section in the same period           [pc/h]
+  (q_i,p)_in  = inflow demand entering section i in period p (first section / on-ramps) [pc/h]
+  (q_i,p)_out = outflow demand leaving section i in period p (off-ramps)          [pc/h]
+  d'_i,(p-1)  = carryover (vertical-queue) demand released from section i, previous period p-1 [pc/h]
+Implemented in: freeway_facilities/planning.rs::PlanningFacility::run_analysis (`demand = (upstream + boundary[i] * mult[p]).max(0.0) + carryover[i]`, where `upstream` carries d_(i-1),p and `boundary[i] * mult[p]` is the net q_in - q_out for period p)
+
+Equation 25-44:  d'_i,p = max(d_i,p - c_i, 0)                                      [pc/h]
+  d'_i,p = vertical-queue carryover demand on section i released to period p+1     [pc/h]
+  c_i    = capacity of section i (Equation 25-45, adjusted)                        [pc/h]
+Implemented in: freeway_facilities/planning.rs::PlanningFacility::run_analysis (`next_carryover[i] = (demand - cap).max(0.0)`)
+
+Equation 25-45:  c_i = 2200 + 10 * [min(70, FFS) - 50]                             [pc/h/ln]
+  c_i = capacity of freeway section i                                             [pc/h/ln]
+  FFS = facility free-flow speed                                                  [mi/h]
+Implemented in: freeway_facilities/planning.rs::basic_section_capacity_pc
+
+Equation 25-46:  CAF_weave = min(0.884 - 0.0752*V_r + 0.0000243*L_s, 1.0)          [decimal, capped at 1.0]
+  CAF_weave = capacity adjustment factor used for a weaving segment                [decimal]
+  V_r       = ratio of weaving demand flow rate to total demand flow rate in the section [decimal]
+  L_s       = weaving segment length                                              [ft]
+Implemented in: freeway_facilities/planning.rs::weave_caf (the `length_mi` argument is converted internally via `length_mi * 5280.0` to get L_s in ft)
+
+Ramp-section CAF (Chapter 25 §6 text, no equation number): "an average CAF of 0.9 can be used for ramp sections" absent a section-specific measured value.
+Implemented in: freeway_facilities/planning.rs::DEFAULT_RAMP_CAF (0.9), applied in ::section_capacity_pc_per_lane when a Ramp section has no `caf_override`.
+
+Equation 25-47 (Exhibit 25-16 coefficients; as implemented — see VERIFICATION.md items 3/4 for the two departures from the printed form, noted below rather than re-flagged):
+  ΔRU_i,p = 0                                                                  if d_i,p/c_i < E
+  ΔRU_i,p = A*(d_i,p/c_i)^3 + B*(d_i,p/c_i)^2 + C*(d_i,p/c_i) + D               otherwise
+  ΔRU_i,p   = undersaturated delay rate for section i, period p                 [s/mi] (printed beside the equation as min/mi — VERIFICATION.md item 4)
+  A,B,C,D,E = Exhibit 25-16 coefficients, keyed by free-flow speed (nearest 5-mi/h column, 55-75 mi/h) [dimensionless]
+  Departure from print (VERIFICATION.md item 3): the code evaluates the cubic at the actual d_i,p/c_i even when it exceeds 1.0, rather than restricting to the printed `E <= d/c <= 1` domain.
+Implemented in: freeway_facilities/planning.rs::undersaturated_delay_rate, ::undersaturated_params (the Exhibit 25-16 table, keyed by FFS)
+
+Equation 25-48:  ΔRO_i,p = (450 / L) * max(0, d_i,p/c_i - 1.0)                     [s/mi] (printed as min/mi)
+  ΔRO_i,p = additional oversaturation delay rate for section i, period p          [s/mi]
+  L       = section length                                                        [mi]
+Implemented in: freeway_facilities/planning.rs::oversaturated_delay_rate — public helper, retained per the printed formulation but NOT summed into the reported delay/travel rate (VERIFICATION.md item 3: oversaturation is instead expressed only through the Equation 25-43/25-44 vertical-queue carryover)
+
+Equation 25-49 (as implemented; VERIFICATION.md item 3 — the printed ΔRO term is omitted):
+  TR_i,p = ΔRU_i,p + TR_FFS                                                       [s/mi] (printed as ΔRU + ΔRO + TR_FFS, min/mi)
+  TR_FFS = 3600 / FFS                                                             [s/mi] (free-flow travel rate)
+Implemented in: freeway_facilities/planning.rs::PlanningFacility::run_analysis (`travel_rate = dru + tr_ffs`, `tr_ffs = 3600.0 / ffs`)
+
+Equation 25-50:  T_i,p = TR_i,p * L_i                                             [s] (printed as min)
+  T_i,p = travel time on section i, period p                                     [s]
+  L_i   = length of section i                                                    [mi]
+Implemented in: freeway_facilities/planning.rs::PlanningFacility::run_analysis (`travel_time_s = travel_rate * sec.length_mi`)
+
+Equation 25-51:  S_i,p = 3600 / TR_i,p                                            [mi/h]
+  S_i,p = space mean speed of section i, period p                                 [mi/h]
+  (the printed form S = L/T assumes T in hours; the s/mi treatment of TR_i,p here — VERIFICATION.md item 4 — makes 3600/TR the equivalent conversion)
+Implemented in: freeway_facilities/planning.rs::PlanningFacility::run_analysis (`speed = 3600.0 / travel_rate`, falling back to FFS when travel_rate <= 0)
+
+Equation 25-52:  D_i,p = d_i,p / (N_i * S_i,p)                                    [pc/mi/ln]
+  D_i,p = density of section i, period p                                         [pc/mi/ln]
+  N_i   = number of lanes in section i                                           [ln]
+Implemented in: freeway_facilities/planning.rs::PlanningFacility::run_analysis (`density = demand / (lanes * speed)`)
+
+Facility aggregation (Exhibit 25-96, no single equation number):
+  Facility travel time      = Sum_i(T_i,p) / 60                                              [min]
+  Facility space mean speed = total_length / (Sum_i(T_i,p) / 3600)                            [mi/h] (falls back to FFS if total time is 0)
+  Facility density           = Sum_i(D_i,p * L_i) / Sum_i(L_i)                                [pc/mi/ln] — length-weighted, NOT the Equation 10-1 lane-mile weighting used elsewhere in Chapter 10 (VERIFICATION.md item 5)
+  Facility vertical queue    = Sum_i(queue_length_mi_i)                                        [mi]
+  Facility oversaturated     = true if any section d_i,p/c_i > 1.0
+Implemented in: freeway_facilities/planning.rs::PlanningFacility::aggregate_facility
+
+Facility LOS (Exhibit 25-17): urban thresholds <=11/18/26/35/45 pc/mi/ln, rural <=6/14/22/29/39 pc/mi/ln (A through E), F above the E threshold or if any section v_d/c > 1.00 — confirmed identical to the Exhibit 10-6 breakpoints reused by the code (verified against `197_Ch25_06.xhtml`, no discrepancy).
+Implemented in: freeway_facilities/exhibits.rs::los_freeway_facility, invoked from planning.rs::aggregate_facility with the `oversaturated` flag forcing F
+```
 
 ### Details a reviewer should check against the manual
 
@@ -74,7 +250,7 @@ Integration tests live in `tests/chapter10_integration.rs` (the Example Problem 
 - `ep6_delay_rates_match_exhibit_25_92`: full delay-rate matrix at +-0.4 s/mi, including Section 6 Period 2 = 11.7 s/mi — which is `delta_RU(1.016)`, only reproducible under the ΔRU-at-actual-d/c reading (VERIFICATION.md item 3).
 - `ep6_facility_performance_matches_exhibit_25_96`: per-period oversaturated flag (period 2 only), travel time (+-0.15 min), space mean speed (+-0.6 mi/h), length-weighted density (+-0.8 pc/mi/ln, the widened band covering the Section 6 Period 2 book rounding of VERIFICATION.md item 5), total vertical queue (0.8 mi in period 2, +-0.15 — reproducing the published queue via Equations 25-43/25-44), and LOS letters exact (D/F/D/C).
 
-Unit tests in `src/hcm/chapter10/tests.rs` (managed-lanes and planning sections): `test_cross_weave_caf_equation_13_24` checks the CRF formula against a hand computation (CW = 1,000 pc/h, L = 1,000 ft, N = 3 gives CRF ~ 0.0788) and monotonicity in length; `test_cross_weave_reduces_gp_capacity_step_a9` verifies the Step A-9 capacity reduction end-to-end on the EP1 facility (capacity-reduction effect only, per VERIFICATION.md item 7); `test_ml_adjacent_friction_activates_above_threshold` verifies on the EP2 (+11%) facility that friction flags fire only where GP density exceeds 35 pc/mi/ln; `test_planning_equation_25_45_basic_capacity`, `test_planning_equation_25_46_weave_caf` (including the EP6 weave section value 0.9358 and the 1.0 cap), `test_planning_equation_25_47_delay_rate` (threshold behavior below E = 0.72, the d/c = 0.86 value 2.8 s/mi, and the Equation 25-48 helper), and `test_planning_carryover_propagates_downstream` (a synthetic two-section facility where the released vertical queue raises downstream demand in the next period).
+Unit tests in `src/hcm/freeway_facilities/tests.rs` (managed-lanes and planning sections): `test_cross_weave_caf_equation_13_24` checks the CRF formula against a hand computation (CW = 1,000 pc/h, L = 1,000 ft, N = 3 gives CRF ~ 0.0788) and monotonicity in length; `test_cross_weave_reduces_gp_capacity_step_a9` verifies the Step A-9 capacity reduction end-to-end on the EP1 facility (capacity-reduction effect only, per VERIFICATION.md item 7); `test_ml_adjacent_friction_activates_above_threshold` verifies on the EP2 (+11%) facility that friction flags fire only where GP density exceeds 35 pc/mi/ln; `test_planning_equation_25_45_basic_capacity`, `test_planning_equation_25_46_weave_caf` (including the EP6 weave section value 0.9358 and the 1.0 cap), `test_planning_equation_25_47_delay_rate` (threshold behavior below E = 0.72, the d/c = 0.86 value 2.8 s/mi, and the Equation 25-48 helper), and `test_planning_carryover_propagates_downstream` (a synthetic two-section facility where the released vertical queue raises downstream demand in the next period).
 
 ## Deferred
 

--- a/docs/hcm/procedures/chapter10.md
+++ b/docs/hcm/procedures/chapter10.md
@@ -1,6 +1,6 @@
 # HCM Chapter 10: Freeway Facilities Core Methodology
 
-This document walks a reviewer through the Rust implementation of the HCM 7th Edition Chapter 10 core freeway facility methodology (motorized vehicle, general-purpose lanes), which orchestrates the Chapter 12 basic-segment, Chapter 13 weaving, and Chapter 14 merge/diverge segment engines over an ordered set of segments and consecutive 15-minute analysis periods (the time-space domain of Exhibit 10-10), following Exhibit 10-8's Steps A-1 through A-17. When any segment's demand-to-capacity ratio exceeds 1.00, the facility switches to the Chapter 25 Section 4 node-segment time-step engine (Equations 25-6 through 25-34) rather than the Chapter 25 Section 3 undersaturated closed-form evaluation. The code lives in `src/hcm/chapter10/freeway_facilities.rs` (orchestration and undersaturated evaluation), `src/hcm/chapter10/oversaturated.rs` (the 15-second time-step engine), and `src/hcm/chapter10/exhibits.rs` (equation transcriptions, LOS tables, and work zone models). Managed-lane facilities (Steps A-9/A-13/A-14) and the Chapter 25 planning-level method are explicitly out of scope in this pass and are covered separately (see `docs/hcm/procedures/chapter10-managed-lanes.md` on the `feat/hcm-ch10-managed-lanes` branch). No `docs/hcm/VERIFICATION.md` exists on this branch, so deviations from the printed manual are documented inline below as `VERIFY-HCM` comments rather than cross-referenced.
+This document walks a reviewer through the Rust implementation of the HCM 7th Edition Chapter 10 core freeway facility methodology (motorized vehicle, general-purpose lanes), which orchestrates the Chapter 12 basic-segment, Chapter 13 weaving, and Chapter 14 merge/diverge segment engines over an ordered set of segments and consecutive 15-minute analysis periods (the time-space domain of Exhibit 10-10), following Exhibit 10-8's Steps A-1 through A-17. When any segment's demand-to-capacity ratio exceeds 1.00, the facility switches to the Chapter 25 Section 4 node-segment time-step engine (Equations 25-6 through 25-34) rather than the Chapter 25 Section 3 undersaturated closed-form evaluation. The code lives in `src/hcm/freeway_facilities/freeway_facilities.rs` (orchestration and undersaturated evaluation), `src/hcm/freeway_facilities/oversaturated.rs` (the 15-second time-step engine), and `src/hcm/freeway_facilities/exhibits.rs` (equation transcriptions, LOS tables, and work zone models). Managed-lane facilities (Steps A-9/A-13/A-14) and the Chapter 25 planning-level method are explicitly out of scope in this pass and are covered separately (see `docs/hcm/procedures/chapter10-managed-lanes.md`, implemented at `src/hcm/freeway_facilities/managed_lanes.rs` and `src/hcm/freeway_facilities/planning.rs`). Deviations from the printed manual that are already catalogued are cross-referenced below as `VERIFICATION.md ch10/25 item N` (see `docs/hcm/VERIFICATION.md`, "Chapter 10 / 25 oversaturated engine" section); any deviation found in this pass that is not already catalogued there is marked `**DISCREPANCY:**` inline.
 
 ## Step-by-step walkthrough
 
@@ -20,29 +20,312 @@ This document walks a reviewer through the Rust implementation of the HCM 7th Ed
 
 `segment_ramp_section(gore_to_gore_ft, has_auxiliary_lane)` implements the Exhibit 10-11/10-12 decision tree: an auxiliary lane between gores makes the whole section one weaving segment; spacing beyond 3,000 ft (2 x the 1,500-ft `RAMP_INFLUENCE_AREA_FT`) yields merge + basic + diverge; spacing between 1,500 and 3,000 ft yields merge + `OverlappingRamp` + diverge, where the overlap piece is `2 x 1500 - spacing`; and spacing at or below 1,500 ft collapses to a single `OverlappingRamp` segment spanning the whole distance (the code comment calls this "highly unusual" since it implies no auxiliary lane over a sub-influence-area gap). `FacilitySegment` itself is not auto-segmented from a raw gore list in this module — callers construct the `Vec<FacilitySegment>` directly (as the example fixtures do), and `segment_ramp_section` is a helper for producing the length breakdown, not a full facility builder.
 
+No HCM equation governs segmentation itself — Exhibits 10-1, 10-2, 10-11, and 10-12 define it entirely through the geometric decision rules already described in the paragraph above (the 1,500-ft ramp influence area, the 3,000-ft and 1,500-ft gore-to-gore breakpoints, and the auxiliary-lane weaving rule), which is why `segment_ramp_section` returns `(SegmentType, length_ft)` tuples rather than evaluating a numbered formula.
+Implemented in: freeway_facilities/freeway_facilities.rs::segment_ramp_section
+
 ### Demand accumulation (Steps A-3/A-4)
 
 `compute_demands` accumulates segment demand SD(i, p) by walking segments upstream to downstream, adding on-ramp demand and subtracting off-ramp demand at each node (`onrd_by_node`/`offrd_by_node`), scaled by each segment's own DAF (`FacilitySegment::on_demand`/`off_demand`/`rr_demand` multiply by `self.daf`, i.e. Equation 10-6 is applied to a segment's own ramp demands, not globally). Demand balancing (Eq 10-2/10-3, reconciling inconsistent entering/exiting ramp counts) is implemented as standalone functions (`time_interval_scale_factor`, `balance_exit_demands`) that a caller would run before populating `on_ramp_demand`/`off_ramp_demand`; `compute_demands` itself assumes demands are already balanced, per its doc comment.
+
+Equation 10-2:  f_TIS,i = ( Σ_j VON15(i,j) ) / ( Σ_j VOFF15(i,j) )                                          [dimensionless]
+  f_TIS,i = time interval scale factor for analysis period i                                                [dimensionless]
+  VON15(i,j) = 15-min entering count for analysis period i, entering location j                             [veh]
+  VOFF15(i,j) = 15-min exit count for analysis period i, exiting location j                                 [veh]
+A ratio greater than 1.00 indicates congestion inside the facility is suppressing exit counts below true exit demand.
+Implemented in: freeway_facilities/exhibits.rs::time_interval_scale_factor
+
+Equation 10-3:  VdOFF15(i,j) = VOFF15(i,j) * f_TIS,i                                                        [veh]
+  VdOFF15(i,j) = adjusted (balanced) 15-min exit demand for analysis period i, exiting location j           [veh]
+  VOFF15(i,j), f_TIS,i = as in Equation 10-2
+Implemented in: freeway_facilities/exhibits.rs::balance_exit_demands (standalone preprocessing step; `compute_demands` does not call it, per its own doc comment)
+
+Equation 10-6:  v_adj = v * DAF_cal                                                                          [veh/h]
+  v_adj = adjusted demand input volume                                                                       [veh/h]
+  v = base demand volume                                                                                     [veh/h]
+  DAF_cal = calibration demand adjustment factor                                                             [decimal]  (default 1.0; primarily used in a Chapter 11 reliability analysis, per the Step A-8 text)
+Implemented in: freeway_facilities/exhibits.rs::adjusted_demand (the standalone, generic form); in this module DAF is applied per-segment to that segment's own ramp demands by `FacilitySegment::on_demand`/`off_demand`/`rr_demand` (each multiplies by `self.daf`) rather than as a single facility-wide multiplier on `v`
 
 ### Capacities (Steps A-7/A-8)
 
 `compute_capacities` computes per-segment, per-period capacity in veh/h. Basic and `OverlappingRamp` segments use `base_capacity_pc` (Equation 12-6, `2200 + 10*(FFS_adj - 50)` capped at 2,400 pc/h/ln, or `c_ifl_override` if supplied) times CAF times lanes times f_HV. Merge/Diverge segments use `get_freeway_capacity_per_lane` from the Chapter 14 module (Exhibit 14-10). Weaving segments build a full `WeavingSegment` (Chapter 13 engine) per period and call `determine_capacity()` if the segment still operates as a weave after `determine_max_weaving_length()`; otherwise it falls back to the basic-segment capacity formula, consistent with Exhibit 10-12(b) ("L_S >= L_MAX: operates as a basic segment"). `effective_caf`/`effective_saf` layer a work zone's `caf()`/`saf()` (Equations 10-11/10-12) on top of any per-period `caf_schedule`/`saf_schedule` or scalar `caf`/`saf` calibration factor.
 
+Equation 10-4:  FFS_adj = FFS * SAF_cal                                                                     [mi/h]
+  FFS_adj = adjusted free-flow speed                                                                        [mi/h]
+  FFS = base segment (or facility) free-flow speed                                                          [mi/h]
+  SAF_cal = calibration speed adjustment factor                                                              [decimal]  (default 1.0; should be <= 1.0 per the Step A-8 text)
+Implemented in: freeway_facilities/exhibits.rs::adjusted_ffs (standalone generic form); applied per segment/period as `self.seg_ffs(i) * self.effective_saf(i, p)` by freeway_facilities/freeway_facilities.rs::FreewayFacility::compute_capacities and ::engine_eval
+
+Equation 10-5:  c_adj = c * CAF_cal                                                                          [veh/h or pc/h/ln]
+  c_adj = adjusted capacity                                                                                  [veh/h or pc/h/ln]
+  c = base capacity                                                                                          [veh/h or pc/h/ln]
+  CAF_cal = calibration capacity adjustment factor                                                            [decimal]  (default 1.0; should be <= 1.0 per the Step A-8 text)
+Implemented in: freeway_facilities/exhibits.rs::adjusted_capacity (standalone generic form); applied per segment/period via freeway_facilities/freeway_facilities.rs::FreewayFacility::effective_caf, which multiplies the calibration CAF (scalar `caf` or `caf_schedule`) by the segment's own base-capacity call
+
+Work zone models (Chapter 10, Section 4; NCHRP 03-107), used by `effective_caf`/`effective_saf` when a segment carries a `WorkZone`:
+
+Equation 10-7:  LCSI = 1 / (OR * N_o)                                                                        [decimal]  (capped at 2.0 for severe closures such as 3-to-1 or 4-to-1)
+  LCSI = lane closure severity index                                                                          [decimal]
+  OR = open ratio = N_o / N_total                                                                             [decimal]
+  N_o = number of open lanes through the work zone                                                            [ln]
+  N_total = normal (total) number of lanes upstream of the work zone                                          [ln]
+Exhibit 10-15 values reproduced by this equation (the values transcribed as Rust test fixtures, not a lookup table): 3-to-3 = 0.33; 2-to-2 = 0.50; 4-to-3 = 0.44; 3-to-2 = 0.75; 4-to-2 = 1.00; 2-to-1 = 2.00.
+Implemented in: freeway_facilities/exhibits.rs::lane_closure_severity_index, freeway_facilities/exhibits.rs::WorkZone::lcsi
+
+Equation 10-8:  QDR_wz = 2093 - 154*LCSI - 194*f_Br - 179*f_AT + 9*f_LAT - 59*f_DN                           [pc/h/ln]
+  QDR_wz = average 15-min work zone queue discharge rate                                                      [pc/h/ln]
+  LCSI = lane closure severity index (Equation 10-7)                                                           [decimal]
+  f_Br = barrier type indicator: 0 = concrete/hard barrier, 1 = cone/plastic drum/soft barrier
+  f_AT = area type indicator: 0 = urban, 1 = rural
+  f_LAT = lateral distance from the travel-lane edge to the barrier/barricades/cones                          [ft]  (range 0-12)
+  f_DN = time-of-day indicator: 0 = daylight, 1 = night
+Implemented in: freeway_facilities/exhibits.rs::WorkZone::queue_discharge_rate
+
+Equation 10-9:  c_wz = QDR_wz / (100 - alpha_wz) * 100                                                        [pc/h/ln]  (capped at the non-work-zone capacity c)
+  c_wz = work zone capacity (prebreakdown flow rate)                                                           [pc/h/ln]
+  QDR_wz = as in Equation 10-8                                                                                 [pc/h/ln]
+  alpha_wz = percentage drop in prebreakdown capacity at the work zone due to queuing                          [%]  (default 13.4%, NCHRP 03-107; the non-work-zone default queue discharge drop is 7%, Equation 25-29/Step A-6)
+Implemented in: freeway_facilities/exhibits.rs::WorkZone::capacity_pc (the code stores `queue_discharge_drop` as a decimal fraction, e.g. 0.134, and computes `QDR_wz / (1.0 - queue_discharge_drop)`, which is algebraically identical to the printed `/(100-alpha_wz)*100` form when alpha_wz is expressed as a fraction rather than a percentage)
+
+Equation 10-10:  FFS_wz = 9.95 + 33.49*f_Sr + 0.53*SL_wz - 5.60*LCSI - 3.84*f_Br - 1.71*f_DN - 8.7*TRD        [mi/h]  (1 <= f_Sr <= 1.2; result capped at the non-work-zone FFS)
+  FFS_wz = work zone free-flow speed                                                                          [mi/h]
+  f_Sr = speed ratio = non-work-zone speed limit / work zone speed limit                                      [decimal]  (clamped to 1.0-1.2)
+  SL_wz = work zone regulatory speed limit                                                                     [mi/h]
+  LCSI = as in Equation 10-7
+  f_Br, f_DN = as in Equation 10-8
+  TRD = total ramp density along the facility                                                                  [ramps/mi]
+Implemented in: freeway_facilities/exhibits.rs::WorkZone::ffs
+
+Equation 10-11:  CAF_wz = c_wz / c                                                                             [decimal]  (capped at 1.0)
+  CAF_wz = work zone capacity adjustment factor                                                                [decimal]
+  c_wz = as in Equation 10-9                                                                                    [pc/h/ln]
+  c = non-work-zone basic freeway segment capacity                                                             [pc/h/ln]
+Implemented in: freeway_facilities/exhibits.rs::WorkZone::caf, layered onto the segment's calibration CAF by freeway_facilities/freeway_facilities.rs::FreewayFacility::effective_caf
+
+Equation 10-12:  SAF_wz = FFS_wz / FFS                                                                          [decimal]  (capped at 1.0)
+  SAF_wz = work zone free-flow speed adjustment factor                                                          [decimal]
+  FFS_wz = as in Equation 10-10                                                                                  [mi/h]
+  FFS = non-work-zone free-flow speed                                                                            [mi/h]
+Implemented in: freeway_facilities/exhibits.rs::WorkZone::saf, layered onto the segment's calibration SAF by freeway_facilities/freeway_facilities.rs::FreewayFacility::effective_saf
+
 ### Undersaturated evaluation (Step A-11)
 
 `analyze_undersaturated_period` sets served volume equal to demand for every segment and calls `evaluate_period_chain`, which walks segments in order, evaluates each with the appropriate Chapter 12/13/14 engine via `engine_eval`, and applies the Equation 25-1 maximum-achievable-speed cap (`exhibits::max_achievable_speed`) using the distance between the previous and current segment midpoints. For `OverlappingRamp` segments, the code takes the worse (slower) of the adjacent merge (already computed, upstream) and diverge (computed ad hoc for the next segment) speeds, per the Exhibit 10-11(c) worst-case rule — see `evaluate_period_chain`'s special-case block for `SegmentType::OverlappingRamp`. Segment LOS is computed by `density_los`, which rounds pc density to the nearest integer before the Exhibit 25-59/12-15/14-3 threshold lookups (documented `VERIFY-HCM` rationale: the published Example Problem 1 LOS matrix is only reproducible with integer-rounded densities, e.g. Segment 8 Period 4's D_R = 28.2 pc/mi/ln rounds to LOS C at the <= 28 boundary).
 
-Two deliberate deviations from the literal manual text are called out with `VERIFY-HCM` comments in `engine_eval`: merge/diverge segment speeds from the Chapter 14 ramp engine are additionally capped at the Chapter 12 basic speed-flow value at the same volume (`ramp.get_speed_avg().min(basic(volume))`), justified by reproducing Exhibit 25-49 Segment 10 Period 3 (published 51.8 mi/h = the Equation 12-1 value); and `density_los` falls back to the Exhibit 12-15 basic-segment thresholds (rather than a merge/diverge-specific LOS F rule, which Exhibit 14-3 does not define) for queued ramp segments.
+Two deliberate deviations from the literal manual text are called out with `VERIFY-HCM` comments in `engine_eval`: merge/diverge segment speeds from the Chapter 14 ramp engine are additionally capped at the Chapter 12 basic speed-flow value at the same volume (`ramp.get_speed_avg().min(basic(volume))`), justified by reproducing Exhibit 25-49 Segment 10 Period 3 (published 51.8 mi/h = the Equation 12-1 value; see VERIFICATION.md ch10/25 item 5); and `density_los` falls back to the Exhibit 12-15 basic-segment thresholds (rather than a merge/diverge-specific LOS F rule, which Exhibit 14-3 does not define) for queued ramp segments (see VERIFICATION.md ch10/25 item 7). The density-rounding behavior of `density_los` itself is VERIFICATION.md ch10/25 item 6.
+
+Equation 25-1:  V_max = FFS - (FFS - V_prev) * e^(-0.00162 * L)                                                 [mi/h]
+  V_max = maximum achievable segment speed                                                                     [mi/h]
+  FFS = subject segment free-flow speed (already SAF-adjusted, i.e. FFS_adj of Equation 10-4)                   [mi/h]
+  V_prev = average speed on the immediately upstream segment                                                    [mi/h]
+  L = distance between the midpoints of the upstream segment and the subject segment                            [ft]
+Implemented in: freeway_facilities/exhibits.rs::max_achievable_speed, applied per segment/period (whenever a previous segment's speed is available) by freeway_facilities/freeway_facilities.rs::FreewayFacility::evaluate_period_chain
 
 ### Oversaturated evaluation (Step A-12; the Chapter 25 Section 4 engine)
 
 `analyze_oversaturated(first)` constructs an `OversaturatedEngine` (lengths in mi, lanes, f_HV, jam density, queue discharge drop, and the time step in seconds — default 15 s, giving `steps_per_period = 900/15 = 60` and `steps_per_hour = 3600/15 = 240`) and calls `run_period` once per remaining analysis period starting at the first oversaturated period. Per period, `FreewayFacility` precomputes: expected demand ED (Equation 25-6, `OversaturatedEngine::expected_demand`, a static recursive min-with-capacity walk from the facility entrance); background density KB (Equation 25-7, evaluated by re-running `engine_eval` at the expected demand); diverge percentages for the current and previous period (Equations 25-23 through 25-25, `diverge_percentages`); and the front-clearing-queue flag (Equation 25-12, `OversaturatedEngine::front_clearing_queue`). These feed an `OversatPeriodInput` into `run_period`, which iterates `steps_per_period` 15-s steps and, at each node from 0 to n, computes: off-ramp flow (Equations 25-22 through 25-25, handling the "deficit of vehicles destined into the upstream segment that were metered" case); mainline input (Equation 25-8); on-ramp flow with ramp queueing (Equations 25-17 through 25-21, including ramp-metering-rate and physical ramp-capacity caps); MO1, the on-ramp-flow storage constraint (Equation 25-9); MO3, the front-clearing wave-lookback constraint (Equations 25-13 through 25-15, via `lookback` — a weighted average over a bounded history ring buffer when the wave travel time is not an integer number of steps, matching the manual's explicit instruction for that case); MO2, the downstream-storage constraint (Equations 25-10/25-11, via `queue_density`); and finally mainline flow as the minimum of all constraints (Equation 25-16). Vehicle counts are then conserved per segment (Equations 25-26 through 25-28) and rolled into next-step state. At period end, segment flow, average vehicles, density, and queue length are aggregated (Equations 25-30 through 25-34).
 
-Two `VERIFY-HCM` deviations are documented directly in `oversaturated.rs`: (1) in the MO2 constraint, the code deliberately uses the *prebreakdown* capacity (`base_sc_step`, before the Equation 25-29 queue-discharge-drop reduction) inside the Equation 25-10 queue-density ratio, while the reduced (post-drop) capacity governs node throughput (MO1/MF, Equation 25-16) — the comment states that applying Equation 25-29's reduced capacity to the KQ ratio as well would lower queue storage density and spread queues much farther upstream than the published Chapter 25 Example Problem 2 results; and (2) Equation 25-34 (queue length) as printed omits the lane count from the density-difference term, but the code multiplies by `self.lanes[i]` because `uv` (unserved vehicles) is a total count while the density terms are per-lane, so lane count is needed to convert `veh / (veh/mi/ln)` into miles correctly.
+Two `VERIFY-HCM` deviations are documented directly in `oversaturated.rs`: (1) in the MO2 constraint, the code deliberately uses the *prebreakdown* capacity (`base_sc_step`, before the Equation 25-29 queue-discharge-drop reduction) inside the Equation 25-10 queue-density ratio, while the reduced (post-drop) capacity governs node throughput (MO1/MF, Equation 25-16) — the comment states that applying Equation 25-29's reduced capacity to the KQ ratio as well would lower queue storage density and spread queues much farther upstream than the published Chapter 25 Example Problem 2 results (VERIFICATION.md ch10/25 item 1); and (2) Equation 25-34 (queue length) as printed omits the lane count from the density-difference term, but the code multiplies by `self.lanes[i]` because `uv` (unserved vehicles) is a total count while the density terms are per-lane, so lane count is needed to convert `veh / (veh/mi/ln)` into miles correctly (VERIFICATION.md ch10/25 item 3).
+
+Below is every equation in the Section 4 engine, in the order the engine evaluates them, each with its full where-clause and the implementing Rust location. Node/segment indexing follows Exhibit 25-1/25-4: node `i` is the upstream end of segment `i` (0-based in the code; 1-based, with segment `i-1` upstream of node `i`, in the manual's own convention), and all flow variables (MI, MO1/2/3, MF, ONRF, OFRF, SF) are per-time-step totals across all lanes of the node/segment, in veh/step unless noted.
+
+Equation 25-6 (expected demand, Segment Initialization Steps 1-4):  ED(i,p) = min[ SC(i,p), ED(i-1,p) + ONRD(i,p) - OFRD(i-1,p) ]     [veh/h]
+  ED(i,p) = expected demand for segment i, period p — the flow that would arrive if all upstream queues were stacked vertically with no spillback   [veh/h]
+  SC(i,p) = segment i prebreakdown capacity, period p                                                          [veh/h]
+  ONRD(i,p) = on-ramp demand entering at the upstream node of segment i, period p                               [veh/h]
+  OFRD(i-1,p) = off-ramp demand exiting at the downstream node of segment i-1, period p                          [veh/h]  (VERIFICATION.md ch10/25 item 4: printed under segment-based ramp indexing as OFRD(i-1,p); this module's node-based indexing addresses the same physical ramp as `offrd[i]`)
+Implemented in: freeway_facilities/oversaturated.rs::OversaturatedEngine::expected_demand
+
+Equation 25-7 (segment initialization, Step 1-4):  NV(i,0,p) = KB(i,p) * N(i,p) * L(i) + UV(i,S,p-1)             [veh]
+  NV(i,0,p) = number of vehicles on segment i at the start of the first time step of period p                    [veh]
+  KB(i,p) = background density for segment i, period p, from the Chapter 12/13/14 procedures evaluated at the expected demand ED(i,p)   [veh/mi/ln]
+  N(i,p) = number of lanes on segment i, period p                                                                 [ln]
+  L(i) = length of segment i                                                                                       [mi]
+  UV(i,S,p-1) = unserved vehicles on segment i at the end of the last time step S of the preceding period p-1      [veh]  (0 for the first oversaturated period)
+Implemented in: freeway_facilities/oversaturated.rs::OversaturatedEngine::init_period
+
+Equation 25-8 (mainline input, Step 9):  MI(i,t,p) = MF(i-1,t,p) + ONRF(i-1,t,p) - OFRF(i,t,p) + UV(i-1,t-1,p)    [veh/step]
+  MI(i,t,p) = mainline input at node i, time step t, period p — vehicles wishing to travel through the node this step   [veh/step]
+  MF(i-1,t,p) = mainline flow across the upstream node i-1, this time step                                          [veh/step]
+  ONRF(i-1,t,p) = on-ramp flow entering at node i-1, this time step                                                  [veh/step]
+  OFRF(i,t,p) = off-ramp flow exiting at node i, this time step                                                     [veh/step]
+  UV(i-1,t-1,p) = unserved vehicles on segment i-1 at the end of the previous time step                             [veh]
+Implemented in: freeway_facilities/oversaturated.rs::OversaturatedEngine::run_period (inline, the `mi` binding inside the per-node loop)
+
+Equation 25-9 (MO1, Step 16):  MO1(i,t,p) = min[ SC(i,t,p) - ONRF(i,t,p), MO2(i,t-1,p), MO3(i,t-1,p) ]           [veh/step]
+  MO1(i,t,p) = mainline output constraint at node i from on-ramp flow sharing (competing on-ramp/mainline flow through the node)   [veh/step]
+  SC(i,t,p) = segment i capacity this time step (post-Equation-25-29 reduction, if an upstream bottleneck is active)   [veh/step]
+  ONRF(i,t,p) = on-ramp flow at node i, this time step                                                              [veh/step]
+  MO2(i,t-1,p), MO3(i,t-1,p) = the preceding time step's MO2/MO3 at node i (Equations 25-11, 25-15)                   [veh/step]
+Implemented in: freeway_facilities/oversaturated.rs::OversaturatedEngine::run_period (inline, `mo1[node]`; only evaluated when ONRF(i,t,p) > 0 — when there is no on-ramp flow the term would collapse to SC(i,t,p), which is already enforced separately as one of the Equation 25-16 mainline-flow terms, so leaving `mo1[node]` at its BIG/unconstrained default in that case does not change the final `mf[node]`)
+
+Equation 25-10 (queue density, Steps 20-21):  KQ(i,t,p) = [KJ * f_HV(i,p)] - [(KJ - KC) * f_HV(i,p) * SF(i,t-1,p)] / SC(i,t,p)     [veh/mi/ln]
+  KQ(i,t,p) = queue (congested-branch) density on segment i                                                         [veh/mi/ln]
+  KJ = jam density                                                                                                   [pc/mi/ln]  (default 190, Step A-6/Exhibit 10-7)
+  f_HV(i,p) = heavy-vehicle adjustment factor (pc-to-veh conversion)                                                 [decimal]
+  KC = density at capacity                                                                                          [pc/mi/ln]  (45, Exhibit 12-6; `DENSITY_AT_CAPACITY_PC`)
+  SF(i,t-1,p) = segment i flow in the previous time step                                                            [veh/step]
+  SC(i,t,p) = segment i capacity this time step                                                                     [veh/step]  (VERIFICATION.md ch10/25 item 1: the code deliberately uses the *prebreakdown* capacity `base_sc_step` here, not the Equation 25-29-reduced capacity that governs throughput)
+Implemented in: freeway_facilities/oversaturated.rs::OversaturatedEngine::queue_density
+
+Equation 25-11 (MO2, Steps 20-21):  MO2(i,t,p) = SF(i,t-1,p) - ONRF(i,t,p) + [KQ(i,t,p) * N(i,p) * L(i)] - NV(i,t-1,p)     [veh/step]
+  MO2(i,t,p) = mainline output constraint at node i from downstream segment storage (queue growth on segment i)      [veh/step]
+  SF(i,t-1,p), ONRF(i,t,p) = as in Equations 25-10 and 25-9                                                          [veh/step]
+  KQ(i,t,p) = queue density from Equation 25-10                                                                       [veh/mi/ln]
+  N(i,p), L(i) = number of lanes and length of segment i                                                              [ln], [mi]
+  NV(i,t-1,p) = number of vehicles on segment i at the end of the previous time step                                  [veh]
+Implemented in: freeway_facilities/oversaturated.rs::OversaturatedEngine::run_period (inline, `mo2[node]`, with `max_veh = kq * self.lanes[node] * self.length_mi[node]`)
+
+Equation 25-12 (front-clearing test, Steps 17-19):  front-clears if  [SC(i,p) - ONRD(i,p)] > [SC(i,p-1) - ONRD(i,p-1)]  AND  [SC(i,p) - ONRD(i,p)] > SD(i,p)
+  SC(i,p), SC(i,p-1) = segment i capacity this period and the preceding period                                       [veh/h]
+  ONRD(i,p), ONRD(i,p-1) = on-ramp demand at node i this period and the preceding period                              [veh/h]
+  SD(i,p) = segment i demand this period                                                                              [veh/h]
+Implemented in: freeway_facilities/oversaturated.rs::OversaturatedEngine::front_clearing_queue, evaluated once per period per segment (not per time step) by freeway_facilities/freeway_facilities.rs::FreewayFacility::analyze_oversaturated before `run_period` is called
+
+Equation 25-13 (shock wave speed, front-clearing):  WS(i,p) = SC(i,p) / [ N(i,p) * (KJ - KC) * f_HV ]                [mi/h]
+  WS(i,p) = front-clearing shock wave speed for segment i, period p                                                   [mi/h]
+  SC(i,p) = segment i capacity, period p                                                                              [veh/h]
+  N(i,p) = number of lanes on segment i                                                                               [ln]
+  KJ, KC, f_HV = as in Equation 25-10
+Implemented in: freeway_facilities/oversaturated.rs::OversaturatedEngine::run_period (inline, the `ws` binding inside the `wtt` vector construction, evaluated only for segments flagged `front_clearing`)
+
+Equation 25-14 (wave travel time, front-clearing):  WTT = T * L(i) / WS(i,p)                                        [time steps]
+  WTT = wave travel time, expressed as a (possibly fractional) number of time steps                                   [time steps]
+  T = time steps per hour                                                                                             [steps/h]  (240 at the default 15-s step; `steps_per_hour`)
+  L(i) = length of segment i                                                                                          [mi]
+  WS(i,p) = as in Equation 25-13                                                                                      [mi/h]
+Implemented in: freeway_facilities/oversaturated.rs::OversaturatedEngine::run_period (inline, `t * self.length_mi[i] / ws`)
+
+Equation 25-15 (MO3, Steps 17-19):  MO3(i,t,p) = min[ MO1(i+1,t-WTT,p), MO2(i+1,t-WTT,p)+OFRF(i+1,t-WTT,p), MO3(i+1,t-WTT,p)+OFRF(i+1,t-WTT,p), SC(i,t-WTT,p), SC(i+1,t-WTT,p)+OFRF(i+1,t-WTT,p) ]  -  OFRF(i,t,p)     [veh/step]
+  MO3(i,t,p) = mainline output constraint at node i from a front-clearing downstream queue                            [veh/step]
+  MO1/MO2/MO3(i+1,t-WTT,p) = the downstream node's outputs, looked back WTT time steps (Equation 25-14); if WTT is not an integer number of steps, a weighted average of the two nearest historical steps is used, per the manual's explicit instruction for that case   [veh/step]
+  OFRF(i+1,t-WTT,p) = off-ramp flow at the downstream node, looked back WTT steps                                     [veh/step]
+  SC(i,t-WTT,p), SC(i+1,t-WTT,p) = segment i and i+1 capacities, looked back WTT steps                                 [veh/step]
+  OFRF(i,t,p) = off-ramp flow at node i, this time step (not looked back)                                              [veh/step]
+Implemented in: freeway_facilities/oversaturated.rs::OversaturatedEngine::run_period (inline, `mo3[node]`), via the `::lookback` helper against bounded history ring buffers (`hist_mo1`/`hist_mo2`/`hist_mo3`/`hist_ofrf`/`hist_sc`) that perform the weighted-average non-integer-step lookback
+
+Equation 25-16 (mainline flow, Steps 22-23):  MF(i,t,p) = min[ MI(i,t,p), MO1(i,t,p), MO2(i,t,p), MO3(i,t,p), SC(i,t,p), SC(i-1,t,p) ]     [veh/step]
+  MF(i,t,p) = mainline flow across node i, this time step                                                              [veh/step]
+  MI, MO1, MO2, MO3 = as in Equations 25-8, 25-9, 25-11, 25-15                                                         [veh/step]
+  SC(i,t,p) = downstream segment i capacity this time step                                                            [veh/step]
+  SC(i-1,t,p) = upstream segment i-1 capacity this time step                                                          [veh/step]  (unconstrained/BIG at the facility entrance, node 0)
+Implemented in: freeway_facilities/oversaturated.rs::OversaturatedEngine::run_period (inline, `mf[node]`)
+
+Equation 25-17 (on-ramp input, Steps 10-11):  ONRI(i,t,p) = ONRD(i,t,p) + ONRQ(i,t-1,p)                             [veh/step]
+  ONRI(i,t,p) = on-ramp input at node i, this time step                                                                [veh/step]
+  ONRD(i,t,p) = on-ramp demand at node i, this time step                                                               [veh/step]
+  ONRQ(i,t-1,p) = vehicles queued on the ramp at the end of the previous time step                                     [veh]
+Implemented in: freeway_facilities/oversaturated.rs::OversaturatedEngine::run_period (inline, `onri`)
+
+Equation 25-18 (on-ramp output, Step 12):  ONRO(i,t,p) = min{ RM(i,t,p), ONRC(i,t,p), max[ Lambda - MI(i,t,p),  Lambda / (2*N(i,p)) ] }     where  Lambda = min[ SC(i,t,p), MF(i+1,t-1,p)+ONRF(i,t-1,p), MO3(i,t-1,p)+ONRF(i,t-1,p) ]     [veh/step]
+  ONRO(i,t,p) = maximum on-ramp output at node i, this time step                                                       [veh/step]
+  RM(i,t,p) = ramp-metering rate at node i, this time step, if specified                                               [veh/step]
+  ONRC(i,t,p) = physical ramp roadway capacity at node i (Exhibit 14-12/`get_ramp_capacity`)                          [veh/step]
+  Lambda = total mainline+ramp throughput available at the merge point, estimated from the previous time step          [veh/step]
+  MI(i,t,p) = mainline input, Equation 25-8                                                                            [veh/step]
+  N(i,p) = number of lanes on segment i                                                                                [ln]  (the Lambda/2N term models forced one-to-one Lane-1 merging between ramp and freeway traffic at high demand)
+Implemented in: freeway_facilities/oversaturated.rs::OversaturatedEngine::run_period (inline: `lambda` is the Lambda term above; `onro` is the `max(...)` structure; `ramp_capacity`/`ramp_metering` are then `.min()`-ed on to complete the outer `min{RM, ONRC, max{...}}`)
+
+Equation 25-19 (on-ramp flow, unmetered, Step 13):  ONRF(i,t,p) = ONRI(i,t,p)     [when ONRI(i,t,p) <= ONRO(i,t,p)]     [veh/step]
+Implemented in: freeway_facilities/oversaturated.rs::OversaturatedEngine::run_period (inline, the `if onri <= onro` branch, which also resets `self.onrq[node] = 0.0`)
+
+Equation 25-20 (on-ramp flow, metered, Step 13):  ONRF(i,t,p) = ONRO(i,t,p)     [otherwise]     [veh/step]
+Implemented in: freeway_facilities/oversaturated.rs::OversaturatedEngine::run_period (inline, the `else` branch)
+
+Equation 25-21 (on-ramp queue, Steps 14-15):  ONRQ(i,t,p) = ONRI(i,t,p) - ONRO(i,t,p)                                [veh]
+  ONRQ(i,t,p) = vehicles queued on the on-ramp at the end of this time step                                           [veh]
+Implemented in: freeway_facilities/oversaturated.rs::OversaturatedEngine::run_period (inline, `self.onrq[node] = onri - onrf[node]`, evaluated only on the metered branch)
+
+Equation 25-22 (off-ramp deficit, Steps 5-8):  DEF(i,t,p) = max{ 0,  [ Sum_{X=1}^{p-1} SD(i-1,X) - Sum_{X=1}^{p-1} Sum_{t=1}^{T} (MF(i-1,t,X)+ONRF(i-1,t,X)) ]  +  Sum_{t=1}^{t-1} (MF(i-1,t,p)+ONRF(i-1,t,p)) }     [veh]
+  DEF(i,t,p) = deficit of vehicles destined into upstream segment i-1 that were metered upstream and have not yet arrived   [veh]
+  SD(i-1,X) = segment i-1 demand in period X                                                                           [veh, period total]
+  MF(i-1,t,X), ONRF(i-1,t,X) = mainline and on-ramp flow into segment i-1 at time step t of period X                    [veh/step]
+Implemented in: freeway_facilities/oversaturated.rs::OversaturatedEngine::run_period (inline, `let deficit = (self.cum_demand[node - 1] - self.cum_arrivals[node - 1]).max(0.0);`); the code tracks the two running sums incrementally via the `cum_demand`/`cum_arrivals` fields (the former updated once per period end, the latter every time step) rather than re-summing the full history each step, which is arithmetically equivalent to the printed double summation
+
+Equation 25-23 (off-ramp flow, deficit >= inflow, Step 6):  OFRF(i,t,p) = [MF(i-1,t,p) + ONRF(i-1,t,p)] * [OFRD(i,p-1) / SD(i-1,p-1)]     [veh/step]   (when inflow <= DEF(i,t,p))
+  OFRD(i,p-1) / SD(i-1,p-1) = the preceding period's diverge percentage at node i
+Implemented in: freeway_facilities/oversaturated.rs::OversaturatedEngine::run_period (inline, `inflow_now * pct_prev`)
+
+Equation 25-24 (off-ramp flow, partial deficit, Step 7):  OFRF(i,t,p) = DEF(i,t,p) * [OFRD(i,p-1)/SD(i-1,p-1)]  +  [MF(i-1,t,p)+ONRF(i-1,t,p) - DEF(i,t,p)] * [OFRD(i,p)/SD(i-1,p)]     [veh/step]   (when 0 < DEF(i,t,p) < inflow)
+Implemented in: freeway_facilities/oversaturated.rs::OversaturatedEngine::run_period (inline, `deficit * pct_prev + (inflow_now - deficit) * pct_now`)
+
+Equation 25-25 (off-ramp flow, no deficit, Step 8):  OFRF(i,t,p) = [MF(i-1,t,p)+ONRF(i-1,t,p)] * [OFRD(i,p)/SD(i-1,p)]     [veh/step]   (when DEF(i,t,p) = 0)
+  OFRD(i,p)/SD(i-1,p) = this period's diverge percentage at node i
+Implemented in: freeway_facilities/oversaturated.rs::OversaturatedEngine::run_period (inline, `inflow_now * pct_now`); the diverge percentages themselves (Equations 25-23 through 25-25's OFRD/SD ratios, for both the current and preceding period) are precomputed once per period by freeway_facilities/freeway_facilities.rs::FreewayFacility::diverge_percentages
+
+Equation 25-26 (segment flow, Steps 24-25):  SF(i-1,t,p) = MF(i,t,p) + OFRF(i,t,p)                                    [veh/step]
+  SF(i-1,t,p) = segment i-1 flow (total output) this time step                                                        [veh/step]
+Implemented in: freeway_facilities/oversaturated.rs::OversaturatedEngine::run_period (inline, `sf[i] = mf[i + 1] + ofrf[i + 1];` — the code's segment index `i` stands for the manual's segment `i-1`)
+
+Equation 25-27 (vehicle conservation):  NV(i-1,t,p) = NV(i-1,t-1,p) + MF(i-1,t,p) + ONRF(i-1,t,p) - MF(i,t,p) - OFRF(i,t,p)     [veh]
+  NV(i-1,t,p) = number of vehicles on segment i-1 at the end of this time step                                          [veh]
+Implemented in: freeway_facilities/oversaturated.rs::OversaturatedEngine::run_period (inline, `let inflow = mf[i] + onrf[i]; self.nv[i] += inflow - sf[i];`)
+
+Equation 25-28 (unserved vehicles):  UV(i-1,t,p) = NV(i-1,t,p) - [KB(i-1,p) * L(i-1)]                                 [veh]  (VERIFICATION.md ch10/25 item 2: printed without the lane count N; dimensional consistency with Equation 25-7's NV formula requires it — likely an erratum. The code multiplies KB by N as well.)
+  UV(i-1,t,p) = unserved (queued) vehicles stored on segment i-1                                                       [veh]
+  KB(i-1,p) = background density (Equation 25-7)                                                                       [veh/mi/ln]
+  L(i-1) = length of segment i-1                                                                                        [mi]
+Implemented in: freeway_facilities/oversaturated.rs::OversaturatedEngine::run_period (inline, `self.uv[i] = (self.nv[i] - background).max(0.0);` where `background = input.background_density[i] * self.lanes[i] * self.length_mi[i]`)
+
+Equation 25-29 (queue discharge drop):  SC(i,t,p) = (1 - alpha) * SC(i,t,p)     [applied when UV(i-1,t,p) > 0.001]     [veh/step]
+  alpha = queue discharge capacity drop                                                                                 [decimal]  (default 0.07, Step A-6/Exhibit 10-7; 0.134 in work zones, Equation 10-9)
+Implemented in: freeway_facilities/oversaturated.rs::OversaturatedEngine::run_period (inline, `sc_step[i] *= 1.0 - self.capacity_drop;` when the upstream segment — or the facility entry queue, for node 0 — has UV > 0.001); this reduced capacity governs mainline throughput (Equations 25-16/25-9) but deliberately NOT the Equation 25-10 KQ ratio (VERIFICATION.md ch10/25 item 1)
+
+Equation 25-30 (average segment flow):  SF(i,p) = (T/S) * Sum_{t=1}^{S} SF(i,t,p)                                     [veh/h]
+  SF(i,p) = average segment flow rate over the analysis period                                                          [veh/h]
+  T = time steps per hour                                                                                               [steps/h]  (240 at the default 15-s step)
+  S = time steps per analysis period                                                                                    [steps/period]  (60 at the default 15-s step, so T/S = 4)
+Implemented in: freeway_facilities/oversaturated.rs::OversaturatedEngine::run_period (inline, `segment_flow[i] = (t / s) * sum_sf[i];`)
+
+Equation 25-31 (average vehicles):  NV(i,p) = (1/S) * Sum_{t=1}^{S} NV(i,t,p)                                          [veh]
+  NV(i,p) = average number of vehicles on segment i over the analysis period                                            [veh]
+Implemented in: freeway_facilities/oversaturated.rs::OversaturatedEngine::run_period (inline, `avg_vehicles[i] = sum_nv[i] / s;`)
+
+Equation 25-32 (average density):  K(i,p) = NV(i,p) / [L(i) * N(i,p)]                                                  [veh/mi/ln]
+  K(i,p) = average per-lane density of segment i over the analysis period                                               [veh/mi/ln]
+  L(i) = segment length                                                                                                  [mi]
+  N(i,p) = number of lanes                                                                                                [ln]
+Implemented in: freeway_facilities/oversaturated.rs::OversaturatedEngine::run_period (inline, `density[i] = avg_vehicles[i] / (self.length_mi[i] * self.lanes[i]);`)
+
+Equation 25-33 (average speed):  U(i,p) = SF(i,p) / K(i,p)                                                             [mi/h]
+  U(i,p) = average space mean speed of segment i over the analysis period                                               [mi/h]
+  SF(i,p) = Equation 25-30 (a total, all-lane flow rate)                                                                 [veh/h]
+  K(i,p) = Equation 25-32 (a per-lane density)                                                                           [veh/mi/ln]
+**DISCREPANCY:** as printed, U = SF/K divides a total (all-lane) flow by a per-lane density, which dimensionally yields a value N times too large (i.e., mi/h scaled by lane count) rather than a true space mean speed. This is the same class of lane-count omission already catalogued as VERIFICATION.md ch10/25 items 2 and 3 (Equations 25-28 and 25-34), but Equation 25-33 itself is not listed there. The code correctly divides the segment flow by the lane count before dividing by density: U = (SF(i,p)/N(i,p)) / K(i,p).
+Implemented in: freeway_facilities/freeway_facilities.rs::FreewayFacility::analyze_oversaturated (inline, the `queued_speed` binding: `(res.segment_flow[i] / lanes[i]) / res.density[i]`)
+
+Equation 25-34 (queue length):  Q(i,p) = UV(i,S,p) / max[ (KQ(i,S,p) - KB(i,p)), 1 ] * 5280                            [ft]  (VERIFICATION.md ch10/25 item 3: printed without the lane count N on the density-difference term; the code multiplies the difference by N(i,p) because UV is a total vehicle count while KQ/KB are per-lane densities, so N is needed to convert veh / (veh/mi/ln) into miles correctly)
+  Q(i,p) = queue length at the end of the analysis period                                                               [ft]
+  UV(i,S,p) = unserved vehicles at the end of the last time step S                                                       [veh]
+  KQ(i,S,p) = queue density at the end of the period (Equation 25-10)                                                   [veh/mi/ln]
+  KB(i,p) = background density (Equation 25-7)                                                                          [veh/mi/ln]
+Implemented in: freeway_facilities/oversaturated.rs::OversaturatedEngine::run_period (inline, `queue_length_ft[i] = (self.uv[i] / dk * 5280.0).min(self.length_mi[i] * 5280.0);` where `dk = (kq_last[i] - input.background_density[i]).max(1.0) * self.lanes[i]`; the code additionally clamps the result to the physical segment length, a reasonable implementation bound not stated in the printed equation)
 
 ### Facility aggregation and LOS (Steps A-15/A-17)
 
 `compute_facility_performance` computes, per period: facility space mean speed (Equation 25-2, `exhibits::facility_space_mean_speed`, flow-times-length over flow-times-length-over-speed); facility density in both veh/mi/ln and pc/mi/ln (Equation 10-1, `exhibits::facility_density`, length-and-lane weighted); facility LOS (`exhibits::los_freeway_facility`, Exhibit 10-6, forcing LOS F whenever any segment's vd/c exceeds 1.00 in that period, independent of density); and VMT/VHT/VHD accumulated segment-by-segment using served and demand volumes at 0.25-hour period duration. `overall_space_mean_speed` and `overall_density_veh` implement the facility-wide, all-period aggregates (Equations 25-4 and 25-5) as flow-times-length-weighted averages across every `[segment][period]` cell.
+
+Equation 10-1 (facility density; also printed, identically, as Equation 25-3 "Average facility density in time interval p" — the two equation numbers share one formula):  D_F = Sum_{i=1}^{n} (D_i * L_i * N_i) / Sum_{i=1}^{n} (L_i * N_i)     [pc/mi/ln]
+  D_F = average density for the facility in a given 15-min analysis period                                             [pc/mi/ln]
+  D_i = density for segment i                                                                                           [pc/mi/ln]
+  L_i = length of segment i                                                                                             [mi]
+  N_i = number of lanes in segment i                                                                                     [ln]
+  n = number of segments in the defined facility
+Implemented in: freeway_facilities/exhibits.rs::facility_density, called twice per period by freeway_facilities/freeway_facilities.rs::FreewayFacility::compute_facility_performance — once with `density_veh` (reported as `avg_density_veh`, matching Exhibit 25-52's veh/mi/ln convention) and once with `density_veh / f_HV` as a pc-basis input (reported as `avg_density_pc`, the basis for the Exhibit 10-6 LOS lookup)
+
+Equation 25-2 (facility space mean speed):  SMS(NS,p) = Sum_{i=1}^{NS} [SF(i,p) * L(i)]  /  Sum_{i=1}^{NS} [SF(i,p) * L(i)/U(i,p)]     [mi/h]
+  SMS(NS,p) = facility space mean speed over NS segments in period p                                                     [mi/h]
+  SF(i,p) = segment i flow                                                                                               [veh/h]
+  L(i) = segment i length                                                                                                [any consistent unit; the code uses ft]
+  U(i,p) = segment i speed                                                                                              [mi/h]
+Implemented in: freeway_facilities/exhibits.rs::facility_space_mean_speed
+
+Equation 25-4 (overall space mean speed, all periods):  SMS(NS,P) = Sum_{p=1}^{P} Sum_{i=1}^{NS} [SF(i,p)*L(i)]  /  Sum_{p=1}^{P} Sum_{i=1}^{NS} [SF(i,p)*L(i)/U(i,p)]     [mi/h]
+  SMS(NS,P) = overall space mean speed across all P analysis periods and NS segments                                     [mi/h]
+Implemented in: freeway_facilities/freeway_facilities.rs::FreewayFacility::overall_space_mean_speed
+
+Equation 25-5 (overall average density, all periods):  K(NS,P) = Sum_{p=1}^{P} Sum_{i=1}^{NS} [K(i,p)*L(i)]  /  Sum_{p=1}^{P} Sum_{i=1}^{NS} [L(i)*N(i,p)]     [veh/mi/ln]
+  K(NS,P) = overall average density across all P analysis periods and NS segments                                       [veh/mi/ln]
+Implemented in: freeway_facilities/freeway_facilities.rs::FreewayFacility::overall_density_veh
 
 ## Validation
 
@@ -57,12 +340,12 @@ Example Problem 2 has documented, asserted-at-computed-value reproduction gaps, 
 - `ep2_facility_performance_matches_exhibit_25_60`: per-period speed/density/LOS all match at the standard tolerance including LOS F in period 3, but the overall (all-period) totals are asserted at the computed 49.3 mi/h / 36.5 veh/mi/ln with +-1.5 tolerance against a published 50.5 mi/h / 35.6 veh/mi/ln, attributed to the same period-4 queue-distribution gap.
 - `ep2_queue_lifecycle`: a qualitative check (not matrix comparison) that the Segment 8 bottleneck never exceeds va/c = 1.0, that queues form upstream in period 3, and that all queues clear by period 5.
 
-Unit tests in `src/hcm/chapter10/tests.rs` and `src/hcm/chapter10/exhibits.rs` (inline `#[cfg(test)]` modules) spot-check individual equations against hand-computed or Exhibit-sourced values, e.g. `test_equation_25_1_max_achievable_speed` against Chapter 25 Example Problem 1 Segment 3 Period 1 (V_max ~= 59.71 mi/h at +-0.05), `test_exhibit_10_15_lcsi_values` against all six Exhibit 10-15 LCSI entries, and `test_equations_10_9_through_10_12` against a hand-worked 2-to-2 work zone case. `oversaturated.rs`'s own test module exercises the engine in isolation (bottleneck metering, queue-discharge-drop persistence across periods, queue recovery, ramp forced-merge sharing, ramp metering, off-ramp diverge percentage, and front-clearing detection) with synthetic single- and multi-segment facilities rather than published HCM numbers.
+Unit tests in `src/hcm/freeway_facilities/tests.rs` and `src/hcm/freeway_facilities/exhibits.rs` (inline `#[cfg(test)]` modules) spot-check individual equations against hand-computed or Exhibit-sourced values, e.g. `test_equation_25_1_max_achievable_speed` against Chapter 25 Example Problem 1 Segment 3 Period 1 (V_max ~= 59.71 mi/h at +-0.05), `test_exhibit_10_15_lcsi_values` against all six Exhibit 10-15 LCSI entries, and `test_equations_10_9_through_10_12` against a hand-worked 2-to-2 work zone case. `oversaturated.rs`'s own test module exercises the engine in isolation (bottleneck metering, queue-discharge-drop persistence across periods, queue recovery, ramp forced-merge sharing, ramp metering, off-ramp diverge percentage, and front-clearing detection) with synthetic single- and multi-segment facilities rather than published HCM numbers.
 
 ## Deferred
 
-Per the `chapter10/mod.rs` and `freeway_facilities.rs` module doc comments, explicitly out of scope in this pass:
-- Managed-lane facilities (Steps A-9/A-13/A-14) — implemented separately on `feat/hcm-ch10-managed-lanes` (`src/hcm/chapter10/managed_lanes.rs`, `planning.rs`).
+Per the `freeway_facilities/mod.rs` and `freeway_facilities.rs` module doc comments, explicitly out of scope in this pass:
+- Managed-lane facilities (Steps A-9/A-13/A-14) — implemented separately on `feat/hcm-ch10-managed-lanes` (`src/hcm/freeway_facilities/managed_lanes.rs`, `planning.rs`).
 - The Chapter 25 planning-level method.
 - The Chapter 25 Section 5 special work zone configuration tables (Exhibits 25-8 through 25-14) — only the general NCHRP 03-107 work zone CAF/SAF model (Equations 10-7 through 10-12) is implemented, not the specific configuration-table lookups.
 - Exhibit 12-25 provides no PCE for mountainous terrain; `Terrain::pce()` uses 3.0 (the rolling-terrain value) as a conservative stand-in rather than the Chapter 25/26 mixed-flow model the manual directs to.

--- a/docs/hcm/procedures/chapter11.md
+++ b/docs/hcm/procedures/chapter11.md
@@ -1,6 +1,6 @@
 # HCM Chapter 11: Freeway Reliability Analysis
 
-This document walks a reviewer through the Rust implementation of the HCM 7th Edition Chapter 11 methodology (Steps B-1 through B-13), which wraps the Chapter 10 freeway facilities core methodology in a scenario loop over a multiday/multimonth reliability reporting period (RRP). The Chapter 25, Section 9 scenario generator (Exhibit 25-39's 34-step hybrid procedure) combines deterministic day-of-week x month-of-year demand variability, deterministic scheduled work zones, and weather/incident events (deterministic event counts via delta-rounding equations, with a seeded stochastic pairing to scenarios/start-times/segments); each scenario is evaluated with the Chapter 10 core method; the resulting facility travel times form a weighted travel-time-index (TTI) distribution from which the Chapter 11 reliability performance measures are computed. The code lives in `src/hcm/chapter11/scenario_generation.rs` (the 34-step generator and the in-module PRNG), `src/hcm/chapter11/reliability.rs` (the Chapter 11 `ReliabilityAnalysis` orchestrator), `src/hcm/chapter11/exhibits.rs` (weather/incident/demand-ratio exhibit lookups and the Equations 11-1 through 11-5 planning-level method), and `src/hcm/common/reliability.rs` (the chapter-agnostic weighted TTI distribution and reliability metrics, shared with the future Chapter 17 urban street reliability module). No `docs/hcm/VERIFICATION.md` exists on this branch, so deviations from the printed manual are documented inline below as `VERIFY-HCM` comments rather than cross-referenced.
+This document walks a reviewer through the Rust implementation of the HCM 7th Edition Chapter 11 methodology (Steps B-1 through B-13), which wraps the Chapter 10 freeway facilities core methodology in a scenario loop over a multiday/multimonth reliability reporting period (RRP). The Chapter 25, Section 9 scenario generator (Exhibit 25-39's 34-step hybrid procedure) combines deterministic day-of-week x month-of-year demand variability, deterministic scheduled work zones, and weather/incident events (deterministic event counts via delta-rounding equations, with a seeded stochastic pairing to scenarios/start-times/segments); each scenario is evaluated with the Chapter 10 core method; the resulting facility travel times form a weighted travel-time-index (TTI) distribution from which the Chapter 11 reliability performance measures are computed. The code lives in `src/hcm/freeway_reliability/scenario_generation.rs` (the 34-step generator and the in-module PRNG), `src/hcm/freeway_reliability/reliability.rs` (the Chapter 11 `ReliabilityAnalysis` orchestrator), `src/hcm/freeway_reliability/exhibits.rs` (weather/incident/demand-ratio exhibit lookups and the Equations 11-1 through 11-5 planning-level method), and `src/hcm/common/reliability.rs` (the chapter-agnostic weighted TTI distribution and reliability metrics, shared with the future Chapter 17 urban street reliability module). Deviations from the printed manual are documented inline below as `VERIFY-HCM` comments and cross-referenced against `docs/hcm/VERIFICATION.md` (the "Chapter 11 (feat/hcm-ch11-freeway-reliability)" section), which catalogs six items; each is referenced by item number at its relevant step below rather than re-derived. Every equation named below is transcribed in full plain-text/unicode form under its step, with a where-clause defining every variable's units, and the implementing Rust function at its current (`freeway_reliability`) path, cross-checked against both the Rust source and the HCM 7th Edition EPUB MathML (`74_Ch11_01.xhtml` through `79_Ch11_06.xhtml` for Chapter 11; `200_Ch25_09.xhtml` for the Chapter 25, Section 9 scenario generator).
 
 ## Step-by-step walkthrough
 
@@ -28,21 +28,222 @@ This document walks a reviewer through the Rust implementation of the HCM 7th Ed
 
 **Deterministic-count / stochastic-pairing split.** As documented in the `scenario_generation.rs` module comment, the HCM procedure itself is a hybrid: event *counts* (weather events per month, incidents per severity/duration/location bin) are generated deterministically via the delta-adjusted rounding equations so the marginal distributions match the inputs exactly, while only the *pairing* of events to scenarios/start-times/segments is stochastic. `counts_matching_distribution` (used for all four count-matching steps above) implements this via bisection search for a scale factor `delta` such that `sum(round(delta * n * p_i)) = n`, with a largest-remainder fallback (`counts.iter().max_by`/`min_by` on the rounding gain/loss) when no `delta` hits the target exactly because of rounding-jump gaps.
 
+#### Equations 25-71 through 25-93 (full transcription)
+
+Every equation cited by name above, transcribed from the EPUB MathML (`200_Ch25_09.xhtml`) and cross-checked against the Rust implementation.
+
+**Steps 2-5 (demand combinations, probabilities, DAF):**
+
+```
+Equation 25-71:  N_Scen = Nr x N_DC                                                    [count]
+  N_Scen = total number of scenarios generated                                          [count]
+  Nr     = number of replications per demand combination (book prints this equation with the literal constant 4, its own stated default; the code generalizes to the configured `ScenarioGenerationConfig::replications`, consistent with Step 3's text that the analyst may choose a different value, and with Equation 25-74 where the book itself already calls this quantity Nr) [count]
+  N_DC   = number of demand combinations (months x weekdays)                            [count]
+Implemented in: freeway_reliability/scenario_generation.rs::generate_scenarios (scenarios.len() == N_DC * replications; the `ndc` / `nr` locals)
+
+Equation 25-72:  DAF_s(tp, seg) = DM(s) / DM(Seed_tp)     for all tp in SP, seg in Segments
+  DAF_s(tp,seg) = demand adjustment factor for scenario s, period tp, segment seg        [decimal]
+  DM(s)         = demand multiplier associated with scenario s                          [decimal, ratio to AADT]
+  DM(Seed_tp)   = demand multiplier associated with the seed file                       [decimal]
+Implemented in: freeway_reliability/scenario_generation.rs::generate_scenarios (`daf: dm / dm_seed`), ::ScenarioGenerationConfig::{demand_multiplier, seed_demand_multiplier} (index into `demand_multipliers`, default Exhibit 11-18 URBAN_DEMAND_RATIOS)
+
+Equation 25-73:  P{s} = n_Day,DCs / (Nr x sum_{k=1..N_DC} n_Day,k)
+  P{s}      = probability of scenario s                                                 [decimal; sums to 1.0 over all scenarios]
+  n_Day,DCs = number of days in the RRP for scenario s's demand combination              [days]
+  n_Day,k   = number of days in the RRP for demand combination k (typically 4 for a 1-yr weekday analysis) [days]
+  N_DC      = number of demand combinations                                             [count]
+  As with Equation 25-71, the book's printed denominator multiplier is the literal constant 4; the code generalizes it to `Nr`.
+Implemented in: freeway_reliability/scenario_generation.rs::generate_scenarios (`probability = day_counts[dc] / (nr as f64 * total_days)`)
+```
+
+**Steps 6-9 (deterministic work zone assignment):**
+
+```
+Equation 25-74:  N-bar_DC,WZ = round(r_DC x Nr, 0)                                      [replications, rounded to nearest integer]
+  N-bar_DC,WZ = adjusted number of replications of a demand combination assigned the work zone [count]
+  r_DC        = ratio of active-weekday-type days in a month to the total days of that weekday type in the month [decimal]
+  Nr          = number of replications per demand combination                            [count]
+Implemented in: freeway_reliability/scenario_generation.rs::generate_scenarios (`n_wz = ((wz.active_day_ratio * nr as f64).round() as usize).min(nr)`, assigned to scenarios whose month/weekday match and whose replication index < n_wz); WorkZoneEvent::active_day_ratio supplies r_DC directly (not recomputed from a calendar)
+```
+
+**Steps 10-18 (weather event frequency and assignment):**
+
+```
+Equation 25-75:  P_W{i,j} = (sum of all SP durations in month j that weather type i is present) / (sum of all SP durations in month j)
+  P_W{i,j} = timewise probability of weather type i in month j                           [decimal]
+  SP       = study period                                                                [-]
+  This is an input-data-preparation formula describing how the national/local weather probability tables are derived from historical station data; it is not computed by this crate. `WeatherInputs::probabilities_by_month` supplies P_t{w,j} directly as a user/default input.
+Not computed in code (input data preparation only); consumed as: freeway_reliability/scenario_generation.rs::WeatherInputs::probabilities_by_month
+
+Equation 25-76:  E[n_w,j] = round(P_t{w,j} x D_SP x N_Scen,j / E15min[D_w])              [events, rounded to nearest integer]
+  E[n_w,j]     = expected frequency of weather event w in month j, rounded to the nearest integer [events]
+  P_t{w,j}     = timewise probability of weather type w in month j                       [decimal]
+  D_SP         = duration of the study period                                            [h]
+  N_Scen,j     = number of scenarios associated with month j                             [count]
+  E15min[D_w]  = expected duration of weather event w, rounded to the nearest 15-min increment, minimum 0.25 h [h]
+Implemented in: freeway_reliability/scenario_generation.rs::expected_weather_frequency
+```
+
+**Steps 19-24 (incident frequency and per-scenario counts):**
+
+```
+Equation 25-77:  n_j = IR_j x VMT_j                                                     [incidents, rounded to nearest integer]
+  n_j    = expected frequency of all incidents in the study period for month j, rounded to nearest integer [incidents]
+  IR_j   = incident rate per 100 million VMT in month j                                  [incidents / 10^8 veh-mi]
+  VMT_j  = average VMT for scenarios in month j, after adjusting the base-scenario demand with the month's demand multipliers and multiplying by facility length [veh-mi]
+  See VERIFICATION.md item 4: the published Exhibit 25-103 October value is internally inconsistent with its own inputs (October/November Exhibit 25-100 demand-ratio rows are identical, so n_j must be equal for both months; the code asserts this equality and computes 0.79 vs. the printed 0.83).
+Implemented in: freeway_reliability/scenario_generation.rs::generate_scenarios (`ir * (seed_vmt * mean_daf) / 1e8`; the /1e8 divisor folds the "per 100 million VMT" rate into VMT_j rather than pre-scaling IR_j, algebraically identical to n_j = IR_j x VMT_j)
+
+Equation 25-78:  IR_j = CR_j x ICR
+  IR_j = incident rate per 100 million VMT in month j                                    [incidents / 10^8 veh-mi]
+  CR_j = local facilitywide crash rate per 100 million VMT in month j                     [crashes / 10^8 veh-mi]
+  ICR  = local incident-to-crash ratio (national default 4.9)                             [decimal]
+Implemented in: freeway_reliability/scenario_generation.rs::generate_scenarios (`let ir = cr * incidents.incident_to_crash_ratio;`); freeway_reliability/exhibits.rs::incident_rate_from_crash_rate (standalone helper implementing the same product); DEFAULT_INCIDENT_TO_CRASH_RATIO = 4.9
+
+Equation 25-79 (HERS model):  CR = (154.0 - 1.203*ACR + 0.258*ACR^2 - 0.00000524*ACR^5) x e^(0.0082*(12 - LW))
+  CR  = crash rate per 100 million VMT                                                   [crashes / 10^8 veh-mi]
+  ACR = facility AADT divided by its two-way hourly capacity                              [decimal]
+  LW  = lane width                                                                        [ft]
+Implemented in: freeway_reliability/exhibits.rs::hers_crash_rate (standalone; not wired into generate_scenarios's incident-frequency computation, which only accepts a directly supplied crash_rate_per_100mvmt -- see Deferred below)
+
+Equation 25-80:  sum_{k=0..+inf} round(delta1 x N_Scen,j x Prob{n_inc = k}) = N_Scen,j
+  delta1        = adjustment parameter solved so the rounded Poisson-probability-weighted counts sum to N_Scen,j (hovers near 1) [decimal]
+  N_Scen,j      = number of scenarios associated with month j                             [count]
+  Prob{n_inc=k} = Poisson(n_j) probability mass at k incidents                            [decimal]
+Implemented in: freeway_reliability/scenario_generation.rs::counts_matching_distribution (delta solved by bisection; the same helper implements Eq 25-80/81, 25-83/84, 25-86/87, and 25-90 through 25-93 -- see the "Deterministic-count / stochastic-pairing split" note above), freeway_reliability/scenario_generation.rs::poisson_pmf (Prob{n_inc=k})
+
+Equation 25-81:  Number of scenarios with k incident events = round(delta1 x N_Scen,j x Prob{n_inc = k})
+  (variables as in Equation 25-80)
+Implemented in: freeway_reliability/scenario_generation.rs::generate_scenarios (`count_of_k = counts_matching_distribution(&pmf, nscen_j)`), then randomly shuffled onto scenarios (`rng.shuffle`) per Step 22
+```
+
+**Steps 25-26 (incident severity):**
+
+```
+Equation 25-82:  G(i) = { g1  i=1 (shoulder closed); g2  i=2 (1 lane closed); g3  i=3 (2 lanes closed); g4  i=4 (3 lanes closed); g5  i=5 (4+ lanes closed) }
+  G(i) = discrete incident-severity distribution, assumed homogeneous across the facility and demand levels [decimal, sums to 1.0]
+Implemented in: freeway_reliability/exhibits.rs::IncidentSeverity, INCIDENT_SEVERITIES (the five-category type; symbolic definition, not a computed formula)
+
+Equation 25-83:  sum_i round(delta2 x N_Scen,Inc x G(i)) = N_Scen,Inc
+  delta2      = adjustment parameter solved so rounded severity counts sum to the total incident count [decimal]
+  N_Scen,Inc  = total number of incidents generated across the RRP                        [count]
+  G(i)        = incident severity distribution (Equation 25-82/25-85)                     [decimal]
+Implemented in: freeway_reliability/scenario_generation.rs::counts_matching_distribution(g, n_inc) (called on the severity distribution `g`)
+
+Equation 25-84:  Number of incidents with severity i = round(delta2 x N_Scen,Inc x G(i))
+  (variables as in Equation 25-83)
+Implemented in: freeway_reliability/scenario_generation.rs::generate_scenarios (`severity_counts = counts_matching_distribution(g, n_inc)`, expanded to a per-incident severity list and shuffled per Step 26)
+
+Equation 25-85:  G(i) = { 0.754  i=1; 0.196  i=2; 0.031  i=3; 0.019  i=4; 0  i=5 }
+  G(i) = national default incident severity distribution (shoulder, 1-lane, 2-lane, 3-lane, 4+-lane closures) [decimal]
+Implemented in: freeway_reliability/exhibits.rs::DEFAULT_INCIDENT_SEVERITY_DISTRIBUTION = [0.754, 0.196, 0.031, 0.019, 0.0]
+```
+
+**Steps 27-28 (incident duration, Exhibit 25-41 lognormal parameters):**
+
+```
+Equation 25-86:  sum_t round(delta3 x N_Inc,i x Prob{IncDur = t, IncType = i}) = N_Inc,i
+  delta3                    = adjustment parameter solved so rounded duration-bin counts sum to N_Inc,i [decimal]
+  N_Inc,i                   = number of incidents with severity i                          [count]
+  Prob{IncDur=t, IncType=i} = lognormal duration-distribution probability of duration t (whole 15-min analysis periods) given severity i, from the Exhibit 25-41 moment-matched lognormal, discretized into period-width bins [decimal]
+  Exhibit 25-41 parameters (mean/std-dev/min/max, min): shoulder 34.0/15.1/8.7/58.0; 1-lane 34.6/13.8/16.0/58.2; 2-lane 53.6/13.9/30.5/66.9; 3-or-more-lane 69.6 average (67.9 median)/21.9/36.0/93.3 -- see VERIFICATION.md item 1: Exhibit 11-22 (Chapter 11) prints 67.9 as the "3 Lanes Closed" and "4+ Lanes Closed" mean (matching Exhibit 25-41's median, not its 69.6 average); the code uses 67.9 for both severity types (Exhibit 11-22 value), and Exhibit 11-22 itself already lists identical shoulder/1/2/3/4+-lane columns for the 3-lane and 4+-lane cases.
+Implemented in: freeway_reliability/scenario_generation.rs::incident_duration_bins (discretizes the lognormal into 15-min bins via lognormal_cdf, moment-matched: sigma^2 = ln(1 + (std_dev/mean)^2), mu = ln(mean) - sigma^2/2), DEFAULT_INCIDENT_DURATION_PARAMS (`exhibits.rs`) for the tabulated parameters, freeway_reliability/scenario_generation.rs::counts_matching_distribution (solves delta3 and rounds)
+
+Equation 25-87:  Number of scenarios assigned incident severity i = round(delta3 x N_Inc,i x Prob{IncDur = t, IncType = i})
+  (variables as in Equation 25-86; despite the printed label "incident severity i" this equation is indexed by duration bin t within severity i -- it is the per-duration-bin incident count, consistent with Step 27's stated purpose of generating a duration distribution per severity type, and with the code's per-severity duration-binning loop)
+Implemented in: freeway_reliability/scenario_generation.rs::generate_scenarios (`bin_counts = counts_matching_distribution(&probs, members.len())`, expanded to a per-incident duration list and shuffled per Step 28)
+```
+
+**Steps 29-34 (incident location and start time):**
+
+```
+Equation 25-88:  Prob{Location = segment x} = (sum_p VMT_x,p) / (sum_{seg,p} VMT_i,p)
+  Prob{Location=segment x} = probability that an incident's location is segment x         [decimal]
+  VMT_x,p                  = VMT on segment x during analysis period p in the seed file    [veh-mi]
+  (the book's printed denominator sums VMT_i,p over "seg" and p -- i.e. total facility VMT across all segments/periods; the segment index is written inconsistently as x in the numerator vs. i in the denominator, both denoting "segment")
+Implemented in: freeway_reliability/scenario_generation.rs::SeedStatistics::location_distribution
+
+Equation 25-89:  Prob{StartTime = analysis period y} = (sum_i VMT_i,y) / (sum_{i,p} VMT_i,p)
+  Prob{StartTime=analysis period y} = probability that an incident starts in analysis period y [decimal]
+  VMT_i,y                           = VMT on segment i during analysis period y in the seed file [veh-mi]
+Implemented in: freeway_reliability/scenario_generation.rs::SeedStatistics::start_time_distribution
+
+Equation 25-90:  sum_x round(delta4 x N_Scen,Inc x Prob{Location = x}) = N_Scen,Inc
+Equation 25-92:  Number of incidents assigned to segment seg = round(delta4 x N_Scen,Inc x Prob{Location = seg})
+  delta4     = adjustment parameter solved so rounded location counts sum to N_Scen,Inc    [decimal]
+  N_Scen,Inc = total number of incidents generated across the RRP                          [count]
+Implemented in: freeway_reliability/scenario_generation.rs::counts_matching_distribution(&loc_dist, n_inc) (`loc_counts`, expanded to a shuffled location pool)
+
+Equation 25-91:  sum_y round(delta5 x N_Scen,Inc x Prob{StartTime = y}) = N_Scen,Inc
+Equation 25-93:  Number of incidents assigned a starting time in analysis period p = round(delta5 x N_Scen,Inc x Prob{StartTime = p})
+  delta5     = adjustment parameter solved so rounded start-time counts sum to N_Scen,Inc   [decimal]
+Implemented in: freeway_reliability/scenario_generation.rs::counts_matching_distribution(&start_dist, n_inc) (`start_counts`, expanded to a shuffled start-period pool); the (scenario, severity, duration) x (location, start) pairing itself (Steps 31-34) is the `'search:` loop in generate_scenarios
+```
+
 ### PRNG determinism
 
-`Prng` (`scenario_generation.rs`) is an in-module xorshift64* generator seeded from `ScenarioGenerationConfig::rng_seed` (0 is remapped to a fixed nonzero constant to avoid the all-zeros fixed point) — no external `rand` crate dependency. It exposes `next_u64`, `next_f64` (uniform `[0,1)`), `gen_range` (uniform integer), `pick_weighted` (discrete weighted draw), and `shuffle` (Fisher-Yates). Because the seed is explicit and the algorithm is a fixed deterministic bit-mixing function, `generate_scenarios` is byte-for-byte reproducible for a given seed — verified in the unit test `test_generation_reproducible_for_seed` (`src/hcm/chapter11/tests.rs`) and the integration test `ep7_generation_reproducible` (`tests/chapter11_integration.rs`), both of which run the same config twice and assert identical serialized scenario sets, then change only `rng_seed` and assert the output differs. The module doc comment is explicit that the *published* HCM Example Problem 7 results come from FREEVAL's own Monte Carlo stream (also seeded, but with a different, proprietary generator), so per-scenario reproduction of the book's numbers is not expected or attempted — only distribution-level metrics are compared (see Validation below).
+`Prng` (`scenario_generation.rs`) is an in-module xorshift64* generator seeded from `ScenarioGenerationConfig::rng_seed` (0 is remapped to a fixed nonzero constant to avoid the all-zeros fixed point) — no external `rand` crate dependency. It exposes `next_u64`, `next_f64` (uniform `[0,1)`), `gen_range` (uniform integer), `pick_weighted` (discrete weighted draw), and `shuffle` (Fisher-Yates). Because the seed is explicit and the algorithm is a fixed deterministic bit-mixing function, `generate_scenarios` is byte-for-byte reproducible for a given seed — verified in the unit test `test_generation_reproducible_for_seed` (`src/hcm/freeway_reliability/tests.rs`) and the integration test `ep7_generation_reproducible` (`tests/chapter11_integration.rs`), both of which run the same config twice and assert identical serialized scenario sets, then change only `rng_seed` and assert the output differs. The module doc comment is explicit that the *published* HCM Example Problem 7 results come from FREEVAL's own Monte Carlo stream (also seeded, but with a different, proprietary generator), so per-scenario reproduction of the book's numbers is not expected or attempted — only distribution-level metrics are compared (see Validation below).
 
 ### Scenario evaluation and CAF/SAF/DAF folding (Step B-9/B-10)
 
 `ReliabilityAnalysis::build_scenario_facility` clones the base `FreewayFacility` and, for each scenario, builds per-period facility-wide DAF and per-segment/per-period CAF/SAF arrays by iterating the scenario's `weather_events`, `incidents`, `work_zones`, and `special_events` in that order, multiplying each active event's factor into the running per-cell CAF/SAF/DAF (all effects are multiplicative, matching the Step B-9 semantics documented in the `reliability.rs` module comment). Incident lane closures use `incident_caf_total` (`exhibits.rs`), which converts the Exhibit 11-23 per-open-lane CAF into a total-segment-capacity multiplier as `CAF_table * (N - lanes_closed) / N` — the module doc explicitly flags a **VERIFY-HCM** deviation here: FREEVAL additionally reduces the *number of lanes* (NLAF) on incident/work-zone segments, which changes per-lane density and speed on those segments, whereas this implementation keeps the segment's lane count constant and models the closure entirely through the total-capacity CAF; the comment argues facility travel times (the quantity driving the reliability distribution) are "only marginally affected" since they're governed by the capacity restriction (queueing), not by segment lane count. After the DAF is applied to `mainline_demand` and all ramp demand vectors, and CAF/SAF are multiplied into `caf_schedule`/`saf_schedule` on top of any base per-segment schedule, `ReliabilityAnalysis::run` calls `fac.run_analysis()` per scenario (this is a full Chapter 10 run, described in `docs/hcm/procedures/chapter10.md`) and computes `facility_travel_time_min` (sum of `L_i / U_i` over segments at that period's speeds, with a nominal 1 mi/h floor when a segment is fully stopped to keep travel time finite) and TTI (`(tt_min / free_flow_travel_time_min).max(1.0)`).
 
+```
+Incident CAF total-capacity multiplier (Exhibit 11-23; not an HCM-numbered equation):
+  CAF_total = CAF_table x (N - lanes_closed) / N                                          [decimal]
+  CAF_table     = Exhibit 11-23 per-open-lane CAF for the segment's directional lane count and incident severity [decimal]
+  N             = number of directional lanes on the segment                              [ln]
+  lanes_closed  = number of lanes closed by the incident (severity.lanes_closed())        [ln]
+  Worked example transcribed from the exhibit note: a 2-lane closure on a 6-lane facility keeps CAF_table(0.75) x (6-2)/6 = 0.75 x 4/6 = 0.50 of the original capacity.
+  N/A cells (lanes_closed >= N, full closure) return None; the scenario generator downgrades severity via feasible_severity until a Some(_) result is available for the segment's lane count (Chapter 11 text: "the scenario generation methodology does not assign incidents that result in full segment closure").
+Implemented in: freeway_reliability/exhibits.rs::incident_caf_total (total-capacity form), ::incident_caf_per_open_lane (INCIDENT_CAF_PER_OPEN_LANE, the tabulated Exhibit 11-23 values), ::feasible_severity (severity downgrade); folded into the scenario facility at freeway_reliability/reliability.rs::ReliabilityAnalysis::build_scenario_facility (`caf_inc = incident_caf_total(lanes, inc.severity).unwrap_or(1.0)`)
+```
+
+See VERIFICATION.md item 2: this crate applies the incident's capacity effect entirely through `CAF_total` above, leaving the segment's lane count unchanged for density/speed purposes, whereas FREEVAL additionally reduces the segment's *lane count* (NLAF) on the incident segment. See VERIFICATION.md item 6 for the (book-silent) linear interpolation used by `weather_caf`/`weather_saf` (Exhibits 11-20/11-21) between the tabulated 5-mi/h FFS columns.
+
 ### Reliability performance measures (Step B-11/B-13)
 
 `TravelTimeDistribution` (`src/hcm/common/reliability.rs`) accumulates `(tti, weight)` observations — weight is `scenario.probability * VMT_served` when `vmt_weighted` (the default, matching the Exhibit 25-105 "VMT-Weighted TTI" presentation), or `scenario.probability` alone for a time-based distribution. It computes: `mean` (weighted mean TTI); `percentile(p)` (weighted empirical CDF — smallest observation whose cumulative weight reaches `p`% of total, so `percentile(95.0)` = TTI_95 = PTI); `max`; `std_dev` and `semi_std_dev` (one-sided about TTI = 1, per the Chapter 11 Section 2 definition, with TTI < 1 clamped to zero deviation even though TTI >= 1 by construction); `misery_index` (via `mean_of_worst(0.05)`, the weighted mean TTI of the worst 5% by weight); `reliability_rating` (`pct_at_or_below(1.33)`, the HCM-defined percentage of the distribution with TTI < 1.33 — implemented as `<=` rather than strict `<`); and `pct_above`/`failure_pct`/`on_time_pct` for arbitrary thresholds. `ReliabilityAnalysis::failure_pct_below_speed` converts a target space-mean speed into a TTI threshold via `ffs_equiv = facility_length_mi / (free_flow_travel_time_min / 60)`, then `tti_threshold = ffs_equiv / target_speed`.
 
+HCM Chapter 11, Section 2 ("Travel Time Distribution and Reliability Performance Measures," `75_Ch11_02.xhtml`) defines these measures only in prose, with no numbered equations; the literal formulas implemented by `TravelTimeDistribution` are:
+
+```
+TTI (per observation, no HCM number):  TTI = travel_time / free_flow_travel_time                                [decimal, >= 1.0 by definition]
+Implemented in: freeway_reliability/reliability.rs::ReliabilityAnalysis::run (`tti_p = (tt_min / free_flow_travel_time_min).max(1.0)`)
+
+TTI_mean (no HCM number):  TTI_mean = sum(w_k * TTI_k) / sum(w_k)                                                [decimal]
+  w_k = observation weight = scenario.probability * VMT_served (VMT-weighted, default) or scenario.probability alone (time-weighted) [-]
+Implemented in: common/reliability.rs::TravelTimeDistribution::mean
+
+TTI_p (percentile; no HCM number):  TTI_p = TTI_k*  where k* is the smallest sorted index with cumsum(w_1..w_k*) >= p/100 * sum(w_k)   [decimal]
+  TTI_95 = PTI (planning time index); TTI_80; TTI_50 (median)                                                    [decimal]
+Implemented in: common/reliability.rs::TravelTimeDistribution::percentile (weighted empirical CDF)
+
+Standard deviation (no HCM number):  std_dev = sqrt( sum(w_k * (TTI_k - TTI_mean)^2) / sum(w_k) )                [decimal]
+Implemented in: common/reliability.rs::TravelTimeDistribution::std_dev
+
+Semi-standard deviation (HCM Ch 11 Sec 2, prose-only, no equation number):  semi_std_dev = sqrt( sum(w_k * max(TTI_k - 1, 0)^2) / sum(w_k) )   [decimal]
+  One-sided about TTI = 1 (free-flow travel time) rather than about TTI_mean; TTI < 1 observations clamp to zero deviation (though TTI >= 1 by construction).
+Implemented in: common/reliability.rs::TravelTimeDistribution::semi_std_dev
+
+Misery index (HCM Ch 11 Sec 2 / Ch 36, prose-only, no equation number):  misery_index = mean_of_worst(0.05) = sum(w_k * TTI_k over the worst-5%-by-weight subset) / (0.05 * sum(w_k))   [decimal]
+  The "worst 5%" subset is taken by sorting descending on TTI and accumulating weight until 5% of total weight is reached, with the boundary observation's weight split fractionally.
+Implemented in: common/reliability.rs::TravelTimeDistribution::{misery_index, mean_of_worst}
+
+Reliability rating (HCM Ch 11 Sec 2, prose-only, no equation number):  reliability_rating = 100 * sum(w_k for TTI_k <= 1.33) / sum(w_k)   [%]
+  RELIABILITY_RATING_TTI_THRESHOLD = 1.33; implemented as TTI <= 1.33 (the HCM text says "TTI less than 1.33," i.e. strict <, so the boundary observation TTI = 1.33 exactly is counted here but would not be under a strict reading -- immaterial for continuous TTI values).
+Implemented in: common/reliability.rs::TravelTimeDistribution::{reliability_rating, pct_at_or_below}
+
+Failure / on-time percentage (no HCM number):  failure_pct(threshold) = 100 * sum(w_k for TTI_k > threshold) / sum(w_k);  on_time_pct = 100 - failure_pct
+  tti_threshold = ffs_equiv / target_speed_mi_h,  ffs_equiv = facility_length_mi / (free_flow_travel_time_min / 60)                      [decimal]
+Implemented in: common/reliability.rs::TravelTimeDistribution::{pct_above, failure_pct, on_time_pct}, freeway_reliability/reliability.rs::ReliabilityAnalysis::{failure_pct_below_speed, on_time_pct_at_speed}
+```
+
+See VERIFICATION.md item 5: the distribution *tails* (TTI_95/PTI, TTI_max, reliability rating, pct-TTI-above-2) computed by these formulas differ materially from the published Exhibit 25-104 values for the EP7 fixture (centers match closely); the deviation is attributed to the Chapter 10 oversaturated-engine queue-distribution gap plus differing Monte Carlo incident/scenario pairing versus FREEVAL, not to an error in the formulas above.
+
 ## Validation
 
-The fixture-driven integration test is `tests/chapter11_integration.rs`, reading `tests/ExampleCases/hcm/FreewayReliability/case1.json` (a `facility` + `scenario_generation` + `vmt_weighted` JSON matching `ReliabilityAnalysis`'s serde schema). It reproduces HCM Chapter 25 Example Problem 7 ("Reliability Evaluation of an Existing Freeway Facility," Exhibits 25-97 through 25-105). A PyO3-binding mirror exists at `tests/test_chapter11_integration.py` (102 lines). The Rust test module's doc comment lays out a three-tier verification strategy, since the published results come from FREEVAL's own (different) Monte Carlo stream:
+The fixture-driven integration test is `tests/chapter11_integration.rs`, reading `tests/ExampleCases/hcm/FreewayReliability/case1.json` (a `facility` + `scenario_generation` + `vmt_weighted` JSON matching `ReliabilityAnalysis`'s serde schema). It reproduces HCM Chapter 25 Example Problem 7 ("Reliability Evaluation of an Existing Freeway Facility," Exhibits 25-97 through 25-105); per VERIFICATION.md item 3, several weaving ramp-to-ramp demands for the fixture's access points are not published in the example problem text and are assumed at 50 veh/h. A PyO3-binding mirror exists at `tests/test_chapter11_integration.py` (102 lines). The Rust test module's doc comment lays out a three-tier verification strategy, since the published results come from FREEVAL's own (different) Monte Carlo stream:
 
 **(a) Scenario-generation intermediates, asserted exactly or near-exactly:**
 - `ep7_seed_vmt_matches_published`: seed-file VMT = 71,501 veh-mi (+-1.0), 12 analysis periods, 3.0-h study period.
@@ -55,11 +256,59 @@ The fixture-driven integration test is `tests/chapter11_integration.rs`, reading
 
 **(c) Distribution-level metrics vs Exhibit 25-104, with every deviation documented as computed-vs-published:** `ep7_reliability_metrics_vs_exhibit_25_104` runs both a probability-weighted (`vmt_weighted = false`) and the default VMT-weighted distribution. Central measures are asserted within tight published-relative bands: TTI_50 1.03 (+-0.01), TTI_mean 1.30 (+-0.04), misery index 5.76 (+-0.30), semi-std-dev 2.05 (+-0.12). Several measures are asserted at their computed value with the published number recorded only in the comment/assertion label, documented as VERIFY-HCM gaps: TTI_95/PTI computed 2.00 vs published 1.67 (+20%, attributed to both the Chapter 10 oversaturated-engine queue-distribution gap documented in the Chapter 10 doc and to different Monte Carlo pairing of incidents with high-demand scenarios); TTI_max computed 39.7 vs published 33.57 (+18%, the single worst scenario depends on Monte Carlo pairing); reliability rating computed 84.2% VMT-weighted (86.6% probability-weighted) vs published 90.8%; percentage of observations at TTI>2 computed ~5.1% vs published 2.95% of VMT. The test also checks distribution-shape invariants (TTI_95 >= TTI_80 >= TTI_50, TTI_max >= TTI_95, misery_index >= TTI_mean) and failure/on-time monotonicity at 35/45/50 mi/h targets. `ep7_scenario_results_consistency` checks per-scenario sanity (240 scenarios, TTI >= 1 in every cell, travel time >= 5.5 min, positive VMT, and that July scenarios include at least one oversaturated case while low-demand months do not).
 
-Unit tests in `src/hcm/chapter11/tests.rs` (22 tests) exercise the PRNG (reproducibility and rough uniformity), `counts_matching_distribution` and `poisson_pmf` against hand-worked examples, `expected_weather_frequency` against Equation 25-76 by hand, incident-duration binning, scenario probability/DAF computation with and without explicit `day_counts`, weather/incident generation (counts, severities, non-overlap, feasibility downgrading), work zone and special event assignment, generation reproducibility, the base-scenario-matches-Chapter-10 property, CAF/DAF folding, a small end-to-end `ReliabilityAnalysis::run`, and fixture JSON round-tripping. `src/hcm/chapter11/exhibits.rs`'s own test module spot-checks the Exhibit 11-20/11-21 weather tables (including FFS interpolation and out-of-range clamping), the Exhibit 11-18/11-19 demand ratio tables, Equation 25-85's severity distribution, Exhibit 11-23's incident CAF table (including the documented worked example: a 2-lane closure on 6 directional lanes keeps 0.75 x 4/6 = 50% of total capacity), the HERS crash-rate model (Equation 25-79), and the planning-level method (Equations 11-1 through 11-5) against Chapter 25 Example Problem 10 (FFS 75 mi/h, peak speed 62 mi/h, 3 lanes, X = 0.95: RDR 0.00280, IDR 0.00919, TTI_mean 1.899, TTI_95 3.353, PT_45 74.3%, each at tight tolerances). `src/hcm/common/reliability.rs`'s test module validates `TravelTimeDistribution` in isolation against synthetic (non-HCM) data: mean/percentile computation on a 20-point uniform series, weighted percentiles with unequal weights, misery index, standard and semi-standard deviation, and rejection of non-positive-weight or NaN observations.
+Unit tests in `src/hcm/freeway_reliability/tests.rs` (22 tests) exercise the PRNG (reproducibility and rough uniformity), `counts_matching_distribution` and `poisson_pmf` against hand-worked examples, `expected_weather_frequency` against Equation 25-76 by hand, incident-duration binning, scenario probability/DAF computation with and without explicit `day_counts`, weather/incident generation (counts, severities, non-overlap, feasibility downgrading), work zone and special event assignment, generation reproducibility, the base-scenario-matches-Chapter-10 property, CAF/DAF folding, a small end-to-end `ReliabilityAnalysis::run`, and fixture JSON round-tripping. `src/hcm/freeway_reliability/exhibits.rs`'s own test module spot-checks the Exhibit 11-20/11-21 weather tables (including FFS interpolation and out-of-range clamping), the Exhibit 11-18/11-19 demand ratio tables, Equation 25-85's severity distribution, Exhibit 11-23's incident CAF table (including the documented worked example: a 2-lane closure on 6 directional lanes keeps 0.75 x 4/6 = 50% of total capacity), the HERS crash-rate model (Equation 25-79), and the planning-level method (Equations 11-1 through 11-5) against Chapter 25 Example Problem 10 (FFS 75 mi/h, peak speed 62 mi/h, 3 lanes, X = 0.95: RDR 0.00280, IDR 0.00919, TTI_mean 1.899, TTI_95 3.353, PT_45 74.3%, each at tight tolerances). `src/hcm/common/reliability.rs`'s test module validates `TravelTimeDistribution` in isolation against synthetic (non-HCM) data: mean/percentile computation on a 20-point uniform series, weighted percentiles with unequal weights, misery index, standard and semi-standard deviation, and rejection of non-positive-weight or NaN observations.
+
+### Planning-level method (Equations 11-1 through 11-5)
+
+`exhibits.rs` also implements the Chapter 11, Section 5 "Simplified Method" (`78_Ch11_05.xhtml`): a standalone, non-scenario-based estimate of three TTI percentiles from facility-level peak-hour inputs, intended for planning contexts where the full scenario-generation methodology's data needs are impractical. It is not wired into `ReliabilityAnalysis` (no scenario loop, no TTI distribution); each function is a direct, independent equation evaluation.
+
+```
+Equation 11-2:  RDR = 1/S - 1/FFS                                                        [h/mi]
+  RDR = recurring delay rate                                                             [h/mi]
+  S   = peak-hour speed                                                                  [mi/h]
+  FFS = free-flow speed                                                                  [mi/h]
+Implemented in: freeway_reliability/exhibits.rs::planning_recurring_delay_rate
+
+Equation 11-3:  IDR = [0.020 - (N - 2) x 0.003] x X^12                                    [h/mi]
+  IDR = incident delay rate                                                              [h/mi]
+  N   = number of lanes in one direction (N = 2 to 4; values above 4 capped at 4)         [ln]
+  X   = peak-hour volume-to-capacity ratio (X <= 1.00; values above 1.00 capped at 1.00)  [decimal]
+  Valid only for X <= 1.00 and N = 2, 3, or 4 per the printed text; both inputs are clamped before use.
+Implemented in: freeway_reliability/exhibits.rs::planning_incident_delay_rate (`n.clamp(2, 4)`, `vc_ratio.min(1.0)`)
+
+Equation 11-1:  TTI_mean = 1 + FFS x (RDR + IDR)                                          [decimal]
+  TTI_mean = average annual mean travel time index                                       [decimal]
+  FFS      = free-flow speed                                                             [mi/h]
+  RDR      = recurring delay rate (Equation 11-2)                                        [h/mi]
+  IDR      = incident delay rate (Equation 11-3)                                         [h/mi]
+Implemented in: freeway_reliability/exhibits.rs::planning_tti_mean
+
+Equation 11-4:  TTI_95 = 1 + 3.67 x ln(TTI_mean)                                          [decimal]
+  TTI_95   = 95th percentile travel time index                                           [decimal]
+  TTI_mean = average annual mean travel time index (Equation 11-1)                       [decimal]
+Implemented in: freeway_reliability/exhibits.rs::planning_tti_95
+
+Equation 11-5:  PT_45 = 1 - exp[-1.5115 x (TTI_mean - 1)]                                 [decimal]
+  PT_45    = percent of trips occurring at speeds less than 45 mi/h                       [decimal]
+  TTI_mean = average annual mean travel time index (Equation 11-1)                       [decimal]
+Implemented in: freeway_reliability/exhibits.rs::planning_pt45
+```
+
+Validated against Chapter 25 Example Problem 10 (`202_Ch25_11a.xhtml`; unit test `test_example_problem_10_planning_method` in `exhibits.rs`): FFS 75 mi/h, peak speed 62 mi/h, 3 lanes, X = 0.95 gives RDR 0.00280, IDR 0.00919, TTI_mean 1.899, TTI_95 3.353, PT_45 74.3%, each reproduced within 0.001-0.005 absolute tolerance.
+
+### Exhibit tables (default values)
+
+The following default-value exhibits are transcribed as literal Rust constants/tables (structure only is described here per the copyright note in the task; values already in code are cited by name):
+
+- **Exhibits 11-18/11-19** (default urban/rural demand ratios, ADT/Mondays-in-January, 12 months x 7 weekdays): `freeway_reliability/exhibits.rs::URBAN_DEMAND_RATIOS`, `::RURAL_DEMAND_RATIOS`. `ScenarioGenerationConfig::demand_multipliers` defaults to `URBAN_DEMAND_RATIOS`; `RURAL_DEMAND_RATIOS` is available for the analyst to substitute.
+- **Exhibits 11-20/11-21** (default CAFs/SAFs by weather type and facility FFS, 10 severe weather types x 5 FFS columns 55-75 mi/h): `freeway_reliability/exhibits.rs::WEATHER_CAF`, `::WEATHER_SAF`, looked up via `weather_caf`/`weather_saf` with linear interpolation between the tabulated FFS columns (see VERIFICATION.md item 6).
+- **Exhibit 11-22** (default incident severity distribution and duration parameters by severity type): the severity-distribution row is `DEFAULT_INCIDENT_SEVERITY_DISTRIBUTION` (identical to Equation 25-85); the duration parameters are `DEFAULT_INCIDENT_DURATION_PARAMS` (mean/std-dev/min/max per severity) -- see VERIFICATION.md item 1 for the 3-lane/4+-lane mean-duration cross-check against Exhibit 25-41.
+- **Exhibit 11-23** (CAFs by incident type and number of directional lanes, 2-8 lanes x 5 severity columns): `freeway_reliability/exhibits.rs::INCIDENT_CAF_PER_OPEN_LANE`, looked up via `incident_caf_per_open_lane`/`incident_caf_total` (transcribed above under "Scenario evaluation and CAF/SAF/DAF folding").
+- **`DEFAULT_INCIDENT_SEVERITY_DISTRIBUTION`** and **`DEFAULT_INCIDENT_DURATION_PARAMS`** are also the Chapter 25 Equation 25-85 / Exhibit 25-41 defaults consumed by `generate_scenarios` when `IncidentInputs` does not override them.
 
 ## Deferred
 
-Per the `chapter11/mod.rs` module doc comment, explicitly out of scope in this pass:
+Per the `freeway_reliability/mod.rs` module doc comment, explicitly out of scope in this pass:
 - Managed lane reliability.
 - The Chapter 11 Section 4 ATDM strategy assessment (Steps C-1 through C-9) — implemented separately on `feat/hcm-reliability-enhancements` (`src/hcm/common/atdm.rs`).
 - The Chapter 25 reliability calibration methodology.

--- a/docs/hcm/procedures/chapter12.md
+++ b/docs/hcm/procedures/chapter12.md
@@ -1,6 +1,6 @@
 # Chapter 12: Basic Freeway and Multilane Highway Segments — Procedure Walkthrough
 
-HCM 7th Edition Chapter 12 covers basic freeway and multilane highway segments (Sections 2-3, operational core in Exhibit 12-19's six steps) plus the basic managed lane segment methodology (Section 4, Equations 12-12 through 12-19). Both are implemented under `src/hcm/chapter12/` on the `feat/hcm-ch12-14-completion` branch: `basicfreeways.rs` (the `BasicFreeways` struct handling both basic freeway and multilane highway variants via the `highway_type` string field, `"basic"` vs `"multilane"`) and `managed_lanes.rs` (the `ManagedLaneSegment` struct with per-type parameters from Exhibit 12-30). This branch's commit `ea74afa` corrected three managed-lane equations and one Exhibit 12-37 table entry against the manual (detailed below). Python bindings for both structs are registered in `src/copython/chapter12.rs` (`BasicFreeways`, `ManagedLanes` pyclasses).
+HCM 7th Edition Chapter 12 covers basic freeway and multilane highway segments (Sections 2-3, operational core in Exhibit 12-19's six steps) plus the basic managed lane segment methodology (Section 4, Equations 12-12 through 12-19). Both are implemented under `src/hcm/basicfreeways/` (renamed from `src/hcm/chapter12/`; the old name is retained as a `pub use basicfreeways as chapter12` re-export in `src/hcm/mod.rs` for compatibility): `basicfreeways.rs` (the `BasicFreeways` struct handling both basic freeway and multilane highway variants via the `highway_type` string field, `"basic"` vs `"multilane"`) and `managed_lanes.rs` (the `ManagedLaneSegment` struct with per-type parameters from Exhibit 12-30). This branch's commit `ea74afa` corrected three managed-lane equations and one Exhibit 12-37 table entry against the manual (detailed below; all three equation fixes were cross-checked against the HCM7 EPUB MathML for this pass and reproduce the printed forms exactly). Python bindings for both structs are registered in `src/copython/basicfreeways.rs` (`BasicFreeways`, `ManagedLanes` pyclasses).
 
 ## Operational analysis walkthrough (Exhibit 12-19 steps)
 
@@ -19,13 +19,173 @@ The full sequence is orchestrated by `BasicFreeways::run_operational_analysis()`
 | Step 5: density | Eq 12-11 (`D = v_p/S`) | `estimate_density` | `basicfreeways.rs` | `v_p` (pc/h/ln), S (mi/h) | pc/mi/ln (sentinel 46.0 when oversaturated) |
 | Step 6: LOS | Exhibit 12-15 | `determine_segment_los` (v/c check then delegates to `common::FacilityCalculation::los_from_density`) | `basicfreeways.rs` | density, v/c | `LevelOfService` A-F |
 
+### Equations (Steps 2-6)
+
+All equation forms below were cross-checked against the HCM 7th Edition EPUB MathML (`resources/epub/OEBPS/82_Ch12_02.xhtml` for Eq 12-1, `83_Ch12_03.xhtml` for Eq 12-2 through 12-11) and reproduce the printed forms exactly; no discrepancies were found for this chapter's core methodology.
+
+```
+Equation 12-2 (Step 2, basic freeway FFS):  FFS = BFFS − f_LW − f_RLC − 3.22 × TRD^0.84
+  FFS = free-flow speed of the basic freeway segment, mi/h
+  BFFS = base free-flow speed, mi/h (struct field `bffs`, default 65.0 in BasicFreeways::new(); the HCM default base FFS of 75.4 mi/h is declared as DEFAULT_BFFS_FREEWAY but is not read by the constructor, see Deviation 6)
+  f_LW = adjustment for lane width, mi/h (Exhibit 12-20: >=12 ft -> 0.0, >=11-12 ft -> 1.9, >=10-11 ft -> 6.6)
+  f_RLC = adjustment for right-side lateral clearance, mi/h (Exhibit 12-21, keyed on lane count and clearance in ft, 0-6 ft; interpolated variant available for non-integer clearance)
+  TRD = total ramp density, ramps/mi (struct field `trd`; ramps within 3 mi upstream/downstream of the segment midpoint, divided by 6 mi)
+Implemented in: basicfreeways/basicfreeways.rs::estimate_basic_lane_ffs (via determine_free_flow_speed); adjustments in adjustment_average_lane_width, adjustment_right_side_lateral_clearance[_interpolated]
+```
+
+```
+Equation 12-3 (Step 2, multilane highway FFS):  FFS = BFFS − f_LW − f_TLC − f_M − f_A
+  FFS = free-flow speed of the multilane highway segment, mi/h
+  BFFS = base free-flow speed, mi/h (struct field `bffs`)
+  f_LW = adjustment for lane width, mi/h (Exhibit 12-20, shared with Eq 12-2)
+  f_TLC = adjustment for total lateral clearance, mi/h (Exhibit 12-22, four-lane vs six-lane tables, linearly interpolated between tabulated TLC values)
+  f_M = adjustment for median type, mi/h (Exhibit 12-23: undivided 1.6, TWLTL 0.0, divided 0.0)
+  f_A = adjustment for access point density, mi/h (Exhibit 12-24: min(0.25 × APD, 10.0), interpolation to the nearest 0.1 recommended by the exhibit note; a table-lookup variant matching the exhibit's tabulated points (0/10/20/30/>=40 -> 0.0/2.5/5.0/7.5/10.0) also exists but is `#[allow(dead_code)]`)
+Implemented in: basicfreeways/basicfreeways.rs::estimate_multi_lane_ffs (via determine_free_flow_speed); adjustments in adjustment_average_lane_width, adjustment_total_lateral_clearance, adjustment_median_type, adjustment_access_point_density[_table]
+```
+
+```
+Equation 12-4 (TLC, feeds Eq 12-3):  TLC = LC_R + LC_L
+  TLC = total lateral clearance, ft (maximum value 12 ft)
+  LC_R = right-side lateral clearance, ft (maximum value 6 ft; struct field `lc_r`, default 6)
+  LC_L = left-side lateral clearance, ft (maximum value 6 ft; struct field `lc_l`, default 6)
+Implemented in: basicfreeways/basicfreeways.rs::calculate_total_lateral_clearance
+```
+
+```
+Equation 12-5 (Step 2, SAF adjustment, basic freeway only):  FFS_adj = FFS × SAF
+  FFS_adj = adjusted free-flow speed, mi/h
+  FFS = free-flow speed from Eq 12-2/12-3 (or field-measured), mi/h
+  SAF = speed adjustment factor, decimal (struct field `saf`, default 1.0 = base conditions; weather/work-zone/driver-population SAF defaults live in Chapter 11, src/hcm/common/adjustment_factors.rs — see Deferred)
+Note: the book states "no adjustment of the speed-flow equation using these SAFs is possible for multilane highway segments" (no empirical research); the struct computes FFS_adj = FFS × SAF for both highway_type values, so a caller analyzing a multilane segment should leave `saf` at 1.0 to stay within the documented method.
+Implemented in: basicfreeways/basicfreeways.rs::determine_free_flow_speed
+```
+
+```
+Equation 12-1 (Step 5, speed-flow curve):  S = FFS_adj                                                          if v_p <= BP
+                                            S = FFS_adj − [(FFS_adj − c_adj/D_c) / (c_adj − BP)^a] × (v_p − BP)^a   if BP < v_p <= c_adj
+  S = space mean speed of the traffic stream, mi/h
+  FFS_adj = adjusted free-flow speed, mi/h (Eq 12-5)
+  v_p = demand flow rate under equivalent base conditions, pc/h/ln (Eq 12-9)
+  BP = breakpoint in the speed-flow curve, pc/h/ln — basic freeway: BP = [1,000 + 40 × (75 − FFS_adj)] × CAF², multilane: BP = 1,400 (constant), both from Exhibit 12-6
+  c_adj = adjusted segment capacity, pc/h/ln (Eq 12-8)
+  D_c = density at capacity = DENSITY_AT_CAPACITY = 45.0 pc/mi/ln (Exhibit 12-6)
+  a = exponent calibration parameter (Exhibit 12-6): EXPONENT_BASIC_FREEWAY = 2.00 (basic freeway), EXPONENT_MULTILANE = 1.31 (multilane)
+  Returns 0.0 (breakdown sentinel) when v_p > c_adj — see Deviation 5
+Implemented in: basicfreeways/basicfreeways.rs::calculate_speed; breakpoint in calculate_breakpoint
+```
+
+```
+Equation 12-6 (Step 3, basic freeway base capacity):     c = 2,200 + 10 × (FFS_adj − 50)   [capped at 2,400 pc/h/ln, valid 55 <= FFS <= 75]
+Equation 12-7 (Step 3, multilane highway base capacity): c = 1,900 + 20 × (FFS_adj − 45)   [capped at 2,300 pc/h/ln, valid 45 <= FFS <= 70]
+  c = base segment capacity, pc/h/ln
+  FFS_adj = adjusted free-flow speed, mi/h (Eq 12-5)
+Implemented in: basicfreeways/basicfreeways.rs::estimate_capacity
+```
+
+```
+Equation 12-8 (Step 3, adjusted capacity, basic freeway only):  c_adj = c × CAF
+  c_adj = adjusted capacity of the segment, pc/h/ln
+  c = base capacity, pc/h/ln (Eq 12-6/12-7)
+  CAF = capacity adjustment factor, decimal (struct field `caf`, default 1.0 = base conditions; per the book, no CAF adjustment is defined for multilane highways either)
+Implemented in: basicfreeways/basicfreeways.rs::estimate_adjusted_capacity
+```
+
+```
+Equation 12-9 (Step 4, demand flow rate):  v_p = V / (PHF × N × f_HV)
+  v_p = demand flow rate under equivalent base conditions, pc/h/ln
+  V = demand volume under prevailing conditions, veh/h (struct field `demand_flow_i`)
+  PHF = peak hour factor, decimal (struct field `phf`)
+  N = number of lanes in the analysis direction, ln (struct field `lane_count`, default 2)
+  f_HV = heavy vehicle adjustment factor, decimal (Eq 12-10; struct field `phv`)
+Implemented in: basicfreeways/basicfreeways.rs::estimate_demand_volume
+```
+
+```
+Equation 12-10 (Step 4, heavy vehicle adjustment):  f_HV = 1 / (1 + P_T × (E_T − 1))
+  f_HV = heavy vehicle adjustment factor, decimal
+  P_T = proportion of SUTs and TTs in the traffic stream, decimal (struct field `p_t`)
+  E_T = passenger car equivalent of one heavy vehicle, PCEs — Exhibit 12-25 general terrain (level 2.0, rolling 3.0; mountainous 2.5 is a non-HCM approximation, see Deviation 1), or Exhibit 12-26/12-27/12-28 specific-upgrade tables for a 30/50/70% SUT mix, keyed on (grade %, length mi, truck %); for P_T < 25% the lookup is ET_TABLE_30SUT/50SUT/70SUT (src/hcm/common/pce_table.rs, keyed on (P_T×100, length×1000, grade×100) as integers), for P_T >= 25% a hand-transcribed grade/length match is used (panics via `todo!` on an unhandled combination, see Deviation 2)
+Implemented in: basicfreeways/basicfreeways.rs::adjustment_heavy_vehicle_factor
+```
+
+```
+Equation 12-11 (Step 5, density):  D = v_p / S
+  D = density, pc/mi/ln (sentinel DENSITY_AT_CAPACITY + 1.0 = 46.0 when v_p/c_adj > 1.0 or S <= 0.0 — the book states density is undefined once v_p/c exceeds 1.00 and directs analysts to Chapter 10; see Deviation 5)
+  v_p = demand flow rate, pc/h/ln (Eq 12-9)
+  S = mean speed of the traffic stream, mi/h (Eq 12-1)
+Implemented in: basicfreeways/basicfreeways.rs::estimate_density
+```
+
 ### Planning and design analysis
 
-Planning-level entry points: `estimate_ddhv` (Eq 12-20, `DDHV = AADT × K × D`), `estimate_number_of_lanes` (Eqs 12-21/12-22/12-23, `N = ceil(v/MSF_i)`), `estimate_lanes_from_aadt` (chains 12-20 into 12-23), `determine_basic_max_service_flow_rate` / `determine_multilane_max_service_flow_rate` (Exhibit 12-37/12-38 MSF tables keyed on FFS rounded up to the nearest 5 mi/h and target LOS), `calculate_service_flow_rate` (Eq 12-24), `calculate_service_volume` (Eq 12-25), and `calculate_daily_service_volume` (Eq 12-26). Commit `ea74afa` corrected the Exhibit 12-37 FFS-60/LOS-A entry to 660 pc/h/ln (was 600); the FFS-60 row now reads A=660, B=1080, C=1560, D=2000, E=2300.
+Planning-level entry points: `estimate_ddhv` (Eq 12-20, `DDHV = AADT × K × D`), `estimate_number_of_lanes` (Eqs 12-21/12-22/12-23, `N = ceil(v/MSF_i)`), `estimate_lanes_from_aadt` (chains 12-20 into 12-23), `determine_basic_max_service_flow_rate` / `determine_multilane_max_service_flow_rate` (Exhibit 12-37/12-38 MSF tables keyed on FFS rounded up to the nearest 5 mi/h and target LOS), `calculate_service_flow_rate` (Eq 12-24), `calculate_service_volume` (Eq 12-25), and `calculate_daily_service_volume` (Eq 12-26). Commit `ea74afa` corrected the Exhibit 12-37 FFS-60/LOS-A entry to 660 pc/h/ln (was 600); the FFS-60 row now reads A=660, B=1080, C=1560, D=2000, E=2300. This corrected row was verified against the EPUB (`85_Ch12_05.xhtml`) for this pass and matches the printed Exhibit 12-37 exactly.
+
+#### Equations (planning and design, Eqs 12-20 through 12-26)
+
+Cross-checked against `resources/epub/OEBPS/85_Ch12_05.xhtml`; all forms below match the printed equations exactly.
+
+```
+Equation 12-20 (planning, DDHV):  V = DDHV = AADT × K × D
+  V = DDHV = directional design hour volume, veh/h
+  AADT = annual average daily traffic, veh/day (struct field `aadt`, Option<f64>)
+  K = proportion of AADT occurring during the peak hour, decimal (struct field `k_factor`, default 0.09; Exhibit 12-18 typical ranges 0.08-0.10 urban, 0.09-0.13 rural)
+  D = proportion of peak-hour volume traveling in the peak direction, decimal (struct field `d_factor`, default 0.55; typical value 0.55 for both urban and rural freeways)
+Implemented in: basicfreeways/basicfreeways.rs::estimate_ddhv
+```
+
+```
+Equation 12-21 (design, demand flow rate not per lane):  v = V / (PHF × f_HV)
+  v = demand flow rate, pc/h (not per lane — used when the number of lanes is itself unknown)
+  V = demand volume under prevailing conditions, veh/h
+  PHF = peak hour factor, decimal
+  f_HV = heavy vehicle adjustment factor, decimal (Eq 12-10)
+Implemented in: basicfreeways/basicfreeways.rs::estimate_number_of_lanes (inlined as the local `demand_flow_rate`, rather than a separate method)
+```
+
+```
+Equation 12-22 (design, required lanes):  N = v / MSF_i
+  N = number of lanes required, ln (always rounded up to the next-higher integer)
+  v = demand flow rate, pc/h (Eq 12-21)
+  MSF_i = maximum service flow rate for target LOS i, pc/h/ln (Exhibit 12-37 basic freeway / Exhibit 12-38 multilane, keyed on FFS rounded to the nearest 5 mi/h and target LOS, no interpolation permitted per the exhibit note; (FFS, LOS) pairs outside the transcribed rows — including LOS F — silently default to 2000.0, see Deviation 4)
+Implemented in: basicfreeways/basicfreeways.rs::estimate_number_of_lanes; MSF lookups in determine_basic_max_service_flow_rate / determine_multilane_max_service_flow_rate
+```
+
+```
+Equation 12-23 (design, Eq 12-21 + Eq 12-22 combined):  N = V / (MSF_i × PHF × f_HV)
+  All variables as defined in Eq 12-21 and Eq 12-22
+Implemented in: basicfreeways/basicfreeways.rs::estimate_number_of_lanes (the combined computation is inlined rather than exposed as a separate method)
+```
+
+```
+Equation 12-24 (service flow rate):  SF_i = MSF_i × N × f_HV
+  SF_i = service flow rate for LOS i, veh/h (maximum rate that can exist while LOS i is maintained during the 15-min analysis period)
+  MSF_i = maximum service flow rate, pc/h/ln (Exhibit 12-37/12-38)
+  N = number of lanes, ln (struct field `lane_count`)
+  f_HV = heavy vehicle adjustment factor, decimal (struct field `phv`)
+Implemented in: basicfreeways/basicfreeways.rs::calculate_service_flow_rate
+```
+
+```
+Equation 12-25 (service volume):  SV_i = SF_i × PHF
+  SV_i = service volume for LOS i, veh/h (maximum hourly volume during the worst 15-min period of the analysis hour)
+  SF_i = service flow rate, veh/h (Eq 12-24)
+  PHF = peak hour factor, decimal
+Implemented in: basicfreeways/basicfreeways.rs::calculate_service_volume
+```
+
+```
+Equation 12-26 (daily service volume):  DSV_i = SV_i / (K × D) = (MSF_i × N × f_HV × PHF) / (K × D)
+  DSV_i = daily service volume for LOS i, veh/day (stated as a total in both directions, unlike SF/SV which are single-direction)
+  SV_i = service volume, veh/h (Eq 12-25)
+  K = K-factor, decimal (struct field `k_factor`)
+  D = D-factor, decimal (struct field `d_factor`)
+Implemented in: basicfreeways/basicfreeways.rs::calculate_daily_service_volume
+```
 
 ## Managed lane segment model (Section 4, Eqs 12-12 to 12-19)
 
-`ManagedLaneSegment` in `src/hcm/chapter12/managed_lanes.rs` implements the five managed-lane types of Exhibit 12-9 (`ContinuousAccess`, `Buffer1`, `Buffer2`, `Barrier1`, `Barrier2`) with per-type calibration parameters from Exhibit 12-30 (`ManagedLaneParams::for_type`: BP_75, λ_BP, c_75, λ_c, A2_55, λ_A2, A1, K_cnf, and optional K_cf, where `k_cf` is `Some` only for ContinuousAccess and Buffer1, the two types with a general-purpose-lane friction effect).
+`ManagedLaneSegment` in `src/hcm/basicfreeways/managed_lanes.rs` (renamed from `src/hcm/chapter12/managed_lanes.rs`; also re-exported at `src/hcm/managed_lanes` via `pub use basicfreeways::managed_lanes` in `src/hcm/mod.rs`) implements the five managed-lane types of Exhibit 12-9 (`ContinuousAccess`, `Buffer1`, `Buffer2`, `Barrier1`, `Barrier2`) with per-type calibration parameters from Exhibit 12-30 (`ManagedLaneParams::for_type`: BP_75, λ_BP, c_75, λ_c, A2_55, λ_A2, A1, K_cnf, and optional K_cf, where `k_cf` is `Some` only for ContinuousAccess and Buffer1, the two types with a general-purpose-lane friction effect).
 
 | HCM Eq. | Quantity | Rust method | Notes |
 |---|---|---|---|
@@ -39,6 +199,92 @@ Planning-level entry points: `estimate_ddhv` (Eq 12-20, `DDHV = AADT × K × D`)
 | 12-19 | `S3 = (c_adj/K_cnf − c_adj/K_cf)·((v_p−BP)/(c_adj−BP))²` | `calculate_s3` | **fix (ea74afa)**: leading term is the difference of speeds at capacity without/with friction and the exponent is fixed at 2; old code used `(S1,BP − c_adj/K_cf)·ratio^A2 − S2` |
 
 Density is `calculate_density` (D = v_p/S, sentinel 50.0 when oversaturated), LOS reuses the Exhibit 12-15 thresholds inline in `determine_los` (LOS F when v_p > c_adj), and `run_analysis` chains FFS-adjust → breakpoint → capacity → speed → density → LOS. Exhibit 12-11 estimated lane capacities are separately available via the free function `get_estimated_capacity(lane_type, ffs)` for FFS ∈ {55, 60, 65, 70, 75} mi/h.
+
+#### Equations (Eqs 12-12 through 12-19)
+
+Cross-checked against `resources/epub/OEBPS/84_Ch12_04.xhtml`; all forms below (including the three ea74afa-fixed equations) match the printed forms exactly — no new discrepancies found for this pass. Exhibit 12-30 parameter values below are transcribed from the same source and match `ManagedLaneParams::for_type`.
+
+```
+Equation 12-12 (managed lane speed-flow curve):  S_ML = S1                        if v_p <= BP
+                                                  S_ML = S1 − S2 − Ic × S3         if BP < v_p <= c_adj
+  S_ML = space mean speed of the basic managed lane segment, mi/h
+  S1 = speed within the linear portion, mi/h (Eq 12-15)
+  S2 = speed drop within the curvilinear portion, mi/h (Eq 12-17)
+  S3 = additional speed drop from adjacent GP-lane friction, mi/h (Eq 12-19)
+  Ic = friction indicator, 0 or 1 (Eq 12-18)
+  BP = breakpoint, pc/h/ln (Eq 12-13)
+  v_p = 15-min average flow rate, pc/h/ln (struct field `v_p`)
+  c_adj = adjusted capacity, pc/h/ln (Eq 12-14); returns 0.0 (breakdown sentinel) when v_p > c_adj
+Implemented in: basicfreeways/managed_lanes.rs::calculate_speed
+```
+
+```
+Equation 12-13 (breakpoint):  BP = [BP_75 + λ_BP × (75 − FFS_adj)] × CAF²
+  BP = breakpoint separating the linear and curvilinear sections, pc/h/ln
+  BP_75 = breakpoint at FFS = 75 mi/h, pc/h/ln (Exhibit 12-30: ContinuousAccess 500, Buffer1 600, Buffer2 500, Barrier1 800, Barrier2 700)
+  λ_BP = rate of increase in BP per unit decrease in FFS, pc/h/ln (Exhibit 12-30: 0 for ContinuousAccess/Buffer1/Barrier1, 10 for Buffer2, 20 for Barrier2)
+  FFS_adj = adjusted free-flow speed, mi/h
+  CAF = capacity adjustment factor, decimal (struct field `caf`, default 1.0)
+Implemented in: basicfreeways/managed_lanes.rs::calculate_breakpoint (the squared CAF term matches the book exactly; see the ea74afa fix noted in the table above)
+```
+
+```
+Equation 12-14 (managed lane capacity):  c_adj = CAF × [c_75 − λ_c × (75 − FFS_adj)]
+  c_adj = adjusted basic managed lane segment capacity, pc/h/ln
+  CAF = capacity adjustment factor, decimal
+  c_75 = managed lane capacity at FFS = 75 mi/h, pc/h/ln (Exhibit 12-30: ContinuousAccess 1,800, Buffer1 1,700, Buffer2 1,850, Barrier1 1,750, Barrier2 2,100)
+  λ_c = rate of change in capacity per unit change in FFS, pc/h/ln (Exhibit 12-30: 10 for all five types)
+  FFS_adj = adjusted free-flow speed, mi/h
+Implemented in: basicfreeways/managed_lanes.rs::calculate_capacity
+```
+
+```
+Equation 12-15 (linear portion speed):  S1 = FFS_adj − A1 × min(v_p, BP)
+  S1 = speed within the linear portion of the speed-flow curve, mi/h
+  FFS_adj = adjusted free-flow speed, mi/h
+  A1 = speed reduction per unit flow in the linear section, mi/h per pc/h/ln (Exhibit 12-30: 0 for ContinuousAccess/Buffer2/Barrier2, 0.0033 for Buffer1, 0.004 for Barrier1)
+  v_p = 15-min average flow rate, pc/h/ln
+  BP = breakpoint, pc/h/ln (Eq 12-13)
+Implemented in: basicfreeways/managed_lanes.rs::calculate_s1 (the min(v_p, BP) clamp is printed in the book's own Eq 12-15 — this is the ea74afa fix noted in the table above, not a new discrepancy)
+```
+
+```
+Equation 12-16 (curvilinear calibration factor):  A2 = A2_55 + λ_A2 × (FFS_adj − 55)
+  A2 = speed reduction per unit flow in the curvilinear section, mi/h
+  A2_55 = calibration factor at FFS = 55 mi/h, mi/h (Exhibit 12-30: ContinuousAccess 2.5, Buffer1 1.4, Buffer2 1.5, Barrier1 1.4, Barrier2 1.3)
+  λ_A2 = rate of change in A2 per unit increase in FFS (Exhibit 12-30: 0 for ContinuousAccess/Buffer1/Barrier1, 0.02 for Buffer2/Barrier2)
+  FFS_adj = adjusted free-flow speed, mi/h
+Implemented in: basicfreeways/managed_lanes.rs::calculate_a2
+```
+
+```
+Equation 12-17 (curvilinear speed drop, K_GP <= 35):  S2 = [(S1,BP − c_adj/K_cnf) / (c_adj − BP)^A2] × (v_p − BP)^A2
+  S2 = speed drop within the curvilinear portion, mi/h (0 when v_p <= BP)
+  S1,BP = S1 evaluated at v_p = BP, mi/h (Eq 12-15)
+  c_adj = adjusted capacity, pc/h/ln (Eq 12-14)
+  K_cnf = density at capacity without GP-lane friction, pc/mi/ln (Exhibit 12-30: ContinuousAccess 30, Buffer1 30, Buffer2 45 [average value, footnote a], Barrier1 35, Barrier2 45)
+  A2 = curvilinear calibration factor (Eq 12-16)
+  BP, v_p as above
+Implemented in: basicfreeways/managed_lanes.rs::calculate_s2 (S1,BP via calculate_s1_bp)
+```
+
+```
+Equation 12-18 (friction indicator):  Ic = 0   if K_GP <= 35 pc/mi/ln, or segment type is Buffer2/Barrier1/Barrier2
+                                       Ic = 1   otherwise (ContinuousAccess or Buffer1 with K_GP > 35 pc/mi/ln)
+  Ic = friction indicator, 0 or 1
+  K_GP = density of the adjacent general purpose lane, pc/mi/ln (struct field `k_gp`)
+Implemented in: basicfreeways/managed_lanes.rs::calculate_friction_indicator
+```
+
+```
+Equation 12-19 (additional speed drop from GP friction):  S3 = [(c_adj/K_cnf) − (c_adj/K_cf)] × [(v_p − BP)/(c_adj − BP)]²
+  S3 = additional speed drop within the curvilinear portion, mi/h (0 when v_p <= BP or Ic = 0)
+  c_adj = adjusted capacity, pc/h/ln
+  K_cnf = density at capacity without friction, pc/mi/ln (Exhibit 12-30, see Eq 12-17)
+  K_cf = density at capacity with friction, pc/mi/ln (Exhibit 12-30: ContinuousAccess 45, Buffer1 42 [average value, footnote a]; NA/None for Buffer2, Barrier1, Barrier2 — the only two types with has_friction_effect() == true)
+  v_p, BP as above
+Implemented in: basicfreeways/managed_lanes.rs::calculate_s3 (fixed exponent of 2 and the leading term as the difference of speeds-at-capacity without/with friction match the book's printed form exactly — the ea74afa fix noted in the table above, not a new discrepancy)
+```
 
 ## Validation
 

--- a/docs/hcm/procedures/chapter13.md
+++ b/docs/hcm/procedures/chapter13.md
@@ -1,6 +1,6 @@
 # Chapter 13: Freeway Weaving Segments — Procedure Walkthrough
 
-HCM 7th Edition Chapter 13 analyzes freeway weaving segments (and weaving segments on multilane highways and collector-distributor roads) through the core methodology of Steps 2-8: demand adjustment, configuration characteristics, maximum weaving length, capacity, lane-changing rates, speeds, and density/LOS. The implementation is `src/hcm/chapter13/weaving.rs` on the `feat/hcm-ch12-14-completion` branch, a single `WeavingSegment` struct in the chapter15 house style (plain input fields, `Option<T>` computed fields populated by step methods in HCM order, `get_`/`set_` accessors, and a `run_analysis()` that chains Steps 2-8). This branch's commit `e921e1e` rewrote the module with HCM-verified equations; the headline correction is the Equation 13-22 space-mean (harmonic) speed, which replaced an arithmetic weighted mean. A PyO3 wrapper (`copython::chapter13::WeavingSegment`) is registered on this branch.
+HCM 7th Edition Chapter 13 analyzes freeway weaving segments (and weaving segments on multilane highways and collector-distributor roads) through the core methodology of Steps 2-8: demand adjustment, configuration characteristics, maximum weaving length, capacity, lane-changing rates, speeds, and density/LOS. The implementation is `src/hcm/weaving/weaving.rs` on the `feat/hcm-ch12-14-completion` branch, a single `WeavingSegment` struct in the chapter15 house style (plain input fields, `Option<T>` computed fields populated by step methods in HCM order, `get_`/`set_` accessors, and a `run_analysis()` that chains Steps 2-8). This branch's commit `e921e1e` rewrote the module with HCM-verified equations; the headline correction is the Equation 13-22 space-mean (harmonic) speed, which replaced an arithmetic weighted mean. A PyO3 wrapper (`copython::weaving::WeavingSegment`, in `src/copython/weaving.rs` — renamed from `src/copython/chapter13.rs` with the topic-folder rename) is registered on this branch.
 
 ## Step-by-step walkthrough
 
@@ -16,7 +16,222 @@ HCM 7th Edition Chapter 13 analyzes freeway weaving segments (and weaving segmen
 | Step 8a: density | Eq 13-23 (`D = (v/N)/S`) | `determine_density` | v pc/h, N, S mi/h | D pc/mi/ln |
 | Step 8b: LOS | Exhibit 13-6 | `determine_los` (free function `determine_weaving_los`) | D, over-capacity flag, `facility_type` | `LevelOfService` |
 
-Two-sided weaving segments are handled through the `WeavingType` enum: `nwl()` forces N_WL = 0, Step 2 assigns only the ramp-to-ramp flow as weaving (`v_W = v_RR`, `v_NW = v_FF + v_FR + v_RF`), Step 3 uses Eq 13-3, and Step 5's weaving-flow criterion is skipped (`capacity_weaving = None`). The Exhibit 13-6 LOS table distinguishes freeway thresholds (A≤10 / B≤20 / C≤28 / D≤35 / E≤43 pc/mi/ln) from multilane/C-D thresholds (12/24/32/36/40) via the `FacilityType` enum; F is assigned above the E bound or whenever demand exceeds capacity.
+Two-sided weaving segments are handled through the `WeavingType` enum: `nwl()` forces N_WL = 0, Step 2 assigns only the ramp-to-ramp flow as weaving (`v_W = v_RR`, `v_NW = v_FF + v_FR + v_RF`), Step 3 uses Eq 13-3, and Step 5's weaving-flow criterion is skipped (`capacity_weaving = None`). The Exhibit 13-6 LOS table distinguishes freeway thresholds (A≤10 / B≤20 / C≤28 / D≤35 / E≤43 pc/mi/ln) from multilane/C-D thresholds (12/24/32/36/40) via the `FacilityType` enum; F is assigned above the E bound or whenever demand exceeds capacity. The same Exhibit 13-6 thresholds are also transcribed independently as `los_weaving` / `WeavingFacilityType` in `src/hcm/common/los_tables.rs` (with its own boundary unit tests); `WeavingSegment::determine_los` does not call through that common helper, it uses the free function `determine_weaving_los` defined alongside the struct in `weaving/weaving.rs`, so the two are duplicate-but-consistent transcriptions of the same exhibit rather than a caller/callee pair.
+
+## Equations by step
+
+Every equation below is cross-checked against the HCM 7th Edition MathML source (`resources/epub/OEBPS/90_Ch13_03.xhtml`, Equations 13-1 through 13-23) and against the constants and formulas actually implemented in `src/hcm/weaving/weaving.rs`. All 23 equations agree between the manual and the code exactly as shown; no new discrepancies were found beyond the four already recorded in the fix-history section below and in `docs/hcm/VERIFICATION.md`'s "Chapter 12–14" entries.
+
+### Step 2: Adjust volume
+
+```
+Equation 13-1:  v_i = V_i / (PHF × f_HV)
+  v_i = flow rate for movement i under equivalent ideal conditions, pc/h
+  V_i = hourly demand volume for movement i under prevailing conditions, veh/h
+  PHF = peak hour factor, decimal (Exhibit 13-7 default = 0.94 urban and rural; code struct default phf = 0.94)
+  f_HV = heavy vehicle adjustment factor, decimal, per Chapter 12/Equation 12-10 form 1 / (1 + P_HV·(E_T − 1))
+  i ∈ {FF, FR, RF, RR} (component movements), combined into W (weaving) and NW (nonweaving) per Exhibits 13-9/13-10
+Implemented in: weaving/weaving.rs::determine_demand_flow (f_HV itself via the private calculate_fhv, with E_T = 2.0 level / 3.0 rolling from Exhibit 12-25, and the non-HCM E_T = 5.0 mountainous stand-in — see Deviations item 1)
+```
+
+One-sided segments aggregate `v_W = v_RF + v_FR` and `v_NW = v_FF + v_RR` (Exhibit 13-9); two-sided segments use `v_W = v_RR` and `v_NW = v_FF + v_FR + v_RF` (Exhibit 13-10), both per Equation 13-1 applied component-by-component before aggregation.
+
+### Step 3: Determine configuration characteristics
+
+```
+Equation 13-2 (one-sided):  LC_MIN = (LC_RF × v_RF) + (LC_FR × v_FR)
+  LC_MIN = minimum rate at which weaving vehicles must change lanes to complete all weaving maneuvers, lc/h
+  LC_RF = minimum lane changes for one ramp-to-freeway vehicle, lc (Exhibit 13-7 default = 1; code field lc_rf)
+  v_RF = ramp-to-freeway flow rate, pc/h
+  LC_FR = minimum lane changes for one freeway-to-ramp vehicle, lc (Exhibit 13-7 default = 1; code field lc_fr)
+  v_FR = freeway-to-ramp flow rate, pc/h
+Implemented in: weaving/weaving.rs::determine_configuration_characteristics
+```
+
+```
+Equation 13-3 (two-sided):  LC_MIN = LC_RR × v_RR
+  LC_RR = minimum lane changes for one ramp-to-ramp vehicle, lc (Exhibit 13-7 default = 0; code field lc_rr)
+  v_RR = ramp-to-ramp flow rate, pc/h
+Implemented in: weaving/weaving.rs::determine_configuration_characteristics
+```
+
+N_WL (number of lanes from which a weaving maneuver can be made with one or no lane changes) is 2 or 3 for one-sided segments per Exhibit 13-5 (the code field `num_weaving_lanes`, an analyst-supplied input, not computed), and is always 0 for two-sided segments (the `nwl()` helper forces this via `WeavingType::TwoSided`).
+
+### Step 4: Determine maximum weaving length
+
+```
+Equation 13-4:  L_MAX = 5,728·(1 + VR)^1.6 − 1,566·N_WL
+  L_MAX = maximum weaving segment length, ft
+  VR = volume ratio = v_W / v (unitless)
+  N_WL = number of lanes from which a weaving maneuver can be made with one or no lane change, integer
+Implemented in: weaving/weaving.rs::determine_max_weaving_length
+```
+
+If L_S < L_MAX the segment is analyzed as a weaving segment (continue to Step 5); if L_S ≥ L_MAX the manual directs the analyst to Chapter 14 merge/diverge methodology instead. `determine_max_weaving_length` sets `is_weaving = (L_S < L_MAX)` but `run_analysis` does not branch on it — see Deviations item 4. Exhibit 13-11's VR/N_WL spot values are transcribed as an inline unit test (`test_max_weaving_length`, VR = 0.3 → 5,584 ft at N_WL = 2 and 4,018 ft at N_WL = 3, both ±5 ft).
+
+### Step 5: Determine weaving segment capacity
+
+```
+Equation 13-5:  c_IWL = c_IFL − 438.2·(1 + VR)^1.6 + 0.0765·L_S + 119.8·N_WL
+  c_IWL = capacity per lane of the weaving segment under equivalent ideal conditions, pc/h/ln
+  c_IFL = capacity per lane of a basic freeway segment with the same FFS under ideal conditions, pc/h/ln (code field basic_freeway_capacity; struct default = 2,400 pc/h/ln)
+  VR = volume ratio (unitless)
+  L_S = short length of the weaving segment, ft (code field length_short)
+  N_WL = number of weaving lanes, integer (0, 2, or 3)
+Implemented in: weaving/weaving.rs::determine_capacity (c_iwl)
+```
+
+```
+Equation 13-6:  c_W = c_IWL × N × f_HV
+  c_W = capacity of the weaving segment under prevailing conditions, density criterion, veh/h
+  N = number of lanes within the weaving segment, ln (code field num_lanes)
+  f_HV = heavy vehicle adjustment factor, decimal
+Implemented in: weaving/weaving.rs::determine_capacity (capacity_density)
+```
+
+```
+Equation 13-7:  c_IW = 2,400 / VR  for N_WL = 2 lanes
+                c_IW = 3,500 / VR  for N_WL = 3 lanes
+  c_IW = capacity of all lanes in the weaving segment under ideal conditions, weaving-flow criterion, pc/h
+  VR = volume ratio (unitless)
+  No limiting value is defined for two-sided segments (N_WL = 0)
+  Constants: MAX_WEAVING_FLOW_NWL2 = 2,400.0 pc/h, MAX_WEAVING_FLOW_NWL3 = 3,500.0 pc/h
+Implemented in: weaving/weaving.rs::determine_capacity (capacity_weaving; combined directly with Eq 13-8 into `MAX_WEAVING_FLOW_NWLx / vr * f_hv`; returns None for two-sided N_WL = 0, matching "no limiting value")
+```
+
+```
+Equation 13-8:  c_W = c_IW × f_HV
+  c_W = capacity of the weaving segment under prevailing conditions, weaving-flow criterion, veh/h
+Implemented in: weaving/weaving.rs::determine_capacity (folded into the Eq 13-7 computation, per the harmonic-speed-fix commit e921e1e — see fix history below)
+```
+
+```
+Equation 13-9:  c_wa = c_W × CAF
+  c_wa = adjusted capacity of the weaving segment, veh/h
+  c_W = min(Equation 13-6, Equation 13-8), unadjusted capacity under prevailing conditions, veh/h
+  CAF = capacity adjustment factor, decimal (struct default caf = 1.0; Chapter 11 weather/incident/driver-population adjustments)
+Implemented in: weaving/weaving.rs::determine_capacity (capacity)
+```
+
+```
+Equation 13-10:  v/c = (v × f_HV) / c_wa
+  v/c = volume-to-capacity ratio, decimal
+  v = total demand flow rate = v_W + v_NW, pc/h
+  f_HV = heavy vehicle adjustment factor, decimal
+  c_wa = adjusted capacity, veh/h
+Implemented in: weaving/weaving.rs::determine_capacity (vc_ratio; demand_exceeds_capacity = vc_ratio > 1.0, which forces LOS F in Step 8)
+```
+
+### Step 6: Determine lane-changing rates
+
+```
+Equation 13-11:  LC_W = LC_MIN + 0.39·[(L_S − 300)^0.5 · N² · (1 + ID)^0.8]
+  LC_W = total rate of lane changing by weaving vehicles, lc/h
+  LC_MIN = minimum lane-changing rate from Step 3, lc/h
+  L_S = length of the weaving segment (short length definition), ft; 300 ft is used for all L_S ≤ 300 ft (constant MIN_WEAVING_LENGTH = 300.0)
+  N = number of lanes within the weaving segment, ln
+  ID = interchange density, int/mi (Exhibit 13-7 default: urban 0.8/mi, rural 0.4/mi; code field interchange_density, default 0.8)
+Implemented in: weaving/weaving.rs::determine_lane_changing_rates (lc_w; the (L_S − 300) floor is applied via `.max(0.0)` on `ls_adj`)
+```
+
+```
+Equation 13-12:  I_NW = (L_S × ID × v_NW) / 10,000
+  I_NW = nonweaving vehicle index, unitless
+  v_NW = nonweaving demand flow rate, pc/h
+Implemented in: weaving/weaving.rs::determine_lane_changing_rates (i_nw, local to the method)
+```
+
+```
+Equation 13-13:  LC_NW1 = 0.206·v_NW + 0.542·L_S − 192.6·N
+  LC_NW1 = nonweaving lane-changing rate, lc/h, valid for I_NW ≤ 1,300 (the majority of cases)
+  Can be arithmetically negative; the manual specifies the minimum must be externally set at 0
+Implemented in: weaving/weaving.rs::determine_lane_changing_rates (lc_nw1, floored at 0 via `.max(0.0)` — see Deviations item 2)
+```
+
+```
+Equation 13-14:  LC_NW2 = 2,135 + 0.223·(v_NW − 2,000)
+  LC_NW2 = nonweaving lane-changing rate, lc/h, valid for I_NW ≥ 1,950
+Implemented in: weaving/weaving.rs::determine_lane_changing_rates (lc_nw2)
+```
+
+```
+Equation 13-15:  LC_NW3 = LC_NW1 + (LC_NW2 − LC_NW1) · [(I_NW − 1,300) / 650]
+  LC_NW3 = interpolated nonweaving lane-changing rate, lc/h, used for 1,300 < I_NW < 1,950
+  Only valid when LC_NW1 < LC_NW2; if LC_NW1 ≥ LC_NW2, LC_NW2 is used instead (see Equation 13-16)
+Implemented in: weaving/weaving.rs::determine_lane_changing_rates (inline interpolation branch inside the lc_nw match, not a separate named binding)
+```
+
+```
+Equation 13-16 (selection logic):
+  If LC_NW1 ≥ LC_NW2:            LC_NW = LC_NW2
+  Else if I_NW ≤ 1,300:          LC_NW = LC_NW1
+  Else if I_NW ≥ 1,950:          LC_NW = LC_NW2
+  Else (1,300 < I_NW < 1,950):   LC_NW = LC_NW3   (Equation 13-15)
+  LC_NW = total rate of lane changing by nonweaving vehicles, lc/h
+Implemented in: weaving/weaving.rs::determine_lane_changing_rates (the four-armed `if lc_nw1 >= lc_nw2 { .. } else if i_nw <= 1300.0 { .. } else if i_nw >= 1950.0 { .. } else { .. }` match, checking the LC_NW1≥LC_NW2 override first exactly as the manual's Equation 13-16 orders it)
+```
+
+```
+Equation 13-17:  LC_ALL = LC_W + LC_NW
+  LC_ALL = total rate of lane changing of all vehicles within the weaving segment, lc/h
+Implemented in: weaving/weaving.rs::determine_lane_changing_rates (lc_all, the method's return value)
+```
+
+### Step 7: Determine average speeds
+
+```
+Equation 13-18 (general form):  S_W = S_MIN + (S_MAX − S_MIN) / (1 + W)
+  S_W = average speed of weaving vehicles within the weaving segment, mi/h
+  S_MIN = minimum average speed of weaving vehicles expected in a weaving segment, mi/h (constant MIN_WEAVING_SPEED = 15.0 mi/h)
+  S_MAX = maximum average speed of weaving vehicles expected, mi/h — taken as FFS (adjusted by SAF), per the manual's guidance below Equation 13-18
+  W = weaving intensity factor, unitless (Equation 13-20)
+Implemented in: weaving/weaving.rs::estimate_speed (the general form is not coded separately; it is realized directly as Equation 13-19 with S_MIN and S_MAX substituted)
+```
+
+```
+Equation 13-19:  S_W = 15 + (FFS × SAF − 15) / (1 + W)
+  FFS = free-flow speed of the weaving segment, mi/h (code field ffs)
+  SAF = speed adjustment factor, decimal (struct default saf = 1.0; Chapter 11 weather/work-zone adjustments)
+  W = weaving intensity factor, unitless
+  15 mi/h = S_MIN of Equation 13-18 (constant MIN_WEAVING_SPEED)
+Implemented in: weaving/weaving.rs::estimate_speed (speed_weaving)
+```
+
+```
+Equation 13-20:  W = 0.226 · (LC_ALL / L_S)^0.789
+  W = weaving intensity factor, unitless
+  LC_ALL = total lane-changing rate of all vehicles, lc/h
+  L_S = length of the weaving segment, ft
+Implemented in: weaving/weaving.rs::estimate_speed (weaving_intensity)
+```
+
+```
+Equation 13-21:  S_NW = FFS × SAF − 0.0072·LC_MIN − 0.0048·(v/N)
+  S_NW = average speed of nonweaving vehicles within the weaving segment, mi/h
+  LC_MIN = minimum lane-changing rate from Step 3, lc/h
+  v = total demand flow rate = v_W + v_NW, pc/h
+  N = number of lanes within the weaving segment, ln
+Implemented in: weaving/weaving.rs::estimate_speed (speed_nonweaving; no floor is applied, matching the manual — a previously present non-HCM 15 mi/h floor was removed, see fix history below)
+```
+
+```
+Equation 13-22:  S = (v_W + v_NW) / [(v_W / S_W) + (v_NW / S_NW)]
+  S = space mean speed of all vehicles within the weaving segment, mi/h
+Implemented in: weaving/weaving.rs::estimate_speed (speed_avg; the flow-weighted harmonic mean, guarded for v > 0 and both speeds > 0, falling back to S_W otherwise — this is the headline e921e1e fix, see below)
+```
+
+### Step 8: Determine density and LOS
+
+```
+Equation 13-23:  D = (v/N) / S
+  D = average density of all vehicles within the weaving segment, pc/mi/ln
+  v = total demand flow rate, pc/h
+  N = number of lanes within the weaving segment, ln
+  S = space mean speed of all vehicles, mi/h (Equation 13-22)
+Implemented in: weaving/weaving.rs::determine_density
+```
+
+LOS is then assigned from D (and the `demand_exceeds_capacity` flag) via Exhibit 13-6, already transcribed into `determine_weaving_los` in `weaving/weaving.rs` (and independently into `los_weaving` in `src/hcm/common/los_tables.rs`); see the facility-type thresholds noted above.
 
 ## The harmonic space-mean speed fix (Eq 13-22)
 

--- a/docs/hcm/procedures/chapter14.md
+++ b/docs/hcm/procedures/chapter14.md
@@ -1,6 +1,6 @@
 # Chapter 14: Freeway Merge and Diverge Segments — Procedure Walkthrough
 
-HCM 7th Edition Chapter 14 analyzes ramp-freeway junctions: on-ramps (merge influence areas), off-ramps (diverge influence areas), and the major merge/diverge special cases, each over the standard 1,500-ft ramp influence area (Exhibit 14-1). The implementation is `src/hcm/chapter14/merge_diverge.rs` on the `feat/hcm-ch12-14-completion` branch, a single `RampSegment` struct in the chapter15 house style (plain inputs, `Option<T>` computed fields, step methods in HCM order, `run_analysis()`), plus free functions for the capacity tables and special-case helpers. This branch's rewrite (commit `e921e1e`) corrected roughly twenty equation/exhibit transcriptions against the manual — the full list is in "Equation fixes made by this branch" below, which the reviewer should treat as the checklist of highest-risk spots. A PyO3 wrapper (`copython::chapter14::RampSegment`) is registered on this branch.
+HCM 7th Edition Chapter 14 analyzes ramp-freeway junctions: on-ramps (merge influence areas), off-ramps (diverge influence areas), and the major merge/diverge special cases, each over the standard 1,500-ft ramp influence area (Exhibit 14-1). The implementation is `src/hcm/merge_diverge/merge_diverge.rs` (renamed from `src/hcm/chapter14/merge_diverge.rs` on the topic-folder-rename branch) on the `feat/hcm-ch12-14-completion` lineage, a single `RampSegment` struct in the chapter15 house style (plain inputs, `Option<T>` computed fields, step methods in HCM order, `run_analysis()`), plus free functions for the capacity tables and special-case helpers. This branch's rewrite (commit `e921e1e`) corrected roughly twenty equation/exhibit transcriptions against the manual — the full list is in "Equation fixes made by this branch" below, which the reviewer should treat as the checklist of highest-risk spots. A PyO3 wrapper (`copython::merge_diverge::RampSegment`) is registered on this branch. All twenty-eight numbered HCM equations (14-1 through 14-28) plus the Exhibit 14-13/14-14/14-15 speed models and the Exhibit 14-18 left-hand-ramp factors are cross-checked and transcribed in full in the "Equation Reference" section below, verified against the EPUB source (`94_Ch14.xhtml` through `100_Ch14_06.xhtml`) and against the current state of `merge_diverge.rs`.
 
 ## Step-by-step walkthrough
 
@@ -15,7 +15,279 @@ HCM 7th Edition Chapter 14 analyzes ramp-freeway junctions: on-ramps (merge infl
 
 `run_analysis()` chains Steps 1-5 in order (LOS is determined before speeds, matching the manual's core-output ordering).
 
-## Equation fixes made by this branch
+## Equation Reference
+
+Every numbered HCM equation used by this chapter (14-1 through 14-28), plus the Exhibit 14-13/14-14/14-15 speed models and the Exhibit 14-18 left-hand-ramp factors, cross-checked line by line against the current `src/hcm/merge_diverge/merge_diverge.rs` and against the EPUB MathML (`97_Ch14_03.xhtml` for Eqs 14-1 through 14-24, `98_Ch14_04.xhtml` for Eqs 14-25 through 14-28 and Exhibits 14-16 through 14-19). No discrepancies were found between the manual and the current code state for this chapter; every equation below reproduces the published form exactly.
+
+### Step 1 — Demand flow rates
+
+```
+Equation 14-1:  v_i = V_i / (PHF·f_HV)
+  v_i = demand flow rate for movement i, pc/h
+  V_i = demand volume for movement i, veh/h
+  PHF = peak hour factor, decimal (default 0.94 urban/rural per Exhibit 14-4)
+  f_HV = adjustment factor for heavy-vehicle presence, decimal (Eq 12-10 form, Exhibit 12-25 PCEs)
+Implemented in: merge_diverge/merge_diverge.rs::RampSegment::determine_demand_flow (via the private `fhv_for` helper); applied separately to the freeway flow and the ramp flow, with an optional distinct `ramp_heavy_vehicle_pct`.
+```
+
+```
+Equation 14-27 (10-lane freeways, Lane-5 deduction — applied within Step 1):  v_F4eff = v_F − v_5
+  v_F4eff = effective approaching freeway flow in the remaining four lanes, pc/h
+  v_F = total approaching freeway flow in five lanes, pc/h
+  v_5 = estimated approaching freeway flow in Lane 5, pc/h, from Exhibit 14-19's piecewise table (on-ramp and off-ramp forms differ)
+Implemented in: merge_diverge/merge_diverge.rs::RampSegment::determine_demand_flow, using merge_diverge/merge_diverge.rs::get_lane5_flow for v_5 (Exhibit 14-19 constants transcribed as code constants/branches, not re-typed here); the segment is then analyzed as an 8-lane freeway (`freeway_lanes.min(4)`).
+```
+
+### Step 2 — Flow in Lanes 1 and 2 (merge side, P_FM)
+
+```
+Equation 14-2:  v_12 = v_F·P_FM
+  v_12 = flow rate in Lanes 1 and 2 immediately upstream of the on-ramp (merge) influence area, pc/h
+  v_F = total flow rate on the freeway immediately upstream of the merge influence area, pc/h
+  P_FM = proportion of freeway vehicles remaining in Lanes 1 and 2 upstream of the on-ramp influence area, decimal
+Implemented in: merge_diverge/merge_diverge.rs::RampSegment::estimate_v12 (on-ramp/major-merge arm), calling the private `calculate_pfm`.
+```
+
+```
+Equation 14-3 (P_FM base case, 6-lane freeway, isolated or adjacent ramps without influence):  P_FM = 0.5775 + 0.000028·L_A
+  P_FM = proportion of freeway vehicles in Lanes 1 and 2, decimal
+  L_A = length of the acceleration lane, ft (effective two-lane length from Eq 14-25 where applicable; default 800 ft)
+  (4-lane freeways: P_FM = 1.000 fixed, since only Lanes 1 and 2 exist; 8-lane freeways: see the piecewise form below)
+Implemented in: merge_diverge/merge_diverge.rs::RampSegment::calculate_pfm, `lanes == 3` arm, `pfm_base`.
+```
+
+```
+Equation 14-4 (P_FM, adjacent upstream off-ramp, when L_UP < L_EQ from Eq 14-6):  P_FM = 0.7289 − 0.0000135·(v_F + v_R) − 0.003296·S_FR + 0.000063·L_UP
+  v_F = freeway demand flow rate, pc/h
+  v_R = ramp demand flow rate, pc/h
+  S_FR = free-flow speed of the ramp, mi/h
+  L_UP = distance to the adjacent upstream off-ramp, ft
+Implemented in: merge_diverge/merge_diverge.rs::RampSegment::calculate_pfm, upstream-adjacent-off-ramp candidate branch.
+```
+
+```
+Equation 14-5 (P_FM, adjacent downstream off-ramp, when L_DOWN < L_EQ from Eq 14-7):  P_FM = 0.5487 + 0.2628·(v_D / L_DOWN)
+  v_D = demand flow rate on the adjacent downstream ramp, pc/h
+  L_DOWN = distance to the adjacent downstream ramp, ft
+Implemented in: merge_diverge/merge_diverge.rs::RampSegment::calculate_pfm, downstream-adjacent-off-ramp candidate branch. When both Eq 14-4 and Eq 14-5 apply, the larger P_FM governs (`candidates ... max` fold), matching the manual's "two solutions may arise ... the larger value ... is used" instruction.
+```
+
+```
+Equation 14-6 (equilibrium distance L_EQ for an adjacent upstream off-ramp, Eq 14-4's applicability gate):  L_EQ = 0.214·(v_F + v_R) + 0.444·L_A + 52.32·S_FR − 2,403
+  L_EQ = equilibrium separation distance at which Eq 14-3 and Eq 14-4 give the same P_FM, ft
+  v_F, v_R = freeway and ramp demand flow rates, pc/h
+  L_A = acceleration lane length, ft
+  S_FR = free-flow speed of the ramp, mi/h
+Implemented in: merge_diverge/merge_diverge.rs::RampSegment::calculate_pfm, inline `l_eq` computation in the upstream-off-ramp branch (Eq 14-4 is used only when L_UP < L_EQ).
+```
+
+```
+Equation 14-7 (equilibrium distance L_EQ for an adjacent downstream off-ramp, Eq 14-5's applicability gate):  L_EQ = v_D / (0.1096 + 0.000107·L_A)
+  v_D = demand flow rate on the adjacent downstream ramp, pc/h
+  L_A = acceleration lane length, ft
+Implemented in: merge_diverge/merge_diverge.rs::RampSegment::calculate_pfm, inline `l_eq` computation in the downstream-off-ramp branch (Eq 14-5 is used only when L_DOWN < L_EQ).
+```
+
+8-lane freeway P_FM (Exhibit 14-8, no equation number assigned in the manual — printed only as the exhibit's third row): for v_F/S_FR ≤ 72, P_FM = 0.2178 − 0.000125·v_R + 0.01115·(L_A/S_FR); for v_F/S_FR > 72, P_FM = 0.2178 − 0.000125·v_R. Implemented in: merge_diverge/merge_diverge.rs::RampSegment::calculate_pfm, `_ => { ... }` (8-lane) arm. See Deviation 6 below: no clamp to [0, 1] is applied, and extreme v_R can drive this negative.
+
+### Step 2 — Flow in Lanes 1 and 2 (diverge side, P_FD)
+
+```
+Equation 14-8:  v_12 = v_R + (v_F − v_R)·P_FD
+  v_12 = flow rate in Lanes 1 and 2 immediately upstream of the deceleration lane, pc/h
+  v_R = flow rate on the off-ramp, pc/h
+  v_F = flow rate on the freeway immediately upstream of the ramp influence area, pc/h
+  P_FD = proportion of through freeway traffic remaining in Lanes 1 and 2 upstream of the deceleration lane, decimal
+Implemented in: merge_diverge/merge_diverge.rs::RampSegment::estimate_v12 (off-ramp/major-diverge arm), calling the private `calculate_pfd`.
+```
+
+```
+Equation 14-9 (P_FD base case, 6-lane freeway):  P_FD = 0.760 − 0.000025·v_F − 0.000046·v_R
+  v_F, v_R = freeway and ramp demand flow rates, pc/h
+  (4-lane freeways: P_FD = 1.000 fixed; 8-lane freeways: P_FD = 0.436, a constant — Exhibit 14-9)
+Implemented in: merge_diverge/merge_diverge.rs::RampSegment::calculate_pfd, `lanes == 3` arm, `pfd_base`.
+```
+
+```
+Equation 14-10 (P_FD, adjacent upstream on-ramp, when v_U/L_UP ≤ 0.20 and L_UP < L_EQ from Eq 14-12):  P_FD = 0.717 − 0.000039·v_F + 0.604·(v_U/L_UP)
+  v_F = freeway demand flow rate, pc/h
+  v_U = demand flow rate on the adjacent upstream ramp, pc/h
+  L_UP = distance to the adjacent upstream ramp, ft
+Implemented in: merge_diverge/merge_diverge.rs::RampSegment::calculate_pfd, upstream-adjacent-on-ramp candidate branch. When v_U/L_UP > 0.20, Eq 14-9 is used instead regardless of L_EQ, per the manual's stated calibration-range limit; the code checks this gate before the L_EQ gate.
+```
+
+```
+Equation 14-11 (P_FD, adjacent downstream off-ramp, when L_DOWN < L_EQ from Eq 14-13):  P_FD = 0.616 − 0.000021·v_F + 0.124·(v_D/L_DOWN)
+  v_F = freeway demand flow rate, pc/h
+  v_D = demand flow rate on the adjacent downstream ramp, pc/h
+  L_DOWN = distance to the adjacent downstream ramp, ft
+Implemented in: merge_diverge/merge_diverge.rs::RampSegment::calculate_pfd, downstream-adjacent-off-ramp candidate branch. When both Eq 14-10 and Eq 14-11 apply, the larger P_FD governs (`candidates ... max` fold).
+```
+
+```
+Equation 14-12 (equilibrium distance L_EQ for an adjacent upstream on-ramp, Eq 14-10's applicability gate):  L_EQ = v_U / (0.071 + 0.000023·v_F − 0.000076·v_R)
+  v_U = demand flow rate on the adjacent upstream ramp, pc/h
+  v_F, v_R = freeway and ramp demand flow rates, pc/h
+Implemented in: merge_diverge/merge_diverge.rs::RampSegment::calculate_pfd, inline `l_eq`/`denom` computation in the upstream-on-ramp branch; the code additionally guards `denom > 0.0` before comparing, which the manual does not state but which prevents a sign-flipped comparison when the denominator would otherwise go non-positive.
+```
+
+```
+Equation 14-13 (equilibrium distance L_EQ for an adjacent downstream off-ramp, Eq 14-11's applicability gate):  L_EQ = v_D / (1.15 − 0.000032·v_F − 0.000369·v_R)
+  v_D = demand flow rate on the adjacent downstream ramp, pc/h
+  v_F, v_R = freeway and ramp demand flow rates, pc/h
+Implemented in: merge_diverge/merge_diverge.rs::RampSegment::calculate_pfd, inline `l_eq`/`denom` computation in the downstream-off-ramp branch (same `denom > 0.0` guard as Eq 14-12).
+```
+
+### Step 2 — Reasonableness checks (Eqs 14-14 through 14-19)
+
+Applied after P_FM/P_FD selection and any left-hand-ramp adjustment, to guard against outer-lane flows the regression models were not calibrated to reproduce.
+
+```
+Equation 14-14 (6-lane freeways, one outer lane):  v_3 = v_F − v_12
+  v_3 = flow rate in Lane 3 (the sole outer lane), pc/h/ln
+  v_F, v_12 = freeway flow and Lanes-1-2 flow, pc/h
+Implemented in: merge_diverge/merge_diverge.rs::RampSegment::check_v12, `lanes == 3` arm.
+```
+
+```
+Equation 14-15 (used when v_3 > 2,700 pc/h/ln):  v_12a = v_F − 2,700
+  v_12a = adjusted flow rate in Lanes 1 and 2, pc/h
+Implemented in: merge_diverge/merge_diverge.rs::RampSegment::check_v12, `lanes == 3` arm, using the `MAX_OUTER_LANE_FLOW` constant (2,700 pc/h/ln) in place of the literal.
+```
+
+```
+Equation 14-16 (used when v_3 > 1.5·(v_12/2)):  v_12a = v_F / 1.75
+Implemented in: merge_diverge/merge_diverge.rs::RampSegment::check_v12, `lanes == 3` arm. This is the equation corrected by commit `e921e1e` (see "Equation fixes" below — the divisor was previously 2.5, the 8-lane value).
+```
+
+```
+Equation 14-17 (8-lane freeways, two outer lanes):  v_av34 = (v_F − v_12) / 2
+  v_av34 = average flow rate per outer lane (Lanes 3 and 4), pc/h/ln
+Implemented in: merge_diverge/merge_diverge.rs::RampSegment::check_v12, `lanes == 4` arm.
+```
+
+```
+Equation 14-18 (used when v_av34 > 2,700 pc/h/ln):  v_12a = v_F − 5,400
+Implemented in: merge_diverge/merge_diverge.rs::RampSegment::check_v12, `lanes == 4` arm, as `v_f − 2.0 * MAX_OUTER_LANE_FLOW`.
+```
+
+```
+Equation 14-19 (used when v_av34 > 1.5·(v_12/2)):  v_12a = v_F / 2.50
+Implemented in: merge_diverge/merge_diverge.rs::RampSegment::check_v12, `lanes == 4` arm. Per the manual, "in cases where both limitations ... are violated, the result yielding the highest value of v_12a is used" — `check_v12` collects both candidates into a `Vec` and folds with `max` for both the 6-lane and 8-lane arms (Eqs 14-14/14-17 flow the same candidate-selection logic).
+```
+
+### Step 3 — Capacity
+
+```
+Equation 14-20 (total flow entering an on-ramp's influence area):  v_R12 = v_12 + v_R
+  v_R12 = total flow rate entering the merge influence area, pc/h
+  v_12 = flow rate in Lanes 1 and 2, pc/h
+  v_R = ramp demand flow rate, pc/h
+Implemented in: merge_diverge/merge_diverge.rs::RampSegment::estimate_v12 (the `v_r12` assignment; for off-ramps v_R12 is simply v_12, per the manual's text that at diverges "the total flow rate entering the ramp influence area is merely the estimated value of v_12").
+```
+
+```
+Equation 14-21:  c_mda = c_md·CAF
+  c_mda = adjusted capacity of the merge/diverge area, veh/h
+  c_md = unadjusted capacity of the merge/diverge area, veh/h (Exhibit 14-10 freeway table or Exhibit 14-12 ramp table)
+  CAF = capacity adjustment factor, decimal (default 1.0; Chapter 11 weather/incident/driver-population components)
+Implemented in: merge_diverge/merge_diverge.rs::RampSegment::determine_capacity, applied to both `get_freeway_capacity(...)` and `get_ramp_capacity(...)`. Exhibit 14-10 (freeway capacity per lane by FFS, and the 4,600/4,400 pc/h maximum-desirable influence-area flows) and Exhibit 14-12 (ramp roadway capacity by ramp FFS, doubled for two-lane ramps) are transcribed as the constants/branches in merge_diverge/merge_diverge.rs::get_freeway_capacity_per_lane, ::get_freeway_capacity, and ::get_ramp_capacity — cited here, not re-typed, since only the already-coded values are covered per the task scope.
+```
+
+### Step 4 — Density
+
+```
+Equation 14-22 (on-ramp/merge influence area):  D_R = 5.475 + 0.00734·v_R + 0.0078·v_12 − 0.00627·L_A
+  D_R = density in the ramp influence area, pc/mi/ln
+  v_R = ramp demand flow rate, pc/h
+  v_12 = flow rate in Lanes 1 and 2, pc/h
+  L_A = acceleration lane length, ft (effective two-lane value from Eq 14-25 where applicable)
+Implemented in: merge_diverge/merge_diverge.rs::RampSegment::determine_density, `RampType::OnRamp` arm.
+```
+
+```
+Equation 14-23 (off-ramp/diverge influence area):  D_R = 4.252 + 0.0086·v_12 − 0.009·L_D
+  D_R = density in the ramp influence area, pc/mi/ln
+  v_12 = flow rate in Lanes 1 and 2 (includes v_R for off-ramps), pc/h
+  L_D = deceleration lane length, ft (effective two-lane value from Eq 14-26 where applicable)
+Implemented in: merge_diverge/merge_diverge.rs::RampSegment::determine_density, `RampType::OffRamp` arm.
+```
+
+```
+Equation 14-24 (aggregate density across all lanes of the 1,500-ft influence area, computed in Step 5 since it depends on the Exhibit 14-15 all-lane speed):  D = v/S
+  D = density including all lanes of the 1,500-ft ramp influence area, pc/mi/ln
+  v = total flow rate through the merge or diverge area, all lanes, pc/h/ln
+  S = average speed of all vehicles through the merge or diverge area, all lanes, from Exhibit 14-15, mi/h
+Implemented in: merge_diverge/merge_diverge.rs::RampSegment::estimate_speed, `density_all_lanes` assignment (merge: v = v_F+v_R; diverge: v = v_F, both divided by `freeway_lanes`). **See Deviation 3 below (VERIFY-HCM in code):** the manual states v in pc/h/ln without fixing the lane basis for the total; the per-mainline-lane-count division implemented here is a documented interpretation, not a manual-stated formula.
+```
+
+```
+Equation 14-28 (major diverge density, no HCM model exists for major merge):  D_MD = 0.0175·(v_F/N)
+  D_MD = density in the major diverge influence area (all approaching freeway lanes), pc/mi/ln
+  v_F = demand flow rate immediately upstream of the major diverge influence area, pc/h
+  N = number of lanes approaching the major diverge, ln
+Implemented in: merge_diverge/merge_diverge.rs::RampSegment::determine_density, `RampType::MajorDiverge` arm. `RampType::MajorMerge` leaves `density = None` — the manual states "there are no effective models of performance for a major merge area" and limits major-merge analysis to capacity checks only (see Deviation 2 below).
+```
+
+### Step 5 — Speeds (Exhibits 14-13, 14-14, 14-15)
+
+```
+Exhibit 14-13 (on-ramp/merge speeds):
+  M_S = 0.321 + 0.0039·e^(v_R12/1,000) − 0.002·(L_A·S_FR·SAF/1,000)
+  S_R = FFS·SAF − (FFS·SAF − 42)·M_S
+    M_S = speed index for merge areas (intermediate term), unitless
+    S_R = average speed within the ramp influence area, mi/h
+    v_R12 = total flow rate entering the merge influence area, pc/h (capped at 4,600 pc/h for this calculation only, per the exhibit's note)
+    L_A = acceleration lane length, ft; S_FR = ramp free-flow speed, mi/h; FFS = freeway free-flow speed, mi/h; SAF = speed adjustment factor, decimal (default 1.0)
+  Outer-lane speed S_O (piecewise, N_O > 0 only): S_O = FFS·SAF for v_OA < 500 pc/h/ln; S_O = FFS·SAF − 0.0036·(v_OA − 500) for 500 ≤ v_OA ≤ 2,300 pc/h/ln; S_O = FFS·SAF − 6.53 − 0.006·(v_OA − 2,300) for v_OA > 2,300 pc/h/ln.
+Implemented in: merge_diverge/merge_diverge.rs::RampSegment::estimate_speed, `RampType::OnRamp | RampType::MajorMerge` arm. The v_R12 cap is `v_r12.min(MAX_MERGE_INFLUENCE_FLOW)`; S_R is further capped at FFS·SAF, per the manual's statement that merge-area predicted speeds may not exceed FFS.
+```
+
+```
+Exhibit 14-14 (off-ramp/diverge speeds):
+  D_S = 0.883 + 0.00009·v_R − 0.013·S_FR·SAF
+  S_R = FFS·SAF − (FFS·SAF − 42)·D_S
+    D_S = speed index for diverge areas (intermediate term), unitless
+    v_R = ramp demand flow rate, pc/h; S_FR, FFS, SAF as above
+  Outer-lane speed S_O (piecewise, N_O > 0 only): S_O = 1.097·FFS·SAF for v_OA < 1,000 pc/h/ln; S_O = 1.097·FFS·SAF − 0.0039·(v_OA − 1,000) for v_OA ≥ 1,000 pc/h/ln.
+Implemented in: merge_diverge/merge_diverge.rs::RampSegment::estimate_speed, `RampType::OffRamp | RampType::MajorDiverge` arm. The manual notes diverge-area outer-lane speed may marginally exceed FFS via the 1.097 factor — this is not clamped in code, matching the manual's explicit statement.
+```
+
+```
+Exhibit 14-15 (average speed of all vehicles):
+  v_OA = (v_F − v_12) / N_O
+  Merge: S = (v_R12 + v_OA·N_O) / [(v_R12/S_R) + (v_OA·N_O/S_O)]
+  Diverge: S = (v_12 + v_OA·N_O) / [(v_12/S_R) + (v_OA·N_O/S_O)]
+    v_OA = average demand flow per outer lane, pc/h/ln
+    N_O = number of outer lanes (0 for 4-lane, 1 for 6-lane, 2 for 8-lane freeways), ln
+    S = space-mean (harmonic) average speed of all vehicles in all lanes within the 1,500-ft influence area, mi/h, capped at FFS·SAF
+Implemented in: merge_diverge/merge_diverge.rs::RampSegment::estimate_v12 (`v_oa` assignment) and ::estimate_speed (`s_avg` assignment, the harmonic-mean form with the `.min(ffs_adj)` cap). This is the quantity corrected by commit `e921e1e` (see "Equation fixes" below — the average was previously arithmetic and uncapped).
+```
+
+### Extensions to the methodology (Eqs 14-25/14-26, Exhibit 14-18)
+
+```
+Equation 14-25 (two-lane on-ramps, effective acceleration lane length, substituted for L_A everywhere it appears above):  L_Aeff = 2·L_A1 + L_A2
+  L_Aeff = effective acceleration lane length for a two-lane on-ramp, ft
+  L_A1 = length of the first (rightmost) acceleration lane, ft
+  L_A2 = length of the second acceleration lane, ft
+Implemented in: merge_diverge/merge_diverge.rs::effective_accel_length, called from RampSegment::effective_la. The manual also fixes the two-lane P_FM at 1.000/0.555/0.209 for 4-/6-/8-lane freeways (Exhibit 14-16 discussion, no equation number) — merge_diverge/merge_diverge.rs::pfm_two_lane_onramp — and states a two-lane ramp is always treated as isolated (no adjacent-ramp equations apply). **See Deviation 1 below:** the manual caps individual acceleration-lane component lengths (L_A1, L_A2) at 1,500 ft each ("the acceleration lane length used for calculation should be set to 1,500 ft"), but `effective_accel_length` caps only the computed *effective total* L_Aeff at 1,500 ft, which is a looser cap than the manual describes for cases where either component alone would exceed 1,500 ft.
+```
+
+```
+Equation 14-26 (two-lane off-ramps, effective deceleration lane length, only when two deceleration lanes exist):  L_Deff = 2·L_D1 + L_D2
+  L_Deff = effective deceleration lane length for a two-lane off-ramp, ft
+  L_D1 = length of the first deceleration lane, ft
+  L_D2 = length of the second deceleration lane, ft
+Implemented in: merge_diverge/merge_diverge.rs::effective_decel_length, called from RampSegment::effective_ld. The manual also fixes the two-lane P_FD at 1.000/0.450/0.260 for 4-/6-/8-lane freeways — merge_diverge/merge_diverge.rs::pfd_two_lane_offramp. Same component-vs-effective-total cap caveat as Eq 14-25 (Deviation 1).
+```
+
+```
+Exhibit 14-18 (left-hand ramp-freeway junctions, adjustment factors applied to v_12 computed as if the ramp were right-hand): on-ramps 1.00/1.12/1.20 and off-ramps 1.00/1.05/1.10 for 4-/6-/8-lane freeways respectively. The manual states the remaining computations then use v_23 (six-lane) or v_34 (eight-lane) in place of v_12, with "all capacity values remain unchanged."
+Implemented in: merge_diverge/merge_diverge.rs::left_hand_adjustment, applied in RampSegment::estimate_v12 before the Eqs 14-14..14-19 reasonableness checks (see Deferred section below regarding the ordering question between the two).
+```
+
+
 
 Commit `e921e1e` ("refactor(hcm13,hcm14): chapter15-style structs with HCM-verified equations") lists the Chapter 14 corrections against the pre-existing code; together with the Chapter 13 items and the Chapter 12 items in `ea74afa` they are the "~20 equation fixes" of this branch. The Chapter 14 list, cross-checked against the current code:
 
@@ -45,7 +317,7 @@ Additional published details implemented in the rewrite (not framed as fixes but
 
 ## Deviations
 
-1. **Acceleration/deceleration lane length caps (VERIFY-HCM on `effective_accel_length`/`effective_decel_length`)**: the helpers cap the effective two-lane lengths at 1,500 ft citing the Exhibit 14-16 discussion; the reviewer should confirm the manual caps the *effective* total rather than each component.
+1. **Acceleration/deceleration lane length caps (VERIFY-HCM on `effective_accel_length`/`effective_decel_length`)**: the helpers cap the *effective* two-lane length (L_Aeff/L_Deff, Eqs 14-25/14-26 — i.e., `2·L_1 + L_2`) at 1,500 ft. Confirmed against the EPUB (`98_Ch14_04.xhtml`, Exhibit 14-16/14-17 discussion): the manual's stated rule is that an individual *component* lane length longer than 1,500 ft should itself be set to 1,500 ft before being used in the equations ("the acceleration lane length used for calculation should be set to 1,500 ft"); it says nothing about capping the summed effective total. Since `2·L_1 + L_2` exceeds 1,500 ft for almost any realistic two-lane ramp (e.g., the 800 ft/400 ft chapter defaults already give 2·800+400 = 2,000 ft), the current code's total-sum cap fires in the common case, not just the rare case the manual describes, and clamps L_Aeff/L_Deff down to exactly 1,500 ft whenever it does — well below the manual's uncapped (or component-capped) value. This is a more consequential deviation than previously described; code not changed per this task's scope (equation-documentation only) but flagged here for a likely follow-up code fix: cap components before summing, not the sum itself.
 2. **Major merge LOS return value**: `determine_los` for `MajorMerge` under capacity sets `self.los = None` (correct — HCM defines no LOS) but *returns* `LevelOfService::E` from the function, with an inline comment acknowledging the returned letter is not HCM-sanctioned and callers should consult `get_los()`. `run_analysis` propagates that E as its return value, which is a trap for callers that use the return instead of the field.
 3. **Eq 14-24 lane basis (VERIFY-HCM in `estimate_speed`)**: the aggregate all-lane density divides the per-direction flow (merge: v_F+v_R; diverge: v_F) by the mainline lane count; the manual states v in pc/h/ln without fixing the lane basis, so this is a documented interpretation.
 4. **Mountainous PCE (VERIFY-HCM in `fhv_for`)**: `E_T = 5.0` is a non-HCM approximation (Exhibit 12-25 has no mountainous entry) — same flag as chapter13, and again inconsistent with chapter12's 2.5 placeholder.

--- a/docs/hcm/procedures/chapter15.md
+++ b/docs/hcm/procedures/chapter15.md
@@ -1,6 +1,8 @@
 # Chapter 15: Two-Lane Highways — Procedure Walkthrough
 
-HCM 7th Edition Chapter 15 covers the motorized-vehicle methodology (Section 3, "Motorized Vehicle Methodology") for Passing Constrained (PC), Passing Zone (PZ), and Passing Lane (PL) segments, plus the bicycle LOS methodology (Section 4). Both are implemented in a single file, `src/hcm/chapter15/twolanehighways.rs` (2,495 lines) on the `feat/hcm-restructure` branch, re-exported through `src/hcm/chapter15/mod.rs`. The motorized methodology walks each `Segment` through an 11-step sequence (free-flow speed → average speed → percent followers → follower density → LOS), driven by the `TwoLaneHighways` struct holding a `Vec<Segment>` plus facility-wide geometry (`lane_width`, `shoulder_width`, `apd`, `pmhvfl`, `l_de`); the bicycle methodology is a self-contained `BicycleLOS` struct with its own 5-step chain. This document covers the motorized steps in manual order, then the bicycle method, then documents the two internal unit conventions that most easily trip up a caller.
+HCM 7th Edition Chapter 15 covers the motorized-vehicle methodology (Section 3, "Motorized Vehicle Methodology") for Passing Constrained (PC), Passing Zone (PZ), and Passing Lane (PL) segments, plus the bicycle LOS methodology (Section 4). Both are implemented in a single file, `src/hcm/twolanehighways/twolanehighways.rs` (2,510 lines), re-exported through `src/hcm/twolanehighways/mod.rs` (this is the current topic-folder path; the module was renamed from `src/hcm/chapter15/`). The motorized methodology walks each `Segment` through an 11-step sequence (free-flow speed → average speed → percent followers → follower density → LOS), driven by the `TwoLaneHighways` struct holding a `Vec<Segment>` plus facility-wide geometry (`lane_width`, `shoulder_width`, `apd`, `pmhvfl`, `l_de`); the bicycle methodology is a self-contained `BicycleLOS` struct with its own 5-step chain. This document covers the motorized steps in manual order, then the bicycle method, then documents the two internal unit conventions that most easily trip up a caller.
+
+This pass re-verified every equation below directly against the HCM 7th Edition EPUB (`resources/epub/OEBPS/101_Ch15.xhtml` through `108_Ch15_appa.xhtml` in the user's main checkout, read-only) and against the *current* `twolanehighways.rs`, not against the previous revision of this document. Two things called out as open questions in the previous revision are resolved below: the Step 3 vertical-class bucket gap (Exhibit 15-11) has been fixed in code since this document was last written and is transcribed correctly row-for-row against the manual; and Step 9's previously uncited equations are confirmed to be Eq 15-36 through 15-38, not Eq 15-30 through 15-33 as previously guessed. Several small numeric coefficient transcription errors were found in the process and are marked `**DISCREPANCY:**` inline.
 
 ## Step-by-step walkthrough (motorized methodology)
 
@@ -10,37 +12,257 @@ HCM 7th Edition Chapter 15 covers the motorized-vehicle methodology (Section 3, 
 | Step 2: demand flow rates & capacity | Eq 15-1; capacity Exhibit 15-5 | `determine_demand_flow` | `twolanehighways.rs` | `seg_num` (uses `volume`, `volume_op`, `phf`, `phv`, `passing_type`, `vertical_class`) | `(demand_flow_i, demand_flow_o veh/h, capacity veh/h)`; also mutates `segments[seg_num]` |
 | Step 3: vertical alignment classification | Exhibit 15-11 | `determine_vertical_alignment` | `twolanehighways.rs` | `seg_num` (`length` mi, `grade` %) | vertical class `i32` 1-5; re-invokes `identify_vertical_class` if the class changed |
 | Step 4: free-flow speed | Eq 15-2 to 15-6, coefficients Exhibit 15-12 | `determine_free_flow_speed` | `twolanehighways.rs` | `seg_num`, facility `lane_width`/`shoulder_width`/`apd` (ft, ft, pts/mi) | FFS, mi/h |
-| Step 5: average speed | Eq 15-7 to 15-16, coefficients Exhibits 15-13/15-14/15-19/15-20 | `estimate_average_speed` (delegates per-subsegment/tangent work to private `calc_speed`) | `twolanehighways.rs` | `seg_num` | `(average_speed mi/h, horizontal_class 0-5)` |
+| Step 5: average speed | Eq 15-7 to 15-16, coefficients Exhibits 15-13/15-14/15-19/15-20/15-22 | `estimate_average_speed` (delegates per-subsegment/tangent work to private `calc_speed`) | `twolanehighways.rs` | `seg_num` | `(average_speed mi/h, horizontal_class 0-5)` |
 | Step 6: percent followers | Eq 15-17 to 15-23, coefficients Exhibits 15-24 to 15-29 | `estimate_percent_followers` (delegates to private `calc_percent_followers`) | `twolanehighways.rs` | `seg_num` | percent followers, 0-100 |
-| Steps 7-8: passing-lane flow split, lane-specific speed/PF, midpoint follower density | Eq 15-24 to 15-27 (flow split), Eq 15-34 (FD at PL midpoint) | `determine_follower_density_pl` (uses helper `estimate_average_speed_sf` / `estimate_percent_followers_sf` for the faster-lane/slower-lane sub-calculations) | `twolanehighways.rs` | `seg_num`, facility `pmhvfl` | `(fd, fd_mid)` followers/mi/ln |
+| Steps 7-8: passing-lane flow split, lane-specific speed/PF, midpoint follower density | Eq 15-24 to 15-34 (flow/HV split, speed differential, midpoint speeds, midpoint FD) | `determine_follower_density_pl` (uses helper `estimate_average_speed_sf` / `estimate_percent_followers_sf` for the faster-lane/slower-lane sub-calculations) | `twolanehighways.rs` | `seg_num`, facility `pmhvfl` | `(fd, fd_mid)` followers/mi/ln |
 | Step 8 (PC/PZ path): follower density | Eq 15-35 | `determine_follower_density_pc_pz` | `twolanehighways.rs` | `seg_num` (`avg_speed`, `pf`, `flow_rate`) | followers/mi/ln |
-| Step 9: adjustment for upstream passing lane | Eq 15-30 to 15-33 (unlabeled in code comments; see below) | `determine_adjustment_to_follower_density` | `twolanehighways.rs` | `seg_num` | follower-density adjustment, followers/mi/ln |
+| Step 9: adjustment for upstream passing lane | Eq 15-36 to 15-38 (confirmed against the EPUB this pass — see "Step 9 detail" below) | `determine_adjustment_to_follower_density` | `twolanehighways.rs` | `seg_num` | follower-density adjustment, followers/mi/ln |
 | Step 10: segment LOS | Exhibit 15-6 | `determine_segment_los` | `twolanehighways.rs` | `seg_num`, `s_pl` (posted speed limit, mi/h — **not** average speed, see Unit footguns), `cap` (veh/h) | LOS char `'A'..'F'` |
 | Step 11: facility LOS | Eq 15-39 | `determine_facility_los` | `twolanehighways.rs` | length-weighted `fd` (followers/mi/ln), `s_pl` (mi/h) | LOS char `'A'..'F'` |
 
 The recommended per-segment call order is documented directly on `TwoLaneHighways` (module-level `# Analysis Workflow` doc comment) and matches `tests/common/mod.rs::run_complete_analysis()`: `identify_vertical_class` → `determine_demand_flow` → `determine_vertical_alignment` → `determine_free_flow_speed` → `estimate_average_speed` → `estimate_percent_followers` → (`determine_follower_density_pl` if `passing_type == 2` else `determine_follower_density_pc_pz`) → `determine_adjustment_to_follower_density`.
 
-### Step 3 detail: vertical class thresholds
+### Step 2 detail: demand flow and capacity (Eq 15-1, Exhibit 15-5)
 
-`determine_vertical_alignment` is a large, hand-transcribed decision tree over `(seg_length, seg_grade)` bins directly encoding Exhibit 15-11's upgrade/downgrade tables (separate branches for `seg_grade >= 0.0` vs. negative grade, the latter negating `seg_length` before bucketing). There is a length-bin gap worth flagging to the reviewer: the upgrade branch has an `else if seg_length > 0.4 && seg_length <= 0.5` bucket followed directly by `else if seg_length > 0.6 && seg_length <= 0.7` — **the `0.5 < seg_length <= 0.6` interval is never matched** by any explicit branch and falls through to the final `else` (the `> 1.1`-equivalent catch-all bucket), which uses coarser thresholds than the intended 0.5-0.7 mi bucket in Exhibit 15-11. This looks like a transcription gap rather than an intentional simplification.
+```
+Equation 15-1:  v_i = V_i / PHF
+  v_i = demand flow rate in direction i, veh/h (i = "d" analysis direction, or "o" opposing direction)
+  V_i = demand volume for direction i, veh/h
+  PHF = peak hour factor (decimal)
+Implemented in: twolanehighways/twolanehighways.rs::determine_demand_flow
+```
 
-### Step 4 detail: the `a` (HV speed-reduction) coefficient
+`determine_demand_flow` applies Eq 15-1 as `demand_flow_i = v_i / phf` for the analysis direction; the opposing-direction flow rate is set per the passing-type rule the manual specifies (PC: `v_o = 1500` veh/h fixed high-opposing-flow assumption; PZ: `v_o = V_o/PHF` if `volume_op` is supplied, else `0.0`; PL: `v_o = 0.0`, since passing on a PL segment doesn't use the opposing lane). Capacity is 1,700 veh/h flat for PC and PZ segments; for PL segments it is read from Exhibit 15-5 (Maximum Flow Rates for Passing Lane Segments), a 5×5 table of heavy-vehicle-percentage bracket × vertical class, transcribed as nested `if`/`else if` branches on `phv` and `vc` in `determine_demand_flow`.
 
-Eq 15-4's five coefficient sets (`a0`..`a5` per vertical class 1-5) are transcribed as literal `f64` constants inline in `determine_free_flow_speed`, keyed by `if vc == 1 { ... } else if vc == 2 { ... }` etc., rather than pulled from a shared exhibit table — this duplicates the same literal-constant style used for the `b`/`c`/`d`/`f` coefficients in `calc_speed` and the `b`/`c`/`d`/`e` coefficients in `calc_percent_followers` (all three coefficient sets are re-declared per function with no shared table). A reviewer checking these against Exhibit 15-12 needs to check the literals directly in each function since there is no single canonical constants module.
+**DISCREPANCY:** Exhibit 15-5's `≥5% <10%` heavy-vehicle bracket gives 1,500 veh/h for vertical classes 1-4 but **1,400 veh/h for vertical class 5**. The code's branch for that bracket is `if vc == 1 || vc == 2 || vc == 3 { capacity = 1500 } else { capacity = 1500 }` — both arms of the `if`/`else` return the same value, so vertical class 5 never receives the 1,400 veh/h capacity the manual specifies for that cell (class 4's 1,500 is coincidentally correct); the branch is effectively a no-op that always yields 1,500 for this bracket regardless of vertical class. This is a genuine manual-vs-code mismatch, not a rounding artifact; code was left unmodified per this documentation task's scope. All other heavy-vehicle brackets (`<5`, `10-15`, `15-20`, `20-25`, `≥25`) were checked row-by-row against Exhibit 15-5 and match the code's branch structure exactly.
 
-### Step 5 detail: horizontal-curve adjustment and `is_hc`
+**Note on PHF default:** `TwoLaneHighways`'s module-level doc comment lists the Exhibit 15-8 base-condition PHF as `0.94`, but `Segment::get_phf()` returns `self.phf.unwrap_or(0.95)` — i.e., the actual default used when `phf` is `None` is 0.95, not the 0.94 documented as the base condition. Same class of doc/code default mismatch as the `apd` item already noted below.
 
-`estimate_average_speed` first computes the whole-segment tangent speed via `calc_speed(..., is_hc=false, rad=0.0, sup_ele=0.0)`. If `Segment.is_hc` is `true`, it then iterates `Segment.subsegments`, converts each `SubSegment.length` from feet to miles (`/ 5280.0`, line ~1132), and for curved subsegments (`design_rad > 0.0`) recomputes speed with `calc_speed(..., is_hc=true, rad, sup_ele)`, applying the horizontal-class speed cap inside `calc_speed`: `bffshc = min(bffs, 44.32 + 0.3728*bffs - 6.868*hor_class)`, `ffshc = bffshc - 0.0255*phv`, then `shc = min(s, ffshc - mhc*sqrt(vd/1000 - 0.1))` (Eq 15-12 to 15-15 region). The final segment speed is the subsegment-length-weighted average, `tot_s / seg_length`. **If `is_hc` is left `false` (or unset — `Segment::get_is_hc()` defaults to `false`), subsegments and their curve data are silently ignored even if present**, since the `if is_hc { ... }` branch (line ~1124) is the only path that reads `subsegments`. The horizontal-class table itself (radius/superelevation → class 0-5, Exhibit 15-22) is transcribed as a 20-branch `if`/`else if` cascade on `rad`/`sup_ele` inside `calc_speed`.
+### Step 3 detail: vertical class thresholds (Exhibit 15-11) — gap now fixed
 
-One inline comment is a live author TODO worth the reviewer's direct attention: at the point where `shc` is computed (`calc_speed`, immediately before `s = shc;`), the code comment reads `// Should be ST instead of S?` — i.e., the original author was unsure whether the `min(s, ...)` term should use the pre-curve tangent speed `s` (as coded) or a separate "ST" quantity from the manual. This is exactly the kind of translation-fidelity question this documentation exercise is meant to surface.
+The previous revision of this document flagged a missing `0.5 < seg_length <= 0.6` mi bucket in the upgrade branch of `determine_vertical_alignment`, and a bug in the downgrade branch. **Both are fixed in the current code.** The upgrade branch now has an explicit `else if seg_length > 0.5 && seg_length <= 0.6` bucket (tagged in code with the comment `// HCM Exhibit 15-11 row >0.5-0.6 mi (upgrades)`), and the downgrade branch negates the *grade* (`let seg_grade = -1.0 * seg_grade;`) rather than the length, with a code comment explicitly noting the old bug ("Previously the LENGTH was negated instead, which sent every downgrade into the first length bucket with an always-true grade test, so all downgrades returned class 1"). This pass re-verified `determine_vertical_alignment` against Exhibit 15-11 row by row (all 13 length bins × 10 grade columns, upgrade and downgrade/parenthesized values both) and found every threshold now matches the manual exactly, including the two places where the manual's own bucketing skips a vertical class outright: the `>1.1` mi upgrade row jumps from class 2 directly to class 4 (no class-3 bucket exists at that length, i.e. `else if seg_grade <= 5.0 { ver_align = 4 }` following the `<= 3.0 => 2` branch), and the `>0.7-0.8` mi downgrade row similarly skips class 2. Both of these apparent "gaps" are correctly transcribed and are not bugs — they are exactly how Exhibit 15-11 is printed in the manual. The vertical-class bucket gap noted previously in this document's Deviations list no longer applies; see the Deviations section below for the updated status.
 
-### Step 7-8 detail: passing-lane split
+### Step 4 detail: free-flow speed (Eq 15-2 to 15-6, Exhibit 15-12)
 
-`determine_follower_density_pl` computes `NumHV = round(v_d * phv/100)`, the faster-lane flow proportion `PropFlowFL = 0.92183 - 0.05022*ln(v_d) - 0.00030*NumHV` (Eq 15-25), splits `vd_fl`/`vd_sl` and heavy-vehicle percentages accordingly, computes a speed differential adjustment `sda = 2.750 + 0.00056*v_d + 3.8521*phv/100`, and combines lane speeds/percent-followers into `fd_mid = (pf_fl*vd_fl/s_mid_fl + pf_sl*vd_sl/s_mid_sl) / 200`. It also calls `determine_follower_density_pc_pz` internally to populate the ordinary endpoint `fd` alongside `fd_mid`, so both are available for Step 10/11 (Step 10 picks `fd_mid` when `passing_type == 2`, `fd` otherwise — see `determine_segment_los`). When the segment has more than one subsegment, the faster/slower-lane speeds are themselves subsegment-length-weighted using the same `/5280.0` feet→miles conversion as Step 5.
+```
+Equation 15-2:  BFFS = 1.14 * Spl
+  BFFS = base free-flow speed, mi/h
+  Spl = posted speed limit, mi/h
+Implemented in: twolanehighways/twolanehighways.rs::determine_free_flow_speed (also inlined in estimate_average_speed and estimate_average_speed_sf — see Unit footguns)
 
-### Step 9 detail: unlabeled equations
+Equation 15-3:  FFS = BFFS - a*(HV%) - f_LS - f_A
+  FFS = free-flow speed in the analysis direction, mi/h
+  a = heavy-vehicle adjustment factor from Eq 15-4 (decimal)
+  HV% = percent heavy vehicles in the analysis direction (e.g. 5% expressed as 5, not 0.05)
+  f_LS = lane/shoulder-width adjustment, mi/h, from Eq 15-5
+  f_A = access-point-density adjustment, mi/h, from Eq 15-6
+Implemented in: twolanehighways/twolanehighways.rs::determine_free_flow_speed
 
-`determine_adjustment_to_follower_density` implements the "effective distance downstream of a passing lane" logic (locating the nearest upstream PL segment, accumulating downstream length `l_d`, and computing `pf_improve`/`s_improve` via the `y_1`/`y_2`/`x_2`/`x_3`/`x_4` intermediate terms) but **carries no HCM equation-number comments at all**, unlike every other step method in this file. The manual's Eq 15-30 to 15-33 region (percent-followers and speed improvement downstream of a passing lane) is the likely source, but this should be confirmed against the manual directly since the code gives no citation to check against. The method also contains a `// TODO: if there are more than three PL section` comment on the `pl_loc` upstream-passing-lane lookup, which only tracks a single PL location (last one wins) rather than multiple.
+Equation 15-4:  a = max(0.0333, a0 + a1*BFFS + a2*L + max(0, a3 + a4*BFFS + a5*L) * (v_o/1000))
+  a0..a5 = coefficients from Exhibit 15-12, keyed by vertical class (transcribed as literal f64 per-vc branches)
+  L = segment length, mi (subject to Step 1 min/max)
+  v_o = opposing-direction demand flow rate, veh/h (1,500 for PC segments, 0 for PL segments)
+Implemented in: twolanehighways/twolanehighways.rs::determine_free_flow_speed
+
+Equation 15-5:  f_LS = 0.6*(12 - LW) + 0.7*(6 - SW)
+  LW = lane width, ft (manual: constrained to [9, 12] ft)
+  SW = shoulder width, ft (manual: constrained to [0, 6] ft)
+Implemented in: twolanehighways/twolanehighways.rs::determine_free_flow_speed
+
+Equation 15-6:  f_A = min(APD/4, 10)
+  APD = access-point density, access points/mi
+Implemented in: twolanehighways/twolanehighways.rs::determine_free_flow_speed
+```
+
+Exhibit 15-12's five coefficient sets (`a0..a5` per vertical class 1-5) were checked value-for-value against the EPUB and match exactly: class 1 is all zeros; class 2 is `-0.45036, 0.00814, 0.01543, 0.01358, 0, 0`; class 3 is `-0.29591, 0.00743, 0, 0.01246, 0, 0`; class 4 is `-0.40902, 0.00975, 0.00767, -0.18363, 0.00423, 0`; class 5 is `-0.38360, 0.01074, 0.01945, -0.69848, 0.01069, 0.12700`. They are transcribed as literal `f64` constants inline in `determine_free_flow_speed` (`if vc == 1 { ... } else if vc == 2 { ... }` etc.) rather than pulled from a shared exhibit table — this duplicates the same literal-constant style used for the `b`/`c`/`d`/`f` coefficients in `calc_speed` and the `b`/`c`/`d`/`e` coefficients in `calc_percent_followers` (all three coefficient sets are re-declared per function with no shared constants module). A reviewer checking these against Exhibit 15-12 needs to check the literals directly in each function since there is no single canonical constants module.
+
+**DISCREPANCY:** Eq 15-5's `LW` and `SW` inputs are explicitly constrained by the manual to `[9, 12]` ft and `[0, 6]` ft respectively before being plugged into the formula. `determine_free_flow_speed` reads `self.lane_width.unwrap_or(12.0)` and `self.shoulder_width.unwrap_or(6.0)` directly into `f_ls = 0.6*(12.0-lw) + 0.7*(6.0-sw)` with no clamping — a caller supplying, say, `lane_width = 14.0` (wider than the manual's 12 ft ceiling) or a negative/oversized shoulder width would silently get a `f_LS` outside the range the manual's model was fit for, rather than being clamped to the boundary value the manual specifies.
+
+### Step 5 detail: average speed (Eq 15-7 to 15-16, Exhibits 15-13/15-14/15-19/15-20/15-22)
+
+```
+Equation 15-7:  S = FFS                              if v_d <= 100 veh/h
+                S = FFS - m*(v_d/1000 - 0.1)^p        if v_d > 100 veh/h
+  S = average speed in the analysis direction, mi/h
+  m = slope coefficient from Eq 15-8
+  p = power coefficient from Eq 15-11
+Implemented in: twolanehighways/twolanehighways.rs::calc_speed
+
+Equation 15-8:  m = max(b5, b0 + b1*FFS + b2*sqrt(v_o/1000) + max(0,b3)*sqrt(L) + max(0,b4)*sqrt(HV%))
+  b0..b5 = coefficients from Exhibit 15-13 (PC/PZ) or Exhibit 15-14 (PL), keyed by vertical class
+Implemented in: twolanehighways/twolanehighways.rs::calc_speed
+
+Equation 15-9:  b3 = c0 + c1*sqrt(L) + c2*FFS + c3*FFS*sqrt(L)
+  c0..c3 = coefficients from Exhibit 15-15 (PC/PZ) or Exhibit 15-16 (PL)
+Implemented in: twolanehighways/twolanehighways.rs::calc_speed
+
+Equation 15-10:  b4 = d0 + d1*sqrt(HV%) + d2*FFS + d3*FFS*sqrt(HV%)
+  d0..d3 = coefficients from Exhibit 15-17 (PC/PZ) or Exhibit 15-18 (PL)
+Implemented in: twolanehighways/twolanehighways.rs::calc_speed
+
+Equation 15-11:  p = max(f8, f0 + f1*FFS + f2*L + f3*(v_o/1000) + f4*sqrt(v_o/1000) + f5*HV% + f6*sqrt(HV%) + f7*L*HV%)
+  f0..f8 = coefficients from Exhibit 15-19 (PC/PZ) or Exhibit 15-20 (PL)
+Implemented in: twolanehighways/twolanehighways.rs::calc_speed
+```
+
+The `b0..b5`, `c0..c3`, `d0..d3`, `f0..f8` literal constants in `calc_speed` were checked against Exhibits 15-13 through 15-20 across all 5 vertical classes and both segment-type branches (PC/PZ and PL); all matched exactly with two exceptions:
+
+**DISCREPANCY:** Exhibit 15-14 (Eq 15-8 coefficients, Passing Lane segments), vertical class 2, `b0`: the manual gives **-2.0688**; the code (`calc_speed`, `pt == 2`, `vc == 2` branch) has `b0 = -2.0668;`.
+
+Horizontal-curve adjustment (Step 5d, Eq 15-12 to 15-16):
+
+```
+Equation 15-12:  S_HCi = min(S, FFS_HCi - m*sqrt(v_d/1000 - 0.1))
+  S_HCi = average speed on horizontal-curve subsegment i, mi/h
+  S = average speed from Eq 15-7 for the whole segment (the tangent speed) — see note below
+Implemented in: twolanehighways/twolanehighways.rs::calc_speed (the `shc` computation)
+
+Equation 15-13:  FFS_HCi = BFFS_HCi - 0.0255*HV%
+Implemented in: twolanehighways/twolanehighways.rs::calc_speed (`ffshc`)
+
+Equation 15-14:  BFFS_HCi = min(BFFS_T, 44.32 + 0.3728*BFFS_T - 6.868*HorizClass_i)
+  BFFS_T = base free-flow speed on the preceding tangent subsegment, mi/h
+  HorizClass_i = horizontal classification for subsegment i, 0-5 (Exhibit 15-22)
+Implemented in: twolanehighways/twolanehighways.rs::calc_speed (`bffshc`)
+
+Equation 15-15:  m = max(0.277, -25.8993 - 0.7756*FFS_HCi + 10.6294*sqrt(FFS_HCi) + 2.4766*HorizClass_i - 9.8238*sqrt(HorizClass_i))
+Implemented in: twolanehighways/twolanehighways.rs::calc_speed (`mhc`)
+
+Equation 15-16:  S = Sum_i(SubsegSpeed_i * SubsegLength_i) / L
+  L = actual segment length, mi
+Implemented in: twolanehighways/twolanehighways.rs::estimate_average_speed (`res_s = tot_s / seg_length`)
+```
+
+`estimate_average_speed` first computes the whole-segment tangent speed via `calc_speed(..., is_hc=false, rad=0.0, sup_ele=0.0)`. If `Segment.is_hc` is `true`, it then iterates `Segment.subsegments`, converts each `SubSegment.length` from feet to miles (`/ 5280.0`, line ~1149), and for curved subsegments (`design_rad > 0.0`) recomputes speed with `calc_speed(..., is_hc=true, rad, sup_ele)`. The final segment speed is the subsegment-length-weighted average, `tot_s / seg_length`, matching Eq 15-16. **If `is_hc` is left `false` (or unset — `Segment::get_is_hc()` defaults to `false`), subsegments and their curve data are silently ignored even if present**, since the `if is_hc { ... }` branch is the only path that reads `subsegments`. The horizontal-class table itself (radius/superelevation → class 0-5, Exhibit 15-22) is transcribed as a 20-branch `if`/`else if` cascade on `rad`/`sup_ele` inside `calc_speed`.
+
+**Resolved this pass — the `// Should be ST instead of S?` comment appears to be unfounded author doubt, not a real bug.** The comment sits immediately before `s = shc;` in `calc_speed`, at the `min(s, ffshc - mhc*sqrt(vd/1000.0 - 0.1))` line implementing Eq 15-12. Checking the manual's own variable list for Eq 15-12: there is no separately defined "S_T" ("speed on tangent") term anywhere in Chapter 15 — the only "T" subscript that appears nearby is `BFFS_T` in Eq 15-14 (a distinct base-free-flow-speed term already handled by the `bffs` argument). Eq 15-12's cap is literally bare "S", which the manual's prose defines as "the average speed in the analysis direction ... with consideration of horizontal curvature" and clarifies further: "All tangent subsegments use the average speed calculated by Equation 15-7. The tangent average speed also serves as a limiting speed for any calculated horizontal subsegment speeds." In the code, when `calc_speed` is called with `is_hc=true` for a curve subsegment, `seg_length`, `ffs`, `vc`, `pt`, `vd`, `vo`, and `phv` are passed identically to the whole-segment tangent-only call (only `rad`/`sup_ele` differ), and `rad`/`sup_ele` do not enter the `ms`/`ps`/`s` computation at all — they only affect `hor_class` and the subsequent `is_hc` block. So the `s` value at the `// Should be ST instead of S?` line is already numerically identical to the whole-segment tangent speed (`seg_s`) computed in the outer call, which is exactly what Eq 15-12's "S" means. The code's use of `s` (not some hypothetical distinct "ST" term) matches the manual. This finding doesn't change the code; it downgrades the open question in the Deviations list below from "unresolved" to "checked, appears correct."
+
+### Step 6 detail: percent followers (Eq 15-17 to 15-23, Exhibits 15-24 to 15-29)
+
+```
+Equation 15-17:  PF = 100 * (1 - e^(m*(v_d/1000)^p))
+  PF = percent followers in the analysis direction, %
+  m, p = slope/power coefficients from Eq 15-22/15-23
+Implemented in: twolanehighways/twolanehighways.rs::calc_percent_followers
+
+Equation 15-18 (PC/PZ):  PF_cap = b0 + b1*L + b2*sqrt(L) + b3*FFS + b4*sqrt(FFS) + b5*HV% + b6*FFS*(v_o/1000) + b7*sqrt(v_o/1000)
+  b0..b7 = Exhibit 15-24 coefficients, by vertical class
+Implemented in: twolanehighways/twolanehighways.rs::calc_percent_followers (`pf_cap`, `pt == 0 || pt == 1` branch)
+
+Equation 15-19 (PL):  PF_cap = b0 + b1*L + b2*sqrt(L) + b3*FFS + b4*sqrt(FFS) + b5*HV% + b6*sqrt(HV%) + b7*FFS*HV%
+  b0..b7 = Exhibit 15-25 coefficients, by vertical class
+Implemented in: twolanehighways/twolanehighways.rs::calc_percent_followers (`pf_cap`, `pt == 2` branch)
+
+Equation 15-20 (PC/PZ):  PF_25cap = c0 + c1*L + c2*sqrt(L) + c3*FFS + c4*sqrt(FFS) + c5*HV% + c6*FFS*(v_o/1000) + c7*sqrt(v_o/1000)
+  c0..c7 = Exhibit 15-26 coefficients, by vertical class
+Implemented in: twolanehighways/twolanehighways.rs::calc_percent_followers (`pf_25_cap`, `pt == 0 || pt == 1` branch)
+
+Equation 15-21 (PL):  PF_25cap = c0 + c1*L + c2*sqrt(L) + c3*FFS + c4*sqrt(FFS) + c5*HV% + c6*sqrt(HV%) + c7*FFS*HV%
+  c0..c7 = Exhibit 15-27 coefficients, by vertical class
+Implemented in: twolanehighways/twolanehighways.rs::calc_percent_followers (`pf_25_cap`, `pt == 2` branch)
+
+Equation 15-22:  m = d1*z_25cap + d2*z_cap,  where z_x = -ln(1 - PF_x/100) / (cap_x/1000)
+  d1, d2 = Exhibit 15-28 coefficients, by segment type (PC/PZ: -0.29764, -0.71917; PL: -0.15808, -0.83732)
+  cap = directional capacity, veh/h (Exhibit 15-5 for PL, 1,700 for PC/PZ)
+Implemented in: twolanehighways/twolanehighways.rs::calc_percent_followers (`m_pf`, `z_cap`, `z_25_cap`)
+
+Equation 15-23:  p = e0 + e1*z_25cap + e2*z_cap + e3*sqrt(z_25cap) + e4*sqrt(z_cap)
+  e0..e4 = Exhibit 15-29 coefficients, by segment type (PC/PZ: 0.81165, 0.37920, -0.49524, -2.11289, 2.41146; PL: -1.63246, 1.64960, -4.45823, -4.89119, 10.33057)
+Implemented in: twolanehighways/twolanehighways.rs::calc_percent_followers (`p_pf`)
+```
+
+Exhibit 15-28 and 15-29 (the `d1`/`d2` and `e0..e4` constants, which don't vary by vertical class, only by segment type) match the manual exactly. Exhibits 15-24 through 15-27 (the `b0..b7`/`c0..c7` per-vertical-class tables) were checked value-for-value; two transcription errors were found:
+
+**DISCREPANCY:** Exhibit 15-24 (Eq 15-18 coefficients, PC/PZ), vertical class 1, `b7`: the manual gives **7.13758**; the code has `b7 = 7.13760;`.
+
+**DISCREPANCY:** Exhibit 15-26 (Eq 15-20 coefficients, PC/PZ), vertical class 1, `c7`: the manual gives **11.60405**; the code has `c7 = 11.60410;`.
+
+**DISCREPANCY:** Exhibit 15-27 (Eq 15-21 coefficients, PL), vertical class 2, `c6`: the manual gives **0.77217**; the code has `c6 = 0.77127;`.
+
+All other entries across the four exhibits (Exhibit 15-24/15-25/15-26/15-27, 5 vertical classes each) matched the manual exactly.
+
+### Step 7-8 detail: passing-lane flow/HV split and midpoint measures (Eq 15-24 to 15-34)
+
+```
+Equation 15-24:  NumHV = v_d * HV%/100
+Equation 15-25:  PropFlowRate_FL = 0.92183 - 0.05022*ln(v_d) - 0.00030*NumHV
+Equation 15-26:  FlowRate_FL = v_d * PropFlowRate_FL
+Equation 15-27:  FlowRate_SL = v_d * (1 - PropFlowRate_FL)
+  NumHV = number of heavy vehicles entering the passing lane segment, veh
+  v_d = demand flow rate entering the passing lane segment, veh/h
+  HV% = percentage of heavy vehicles entering the passing lane segment, %
+  PropFlowRate_FL = proportion of demand flow in the faster (passing) lane, decimal
+  FlowRate_FL, FlowRate_SL = demand flow rate in the faster/slower lane, veh/h
+Implemented in: twolanehighways/twolanehighways.rs::determine_follower_density_pl (`nhv`, `p_v_fl`, `vd_fl`, `vd_sl`)
+
+Equation 15-28:  HV%_FL = HV% * HVPropMultiplier_FL
+  HVPropMultiplier_FL = 0.4 (manual: a fixed constant, not a caller-supplied parameter — see DISCREPANCY below)
+Equation 15-29:  NumHV_SL = NumHV - (FlowRate_FL * HV%_FL/100)
+Equation 15-30:  HV%_SL = NumHV_SL / FlowRate_SL * 100
+Implemented in: twolanehighways/twolanehighways.rs::determine_follower_density_pl (`phv_fl`, `nhv_sl`, `phv_sl`)
+
+Equation 15-31:  AvgSpeedDiffAdj = 2.750 + 0.00056*v_d + 3.8521*(HV%/100)
+Implemented in: twolanehighways/twolanehighways.rs::determine_follower_density_pl (`sda`)
+
+Equation 15-32:  S_PLmid_FL = S_init_FL + AvgSpeedDiffAdj/2
+Equation 15-33:  S_PLmid_SL = S_init_SL - AvgSpeedDiffAdj/2
+  S_init_FL, S_init_SL = initial average speed in the faster/slower lane (from Step 5's equations/coefficients applied per-lane), mi/h
+Implemented in: twolanehighways/twolanehighways.rs::determine_follower_density_pl (`s_mid_fl`, `s_mid_sl`)
+
+Equation 15-34:  FD_PLmid = (PF_PLmid_FL/100 * FlowRate_FL/S_PLmid_FL + PF_PLmid_SL/100 * FlowRate_SL/S_PLmid_SL) / 2
+  FD_PLmid = follower density at the passing-lane segment midpoint, followers/mi/ln
+  PF_PLmid_FL, PF_PLmid_SL = percent followers in each lane at the segment midpoint, % (from Step 6's equations applied per-lane)
+Implemented in: twolanehighways/twolanehighways.rs::determine_follower_density_pl (`fd_mid = (pf_fl*vd_fl/s_mid_fl + pf_sl*vd_sl/s_mid_sl) / 200.0` — dividing by 200 instead of 100-then-2 is algebraically identical since PF is stored as a 0-100 percent, not a 0-1 decimal)
+```
+
+`determine_follower_density_pl` implements Eq 15-24 through 15-34 in full: it computes `NumHV`, splits flow via `PropFlowFL`, computes each lane's HV% via Eq 15-28 to 15-30, calls `estimate_average_speed_sf`/`estimate_percent_followers_sf` per lane (applying Step 5/6's coefficient tables with the PL-specific flow and HV% for each lane, subsegment-length-weighted if the segment has curve subsegments), computes the speed-differential adjustment (`sda`, Eq 15-31), the midpoint lane speeds (Eq 15-32/15-33), and finally `fd_mid` (Eq 15-34). It also calls `determine_follower_density_pc_pz` internally to populate the ordinary endpoint `fd` alongside `fd_mid`, so both are available for Step 10/11 (Step 10 picks `fd_mid` when `passing_type == 2`, `fd` otherwise — see `determine_segment_los`).
+
+**DISCREPANCY:** Eq 15-28 defines `HVPropMultiplier_FL` as a **fixed constant, 0.4**, not a tunable input. The code instead reads it from `self.pmhvfl.unwrap_or(0.0)` — a facility-level `Option<f64>` field the caller must supply, defaulting to **0.0** (not the manual's 0.4) when omitted. A caller who doesn't set `pmhvfl` gets `phv_fl = 0.0` for every PL segment (i.e., the faster lane is modeled as having zero heavy vehicles regardless of the facility's actual heavy-vehicle mix), rather than the manual's fixed 40% allocation. The field's own doc comment ("Proportion of heavy vehicles using the faster/passing lane (for PL segments). Used in Equation 15-28 for passing lane analysis.") documents it as a real facility input rather than flagging that the manual treats this as a constant, so this is a modeling deviation, not just a doc gap.
+
+### Step 8 detail (PC/PZ path): follower density (Eq 15-35)
+
+```
+Equation 15-35:  FD = (PF/100) * v_d / S
+  FD = follower density, followers/mi/ln
+  PF = percent followers, %
+  v_d = demand flow rate, veh/h
+  S = average speed, mi/h
+Implemented in: twolanehighways/twolanehighways.rs::determine_follower_density_pc_pz
+```
+
+Code computes `fd = (pf * vd) / (100.0 * s)`, algebraically identical to `(PF/100)*v_d/S` since `pf` is stored as a 0-100 percent.
+
+### Step 9 detail: adjustment for downstream-of-passing-lane segments (Eq 15-36 to 15-38) — citation resolved this pass
+
+The previous revision of this document flagged `determine_adjustment_to_follower_density` as carrying no HCM equation-number comments and guessed the source was Eq 15-30 to 15-33. **That guess was wrong.** Cross-checking the EPUB directly (`104_Ch15_03.xhtml`), Eq 15-30 is actually the last of the *Step 7b heavy-vehicle-split* equations (`HV%_SL`, now cited above as part of the Eq 15-24 to 15-34 block), and Eq 15-31 to 15-33 are the *speed-differential/midpoint-speed* equations (also cited above). The manual's own "Step 9: Determine Potential Adjustment to Follower Density" section is headed explicitly by "Equation 15-36 through Equation 15-38 are used to both determine the passing lane's effective length and the improvement in performance measures in downstream segments within the effective length":
+
+```
+Equation 15-36:  %ImprovePF = max(0, 27 - 8.75*ln(max(0.1, DownstreamDistance)) + 0.1*max(0, PF-30) + 3.5*ln(max(0.3, PassLaneLength)) - 0.01*FlowRate)
+Equation 15-37:  %ImproveS  = max(0, 3 - 0.8*DownstreamDistance + 0.1*max(0, PF-30) + 0.75*PassLaneLength - 0.005*FlowRate)
+Equation 15-38:  FD_adj = (PF/100) * (1 - %ImprovePF/100) * FlowRate / (S * (1 + %ImproveS/100))
+  DownstreamDistance = distance downstream from the start of the passing lane segment, mi
+  PassLaneLength = length of the passing-lane segment, mi
+  PF, FlowRate = per the manual's rule, use the values entering the passing lane segment when solving for effective length, and the analysis segment's own PF/FlowRate when computing FD_adj downstream
+  S = average speed for the analysis segment, mi/h
+  FD_adj = adjusted follower density for a segment downstream of a passing lane, followers/mi/ln
+Implemented in: twolanehighways/twolanehighways.rs::determine_adjustment_to_follower_density
+```
+
+`determine_adjustment_to_follower_density` implements this in two branches. When the segment being analyzed (`seg_num`) is itself the Passing Lane segment (`pass_type == 2`), it solves Eq 15-36/15-37 for the effective length `l_de` — the distance downstream at which `%ImprovePF` reaches zero (`l_de_1 = exp(y_1a/8.75)`) or follower density recovers to 95% of the level entering the passing lane (`l_de_2`), taking whichever is shorter, matching the manual's "whichever of these two distances is shorter is taken as the effective length" rule; `x_2`, `x_3a`/`x_3b`, `x_4a`/`x_4b` are the `0.1*max(0,PF-30)`, `3.5*ln(max(0.3,PassLaneLength))`/`0.75*PassLaneLength`, and `0.01*FlowRate`/`0.005*FlowRate` terms of Eq 15-36/15-37 respectively. For downstream non-PL segments within that effective length (`l_d < self.l_de`), the code evaluates Eq 15-36 through 15-38 directly with `DownstreamDistance = l_d` (the accumulated length from the passing lane's start): `x_1a = 8.75*ln(max(0.1,l_d))`, `x_1b = 0.8*l_d`, and the resulting `y_1b`/`y_2b`/`fd_adj` expressions line up term-for-term with Eq 15-36/15-37/15-38 using the *analysis segment's* own `pf`/`vd`, matching the manual's rule for `FD_adj` exactly.
+
+One nuance worth a reviewer's attention, extending the existing TODO in the code: `pl_loc` is found by scanning **all** segments in the facility (`for s_num in 0..seg_len`) and taking the last one with `passing_type == 2`, not the nearest passing lane strictly upstream of `seg_num` — the existing `// TODO: if there are more than three PL section` comment already flags that only one PL location is tracked at all. Additionally, `vd_u` (the flow rate "entering the passing lane segment," per the manual's definition) is read from `self.segments[seg_num - 1]` rather than `self.segments[pl_loc - 1]`; these coincide only when `seg_num == pl_loc` (i.e., in the branch where the current segment is itself the PL segment, which is exactly the situation where this line executes), so it happens to be correct in the one branch that reads it, but is worth flagging as fragile if the method's branching is ever restructured.
+
+## Step 10 and Step 11 (unchanged from prior verification)
+
+Step 10 (`determine_segment_los`, Exhibit 15-6) and Step 11 (`determine_facility_los`, Eq 15-39) were not part of this pass's re-verification scope beyond confirming their equation citations are still accurate; the Eq 15-39 form is:
+
+```
+Equation 15-39:  FD_F = Sum_i(FD_i * L_i) / Sum_i(L_i)
+  FD_F = average follower density for the facility in the analysis direction, followers/mi/ln
+  FD_i = follower density (or adjusted follower density) for segment i, followers/mi/ln
+  L_i = actual segment length for segment i, mi (Step 1 min/max constraints do not apply to this sum)
+Implemented in: twolanehighways/twolanehighways.rs::determine_facility_los (caller supplies the pre-computed length-weighted fd; the summation itself is done by the caller, not inside this method)
+```
 
 ## Bicycle LOS methodology (Section 4)
 
@@ -53,25 +275,71 @@ One inline comment is a live author TODO worth the reviewer's direct attention: 
 | LOS lookup | Exhibit 15-7 | `determine_bicycle_los` | `twolanehighways.rs` | BLOS score | LOS char `'A'..'F'`, thresholds ≤1.5/2.5/3.5/4.5/5.5 |
 | Convenience wrapper | — | `analyze` | `twolanehighways.rs` | `&self` | `BicycleLOSResult { flow_rate_outside_lane, effective_width, effective_speed_factor, blos_score, los }` |
 
-`calculate_effective_width` implements the three shoulder-width branches exactly as printed: Eq 15-41 (`Ws >= 8`): `We = Wv + Ws - %OHP*10`; Eq 15-42 (`4 <= Ws < 8`): `We = Wv + Ws - 2*[%OHP*(2 + Ws)]`; Eq 15-43 (`Ws < 4`): `We = Wv - %OHP*(2 + Ws)`; with `calculate_wv()` returning `W_OL + Ws` when per-lane volume exceeds 160 veh/h (Eq 15-44) and `(W_OL + Ws)*(2 - 0.005V)` otherwise (Eq 15-45). This was corrected against the manual and verified against the HCM Chapter 26 widening worked example (current We = 14 ft, proposed We = 24 ft; see Validation). `calculate_blos_score` clamps `heavy_vehicle_pct` to a maximum of 0.5 when `hourly_volume < 200.0` per the Eq 15-47 note in the manual, and guards `ln(v_ol)` against a non-positive argument by substituting `0.0` (defensive addition, not manual text).
+This section's equations and Exhibit 15-11 (above) were the two areas flagged as recently corrected in code and were re-verified fresh against the current `twolanehighways.rs` and the EPUB (`105_Ch15_04.xhtml`), not assumed from the prior revision of this document. All four bicycle equations match the manual exactly, with no discrepancies found.
+
+```
+Equation 15-40:  v_OL = V / (PHF * N)
+  v_OL = directional demand flow rate in the outside lane, veh/h
+  V = hourly directional volume, veh/h
+  PHF = peak hour factor, decimal
+  N = number of directional lanes (= 1 for two-lane highways)
+Implemented in: twolanehighways/twolanehighways.rs::calculate_flow_rate_outside_lane
+
+Equation 15-41 (Ws >= 8 ft):  We = Wv + Ws - (%OHP * 10 ft)
+Equation 15-42 (4 ft <= Ws < 8 ft):  We = Wv + Ws - 2*[%OHP*(2 ft + Ws)]
+Equation 15-43 (Ws < 4 ft):  We = Wv - [%OHP*(2 ft + Ws)]
+  We = average effective width of the outside through lane, ft
+  Wv = effective width as a function of traffic volume, ft, from Eq 15-44/15-45
+  Ws = paved shoulder width, ft
+  %OHP = percentage of segment with occupied on-highway parking, decimal
+Implemented in: twolanehighways/twolanehighways.rs::calculate_effective_width
+
+Equation 15-44 (V > 160 veh/h per lane):  Wv = W_OL + Ws
+Equation 15-45 (V <= 160 veh/h per lane):  Wv = (W_OL + Ws) * (2 - 0.005*V)
+  W_OL = outside lane width, ft
+  V = hourly directional volume per lane, veh/h
+Implemented in: twolanehighways/twolanehighways.rs::calculate_effective_width (private helper calculate_wv)
+
+Equation 15-46:  St = 1.1199*ln(Spl - 20) + 0.8103
+  St = effective speed factor, unitless
+  Spl = posted speed limit, mi/h
+Implemented in: twolanehighways/twolanehighways.rs::calculate_effective_speed_factor
+
+Equation 15-47:  BLOS = 0.507*ln(v_OL) + 0.1999*St*(1 + 10.38*HV)^2 + 7.066*(1/P)^2 - 0.005*(We)^2 + 0.760
+  BLOS = bicycle level-of-service score
+  v_OL = directional demand flow rate in the outside lane, veh/h
+  St = effective speed factor (Eq 15-46)
+  HV = proportion of heavy vehicles, decimal; if V < 200 veh/h, HV is limited to a maximum of 0.5
+  P = FHWA's 5-point pavement surface condition rating (1-5)
+  We = average effective width of the outside through lane, ft (Eq 15-41 to 15-45)
+Implemented in: twolanehighways/twolanehighways.rs::calculate_blos_score
+```
+
+`calculate_effective_width` implements the three shoulder-width branches exactly as printed in Eq 15-41 to 15-43, with `calculate_wv()` returning `W_OL + Ws` when per-lane volume exceeds 160 veh/h (Eq 15-44) and `(W_OL + Ws)*(2 - 0.005V)` otherwise (Eq 15-45) — all coefficients and branch thresholds confirmed against the EPUB verbatim. This was previously corrected against the manual and verified against the HCM Chapter 26 widening worked example (current We = 14 ft, proposed We = 24 ft; see Validation). `calculate_blos_score`'s formula was checked term-for-term against Eq 15-47 in the EPUB (`0.507*ln(v_OL) + 0.1999*St*(1+10.38*HV)^2 + 7.066*(1/P)^2 - 0.005*(We)^2 + 0.760`) and matches exactly, including the exact coefficients `0.1999`, `10.38`, `7.066`, `0.005`, and `0.760`. It clamps `heavy_vehicle_pct` to a maximum of 0.5 when `hourly_volume < 200.0` per the Eq 15-47 note in the manual (`HV should be limited to a maximum of 0.5` when `V < 200 veh/h`), and guards `ln(v_ol)` against a non-positive argument by substituting `0.0` (defensive addition, not manual text).
+
+Exhibit 15-11's vertical-alignment table (used by the motorized methodology, Step 3 above) was likewise re-verified fresh this pass rather than trusted from the prior revision — see "Step 3 detail" above for the row-by-row confirmation.
 
 ## Unit footguns
 
 Two unit conventions are easy to get backwards and are not enforced by the type system (both fields are plain `f64`/`Option<f64>`):
 
 - **`Segment.spl` is the *posted* speed limit** (mi/h), and Step 4's base free-flow speed is `BFFS = 1.14 * spl` (`determine_free_flow_speed`, and duplicated inline in `estimate_average_speed` as `bffs = round_to_significant_digits(1.14 * spl, 3)` and again in `estimate_average_speed_sf` as `bffs = 1.14 * spl`) — i.e., **BFFS is derived, not itself a stored/settable field**; passing an already-adjusted FFS-like value as `spl` will silently double-inflate BFFS by 14%.
-- **`SubSegment.length` is in FEET**, while **`Segment.length` is in MILES** — both are documented correctly in the field doc comments (`/// Length of subsegment, ft.` vs. `/// Length of segment, mi.`), and the conversion is applied consistently at each subsegment read site (`get_length() / 5280.0` in `estimate_average_speed` and `determine_follower_density_pl`). However, the Python binding's constructor docstring in `src/copython/chapter15.rs` (`SubSegment::new`) says *"length: Length of the sub-segment in miles (default: 0.0)"* — **that docstring is wrong**; the Rust-side field comment and every use site treat it as feet. A Python caller following the PyO3 docstring would pass miles and get a value 5,280× too small once divided by 5280.0 downstream. This is a genuine deviation between the Python-facing documentation and the Rust implementation, worth the reviewer's attention independent of anything else in this document.
+- **`SubSegment.length` is in FEET**, while **`Segment.length` is in MILES** — both are documented correctly in the field doc comments (`/// Length of subsegment, ft.` vs. `/// Length of segment, mi.`), and the conversion is applied consistently at each subsegment read site (`get_length() / 5280.0` in `estimate_average_speed` and `determine_follower_density_pl`). The Python binding's constructor docstring in `src/copython/twolanehighways.rs` (`SubSegment::new`) previously stated the length was in miles, which contradicted the Rust field and every use site; **this has been fixed** — the docstring now reads "Length of the sub-segment in FEET (default: 0.0). Note: unlike Segment.length (miles), sub-segment lengths are in feet; the engine divides by 5,280 internally." (checked directly in the current `src/copython/twolanehighways.rs`, which itself is the renamed file — it was previously `src/copython/chapter15.rs`).
 - **`Segment.is_hc` gates whether horizontal-class/curve data is used at all.** Supplying `subsegments` with real `design_rad`/`sup_ele` data but leaving `is_hc` at its default (`false`, via `get_is_hc()`'s `unwrap_or(false)`) means Step 5 silently falls back to the tangent-only `calc_speed` path and never reads the subsegment curve data — there is no warning or error, the curve data is simply inert.
 
 ## Deviations
 
-No `docs/hcm/VERIFICATION.md` exists on this branch to cross-reference (checked via `git ls-tree -r feat/hcm-restructure`), so the deviations below are called out inline rather than cross-referenced to an existing ledger entry:
+No `docs/hcm/VERIFICATION.md` exists to cross-reference, so the deviations below are called out inline rather than cross-referenced to an existing ledger entry:
 
-1. Step 3 (`determine_vertical_alignment`) has a missing length bucket (`0.5 < length <= 0.6` mi, upgrade branch) — see "Step 3 detail" above.
-2. Step 9 (`determine_adjustment_to_follower_density`) has no HCM equation-number comments, unlike every other step, and only tracks one upstream passing-lane location (`// TODO: if there are more than three PL section`).
-3. `calc_speed`'s horizontal-curve speed cap carries a live author doubt comment, `// Should be ST instead of S?`.
-4. The `copython::chapter15::SubSegment::new` PyO3 docstring states subsegment length is in miles; the Rust implementation and field doc comment say feet.
-6. `TwoLaneHighways.apd` field doc comment says "default: 0" but `determine_free_flow_speed` reads `self.apd.unwrap_or(5.0)` — a 5.0-points/mi default, not 0, is used whenever `apd` is `None`. (Noted in `architecture.md` as well since it's a doc/code mismatch rather than an HCM-fidelity issue.)
+1. ~~Step 3 (`determine_vertical_alignment`) has a missing length bucket~~ **Fixed in code and re-verified against Exhibit 15-11 this pass — no longer a live deviation.** See "Step 3 detail" above; the current code matches the manual's vertical-class table exactly for every length bin and grade column, including the two rows where the manual itself skips a class.
+2. Step 9 (`determine_adjustment_to_follower_density`) still has no HCM equation-number comments in the code itself, unlike every other step, but **this document now confirms the source is Eq 15-36 to 15-38** (not Eq 15-30 to 15-33 as previously guessed) — see "Step 9 detail" above. It also still only tracks one upstream passing-lane location (`// TODO: if there are more than three PL section`), and this pass additionally found that `vd_u` is read from `segments[seg_num-1]` rather than `segments[pl_loc-1]`, which only coincide in the branch where they're currently used.
+3. `calc_speed`'s horizontal-curve speed cap carries a live author doubt comment, `// Should be ST instead of S?` — **checked against the manual this pass and the code's use of `s` appears correct** (there is no separately defined "S_T" term in Eq 15-12; the manual's own prose confirms the tangent-computed "S" from Eq 15-7 is meant to cap the curve speed, and that is exactly what `s` already equals at that point in the code). See "Step 5 detail" above. The comment itself was left in place since this task's scope excludes code changes.
+4. The `copython::twolanehighways::SubSegment::new` PyO3 docstring previously stated subsegment length is in miles, contradicting the Rust implementation and field doc comment (feet). **This has been fixed** in the current code (file also renamed from `chapter15.rs` to `twolanehighways.rs`).
+5. Four small coefficient transcription errors were found this pass, all differing from the manual only in a trailing digit or two: Exhibit 15-14 (`Eq 15-8`, PL, vc 2) `b0 = -2.0668` vs. manual `-2.0688`; Exhibit 15-24 (`Eq 15-18`, PC/PZ, vc 1) `b7 = 7.13760` vs. manual `7.13758`; Exhibit 15-26 (`Eq 15-20`, PC/PZ, vc 1) `c7 = 11.60410` vs. manual `11.60405`; Exhibit 15-27 (`Eq 15-21`, PL, vc 2) `c6 = 0.77127` vs. manual `0.77217`. See the `**DISCREPANCY:**` markers in "Step 4/5/6 detail" above.
+6. Exhibit 15-5's `≥5% <10%` heavy-vehicle capacity bracket has a no-op `if`/`else` in `determine_demand_flow` that always returns 1,500 veh/h regardless of vertical class, when the manual specifies 1,400 veh/h for vertical class 5 in that bracket. See "Step 2 detail" above.
+7. `HVPropMultiplier_FL` (Eq 15-28) is a fixed 0.4 constant in the manual but is exposed as a caller-supplied `pmhvfl` field defaulting to 0.0 in code — a real modeling deviation, not just a doc-comment mismatch. See "Step 7-8 detail" above.
+8. `TwoLaneHighways.apd` field doc comment says "default: 0" but `determine_free_flow_speed` reads `self.apd.unwrap_or(5.0)` — a 5.0-points/mi default, not 0, is used whenever `apd` is `None`. (Noted in `architecture.md` as well since it's a doc/code mismatch rather than an HCM-fidelity issue.)
+9. `Segment::get_phf()` defaults to `0.95` when `phf` is `None`, but the module's own `# Base Conditions (Exhibit 15-8)` doc comment lists the base-condition PHF as `0.94`. Same class of doc/code default mismatch as item 8.
 
 ## Validation
 
@@ -82,5 +350,6 @@ No `docs/hcm/VERIFICATION.md` exists on this branch to cross-reference (checked 
 ## Deferred
 
 - No test in this branch reproduces a full HCM 7th Edition worked example end-to-end with published intermediate values cited by page/exhibit number in the test itself — the `case*.json` fixtures' provenance (whether they are transcribed from a specific manual example) is not documented in the test files or fixture directory.
-- Step 9's uncited equations and the `// Should be ST instead of S?` comment are flagged above but not resolved here — resolving them requires the manual, which is outside this documentation task's scope.
-- The `apd` default mismatch (item 6 above) is reported, not fixed.
+- Step 9's equation citation is now resolved (Eq 15-36 to 15-38, see above); the `// Should be ST instead of S?` comment is now checked and appears to be unfounded doubt rather than a bug (see Deviations item 3). Neither required a code change, so both remain as-is in the source.
+- The five coefficient-table `**DISCREPANCY**` items (Deviations 5) and the capacity-bracket no-op (Deviations 6) and the `pmhvfl`/`HVPropMultiplier_FL` deviation (Deviations 7) are reported, not fixed — each is small in isolation but the capacity-bracket and `pmhvfl` items can change actual LOS/capacity outputs for PL segments, unlike the pure coefficient-rounding items.
+- The `apd` and `phf` default mismatches (Deviations 8-9) are reported, not fixed.

--- a/docs/hcm/procedures/chapter16.md
+++ b/docs/hcm/procedures/chapter16.md
@@ -1,6 +1,6 @@
 # HCM Chapter 16 — Urban Street Facilities, Motorized Vehicle Methodology
 
-This document walks through the Rust translation of HCM 7th Edition Chapter 16, Section 3 ("Motorized Vehicle Mode," EPUB `112_Ch16_03.xhtml`), which aggregates the per-segment Chapter 18 measures of an ordered sequence of segments in one direction of travel into facility-level base free-flow speed, travel speed, spatial stop rate, LOS, and a facility-wide automobile traveler perception score. LOS criteria (Exhibit 16-3) are transcribed from `111_Ch16_02.xhtml`. The code lives entirely in `src/hcm/chapter16/urban_facilities.rs`, which re-uses the Chapter 18 `UrbanSegment` engine and LOS/perception-score helpers directly (`crate::hcm::chapter18::exhibits::exhibit_18_1_los`, `crate::hcm::chapter18::urban_segments::{traveler_perception_score, through_capacity_uncontrolled, UrbanSegment}`) rather than re-implementing them, since Exhibit 16-3's travel-speed thresholds are, per the module doc comment, "value-for-value identical" to Chapter 18's Exhibit 18-1, and Chapter 16 Equation 16-1 is identical to Chapter 18 Equation 18-2.
+This document walks through the Rust translation of HCM 7th Edition Chapter 16, Section 3 ("Motorized Vehicle Mode," EPUB `112_Ch16_03.xhtml`), which aggregates the per-segment Chapter 18 measures of an ordered sequence of segments in one direction of travel into facility-level base free-flow speed, travel speed, spatial stop rate, LOS, and a facility-wide automobile traveler perception score. LOS criteria (Exhibit 16-3) are transcribed from `111_Ch16_02.xhtml`. The code lives entirely in `src/hcm/urban_facilities/urban_facilities.rs`, which re-uses the Chapter 18 `UrbanSegment` engine and LOS/perception-score helpers directly (`crate::hcm::urban_segments::exhibits::exhibit_18_1_los`, `crate::hcm::urban_segments::urban_segments::{traveler_perception_score, through_capacity_uncontrolled, UrbanSegment}`) rather than re-implementing them, since Exhibit 16-3's travel-speed thresholds are, per the module doc comment, "value-for-value identical" to Chapter 18's Exhibit 18-1, and Chapter 16 Equation 16-1 is identical to Chapter 18 Equation 18-2.
 
 ## Step-by-step walkthrough
 
@@ -9,13 +9,90 @@ This document walks through the Rust translation of HCM 7th Edition Chapter 16, 
 | Step 1 — Facility base free-flow speed | Eq. 16-2, `S_fo,F = ΣL_i / Σ(L_i/S_fo,i)` | `facility_base_ffs` (thin wrapper over `length_weighted_harmonic_mean`) | `urban_facilities.rs` | `&[(f64, f64)]` per-segment `(L_i ft, S_fo,i mi/h)` pairs | `S_fo,F` (mi/h) |
 | Step 2 — Facility travel speed | Eq. 16-3, `S_T,F = ΣL_i / Σ(L_i/S_T,seg,i)` | `facility_travel_speed` (same `length_weighted_harmonic_mean` helper) | `urban_facilities.rs` | `&[(f64, f64)]` per-segment `(L_i ft, S_T,seg,i mi/h)` pairs | `S_T,F` (mi/h) |
 | Step 3 — Facility spatial stop rate | Eq. 16-4, `H_F = Σ(H_seg,i L_i) / ΣL_i` | `facility_spatial_stop_rate` | `urban_facilities.rs` | `&[(f64, f64)]` per-segment `(L_i ft, H_seg,i stops/mi)` pairs | `H_F` (stops/mi); `None` unless every segment reports a stop rate |
-| (Step 3, continued) — Facility perception score | Ch. 18 Eqs. 18-17..18-22, with `H_F`/facility-wide P_LTL substituted | `traveler_perception_score` (re-used from `chapter18::urban_segments`) | `chapter18/urban_segments.rs` (called from `aggregate_segment_summaries`) | `H_F` (stops/mi), `prop_left_turn_lanes` (P_LTL, decimal) | `perception_score` (dimensionless), `None` unless both inputs present |
+| (Step 3, continued) — Facility perception score | Ch. 18 Eqs. 18-17..18-22, with `H_F`/facility-wide P_LTL substituted | `traveler_perception_score` (re-used from `urban_segments::urban_segments`) | `urban_segments/urban_segments.rs` (called from `aggregate_segment_summaries`) | `H_F` (stops/mi), `prop_left_turn_lanes` (P_LTL, decimal) | `perception_score` (dimensionless), `None` unless both inputs present |
 | Step 4 — LOS | Exhibit 16-3 (= Exhibit 18-1) with the critical v/c footnote | `exhibit_16_3_los` (delegates to `exhibit_18_1_los`) | `urban_facilities.rs` | `travel_speed_mph` (S_T,F), `base_ffs_mph` (S_fo,F), `critical_vc_gt_1: bool` | `LevelOfService` |
 | Step 4, continued — Critical v/c and poorest-segment report | Exhibit 16-3 footnote; Chapter 16 Step 4 discussion | `aggregate_segment_summaries` (critical-v/c fold and `los_rank`-ordered poorest-segment fold) | `urban_facilities.rs` | per-segment `vc_ratio: Option<f64>`, `los: Option<LevelOfService>` | `critical_vc_ratio: Option<f64>` (max across segments), `poorest_segment_los: Option<LevelOfService>` |
 
 `aggregate_segment_summaries(segments: &[SegmentSummary], prop_left_turn_lanes: Option<f64>) -> Result<FacilityResults, String>` is the single function implementing Steps 1-4 together; it validates that every segment has positive length and positive base/travel speeds, then runs Equations 16-2 through 16-4 and the LOS/perception-score logic described above. `SegmentSummary` is the Exhibit 16-7 "HCM method output" input record (`length_ft`, `base_ffs_mph`, `travel_speed_mph`, `spatial_stop_rate_stops_mi: Option<f64>`, `vc_ratio: Option<f64>`, `los: Option<LevelOfService>`) — it can be supplied directly (e.g., published example-problem values) or produced by `UrbanFacility::segment_summaries()` from already-analyzed Chapter 18 `UrbanSegment`s. `FacilityResults` additionally carries `length_ft` (ΣL_i, ft), `travel_time_s` and `base_free_flow_travel_time_s` (both `3,600 L/(5,280 S)`, s, computed directly in `aggregate_segment_summaries` rather than being separately-numbered HCM equations).
 
 `UrbanFacility` (the top-level struct, `segments: Vec<UrbanSegment>`, `prop_left_turn_lanes: Option<f64>`, `spillback_inputs: Option<Vec<SpillbackCheckInput>>`) exposes two entry points: `analyze()`, which runs every segment's Chapter 18 `analyze()` first and then aggregates, and `aggregate()`, which aggregates already-computed segment measures without re-running Chapter 18 (for when per-segment measures were supplied directly, e.g. `case1.json`/`case2.json` below). `spatial_stop_rate` is only computed when every segment in the facility reports a stop rate, per the code comment "a partial aggregation would misstate the facility value" — this is a code-level completeness guard, not a separate HCM rule.
+
+### Step equations in full
+
+#### Step 1 — Facility base free-flow speed
+
+```
+Equation 16-2:  S_fo,F = Σ(i=1→m) L_i / Σ(i=1→m) (L_i / S_fo,i)     [mi/h]
+  L_i    = length of segment i                                      (ft)
+  m      = number of segments on the facility
+  S_fo,i = base free-flow speed for segment i                       (mi/h)
+Implemented in: urban_facilities/urban_facilities.rs::facility_base_ffs
+```
+
+This is the length-weighted harmonic mean of the segment base free-flow speeds (equivalently, total facility length divided by the total travel time at the base free-flow speed); the shared helper `length_weighted_harmonic_mean` computes both Equation 16-2 and Equation 16-3.
+
+#### Step 2 — Facility travel speed
+
+```
+Equation 16-3:  S_T,F = Σ(i=1→m) L_i / Σ(i=1→m) (L_i / S_T,seg,i)   [mi/h]
+  S_T,F     = travel speed for the facility                         (mi/h)
+  L_i       = length of segment i                                   (ft)
+  m         = number of segments on the facility
+  S_T,seg,i = travel speed of through vehicles for segment i         (mi/h)
+Implemented in: urban_facilities/urban_facilities.rs::facility_travel_speed
+```
+
+#### Step 3 — Facility spatial stop rate and perception score
+
+```
+Equation 16-4:  H_F = Σ(i=1→m) (H_seg,i · L_i) / Σ(i=1→m) L_i        [stops/mi]
+  H_F     = spatial stop rate for the facility                      (stops/mi)
+  H_seg,i = spatial stop rate for segment i                         (stops/mi)
+  L_i     = length of segment i                                     (ft)
+  m       = number of segments on the facility
+Implemented in: urban_facilities/urban_facilities.rs::facility_spatial_stop_rate
+```
+
+`H_F` is computed only when every segment reports a stop rate (a code-level completeness guard, not a separate HCM rule, per the note above). When it is available, Chapter 16's text directs that "the equations in Step 10, Section 3, of Chapter 18" (Equations 18-17 through 18-22) be reused with `H_F` substituted for `H_seg` and a facility-wide `P_LTL` substituted for `P_LTL,seg`:
+
+```
+Equations 18-17..18-22 (facility-substituted):
+  I_a,F = 1 + P_BCDEF + P_CDEF + P_DEF + P_EF + P_F                  [dimensionless]
+  P_x   = (1 + e^(a_x − 0.253·H_F + 0.3434·P_LTL))⁻¹
+  a_x   = −1.1614, 0.6234, 1.7389, 2.7047, 3.8044 for x = BCDEF, CDEF, DEF, EF, F respectively
+  H_F   = facility spatial stop rate (Equation 16-4)                 (stops/mi)
+  P_LTL = facility-wide proportion of intersections with a left-turn lane (or bay)  (decimal)
+Implemented in: urban_facilities/urban_facilities.rs::aggregate_segment_summaries (calls urban_segments/urban_segments.rs::traveler_perception_score with H_F and the facility-wide P_LTL substituted for H_seg and P_LTL,seg)
+```
+
+#### Step 4 — Through-movement capacity, critical v/c, and LOS
+
+Equation 16-1 supplies the through-movement capacity input (for the v/c ratio in `SegmentSummary::vc_ratio`) when the downstream boundary intersection is a two-way STOP-controlled intersection and the through movement is uncontrolled — Chapter 20 does not otherwise provide a capacity procedure for that movement:
+
+```
+Equation 16-1:  c_th = 1,800 · (N_th − 1 + p*_0,j)                   [veh/h]
+  c_th   = through-movement capacity                                 (veh/h)
+  N_th   = number of through lanes, shared or exclusive               (ln)
+  p*_0,j = probability that there will be no queue in the inside through lane (dimensionless);
+           equal to 1.0 if a left-turn bay is provided for left turns from the major street,
+           otherwise computed per Chapter 20's queue-free-probability procedure
+  1,800  = HCM default saturation flow rate per lane assumption        (veh/h/ln)
+Implemented in: urban_facilities/urban_facilities.rs::through_capacity_uncontrolled (re-exported from urban_segments/urban_segments.rs::through_capacity_uncontrolled, Equation 18-2 — identical form)
+```
+
+The `p*_0,j` computation itself (Chapter 20's queue-free-probability procedure) is Chapter 18/20 territory and is not re-documented here; see `docs/hcm/VERIFICATION.md`'s Chapter 18 section for the HCM6/HCM7 equation-numbering note on that citation ("Eq 20-43" vs. Eqs 20-29..20-34).
+
+LOS itself (Exhibit 16-3) is a table lookup, not an equation — its travel-speed thresholds by base free-flow speed are value-for-value identical to Chapter 18's Exhibit 18-1 (already transcribed as `exhibit_18_1_los`), so only the critical v/c footnote logic is new at the facility level:
+
+```
+Exhibit 16-3 footnote (critical v/c rule):
+  vc_crit = max(i=1→m) { vc_ratio_i }                                 [dimensionless]
+  LOS = F  if vc_crit > 1.0, else per Exhibit 16-3 travel-speed thresholds
+  vc_ratio_i = through-movement v/c ratio at segment i's downstream boundary intersection (dimensionless)
+Implemented in: urban_facilities/urban_facilities.rs::aggregate_segment_summaries (critical_vc fold) and urban_facilities/urban_facilities.rs::exhibit_16_3_los (delegates to urban_segments/exhibits.rs::exhibit_18_1_los)
+```
+
+Chapter 16 Step 4 also directs reporting the poorest-performing segment's own LOS for context; that is a simple max-over-`los_rank` fold with no HCM equation number, implemented in `urban_facilities/urban_facilities.rs::aggregate_segment_summaries` alongside the critical-v/c fold.
 
 ### Spillback check (queue-storage-ratio hook)
 
@@ -29,7 +106,7 @@ Fixtures live under `tests/ExampleCases/hcm/UrbanFacilities/` as `case1.json`, `
 
 `case3.json` instead drives the full Chapter 18 pipeline (`analyze()`) over three identical copies of the Chapter 30, Example Problem 1 eastbound segment (documented in `chapter18.md`), so the facility-level aggregation of three identical segments must reproduce that segment's own published Exhibit 30-36 values exactly: `test_case3_chapter18_driven_facility` asserts base FFS 40.78 mi/h (±0.02), travel speed 23.67 mi/h (±0.02), spatial stop rate 1.61 stops/mi (±0.02), critical v/c 0.52 (±0.005, `= 968/1848`), LOS C, and poorest-segment LOS C. This test also contains the length-weighted-speed cross-check the task calls out: it independently recomputes `Σ L_i / Σ (L_i/S_T,seg,i)` from the analyzed segments' own `segment_length_ft`/`travel_speed_mph` fields and asserts the facility's `travel_speed_mph` matches that identity to 1e-12 — i.e., that `aggregate_segment_summaries`'s Equation 16-3 implementation is exactly the harmonic-mean identity applied to the Chapter 18 engine's own outputs, not merely close to it. `test_round_trip` additionally confirms a JSON round-trip of a fully analyzed facility preserves the computed travel speed to 1e-12.
 
-Unit tests in `src/hcm/chapter16/tests.rs` spot-check the aggregation equations directly: `test_eq_16_2_example_problem_1_base_ffs` and `test_harmonic_aggregation` against hand-computed harmonic means, `test_eq_16_4_spatial_stop_rate` against a hand-computed length-weighted arithmetic mean, `test_exhibit_16_3_los` against the shared Exhibit 18-1 table, `test_aggregate_example_problem_1_eastbound` (a unit-level version of the case1 integration check), `test_critical_vc_rule_forces_f` and (mirrored in `tests/chapter16_integration.rs::test_case1_vc_footnote_forces_los_f`) confirming a single segment's v/c > 1.0 forces facility LOS F regardless of speed, `test_aggregate_rejects_empty_and_invalid` for the input-validation error paths, `test_facility_speed_equals_length_weighted_ch18_computation` (the unit-level counterpart of the case3 cross-check, run directly against Chapter-18-analyzed segments rather than through the JSON fixture), `test_facility_json_round_trip`, `test_spillback_check_hook`, and `test_eq_16_1_through_capacity` (confirming the re-exported Chapter 18 Equation 18-2 implementation).
+Unit tests in `src/hcm/urban_facilities/tests.rs` spot-check the aggregation equations directly: `test_eq_16_2_example_problem_1_base_ffs` and `test_harmonic_aggregation` against hand-computed harmonic means, `test_eq_16_4_spatial_stop_rate` against a hand-computed length-weighted arithmetic mean, `test_exhibit_16_3_los` against the shared Exhibit 18-1 table, `test_aggregate_example_problem_1_eastbound` (a unit-level version of the case1 integration check), `test_critical_vc_rule_forces_f` and (mirrored in `tests/chapter16_integration.rs::test_case1_vc_footnote_forces_los_f`) confirming a single segment's v/c > 1.0 forces facility LOS F regardless of speed, `test_aggregate_rejects_empty_and_invalid` for the input-validation error paths, `test_facility_speed_equals_length_weighted_ch18_computation` (the unit-level counterpart of the case3 cross-check, run directly against Chapter-18-analyzed segments rather than through the JSON fixture), `test_facility_json_round_trip`, `test_spillback_check_hook`, and `test_eq_16_1_through_capacity` (confirming the re-exported Chapter 18 Equation 18-2 implementation).
 
 `tests/test_chapter16_integration.py` exercises the PyO3 bindings against `case1.json`, including its own `test_length_weighted_identity` (the Python-side counterpart of the Rust cross-check) and `test_published_values`, `test_los`, `test_json_round_trip`.
 

--- a/docs/hcm/procedures/chapter17.md
+++ b/docs/hcm/procedures/chapter17.md
@@ -1,8 +1,8 @@
 # HCM Chapter 17 — Urban Street Reliability and ATDM, Core Methodology
 
-This document walks through the Rust translation of HCM 7th Edition Chapter 17, Section 3 core methodology (EPUB `121_Ch17_03.xhtml`), together with the Chapter 29 ("Urban Street Facilities: Supplemental"), Section 2 Scenario Generation Procedure (`227_Ch29_02.xhtml`) that supplies its computational detail: weather event generation (Equations 29-1 through 29-12), traffic demand variation (Exhibits 17-5 through 17-8), traffic incident generation (Equations 29-13 through 29-24), and scenario dataset generation (Equations 29-25 through 29-36). The code lives in `src/hcm/chapter17/urban_reliability.rs` (the Monte Carlo generation stages, the inverse-distribution primitives, and the `UrbanReliability` driver) and `src/hcm/chapter17/exhibits.rs` (Exhibits 17-5 through 17-12 lookups and Equations 29-25 through 29-36). Each generated scenario (one analysis period of one day) is evaluated with the Chapter 16/18 facility engine documented in `chapter16.md`; the per-scenario facility travel times feed `crate::hcm::common::reliability::TravelTimeDistribution`, from which the Chapter 17 performance measures are computed.
+This document walks through the Rust translation of HCM 7th Edition Chapter 17, Section 3 core methodology (EPUB `121_Ch17_03.xhtml`), together with the Chapter 29 ("Urban Street Facilities: Supplemental"), Section 2 Scenario Generation Procedure (`227_Ch29_02.xhtml`) that supplies its computational detail: weather event generation (Equations 29-1 through 29-12), traffic demand variation (Exhibits 17-5 through 17-8), traffic incident generation (Equations 29-13 through 29-24), and scenario dataset generation (Equations 29-25 through 29-36). The code lives in `src/hcm/urban_reliability/urban_reliability.rs` (the Monte Carlo generation stages, the inverse-distribution primitives, and the `UrbanReliability` driver) and `src/hcm/urban_reliability/exhibits.rs` (Exhibits 17-5 through 17-12 lookups and Equations 29-25 through 29-36). Each generated scenario (one analysis period of one day) is evaluated with the Chapter 16/18 facility engine documented in `chapter16.md`; the per-scenario facility travel times feed `crate::hcm::common::reliability::TravelTimeDistribution`, from which the Chapter 17 performance measures are computed.
 
-Per the module doc comment, the HCM procedure is itself Monte Carlo ("A random number seed is used ... so that the sequence of random events can be reproduced"), and the module follows the Chapter 11 freeway-reliability implementation's convention of an in-crate seeded xorshift64* PRNG (`crate::hcm::chapter11::scenario_generation::Prng`) with three independent seeds (`weather_seed`, `demand_seed` — unused directly since demand is deterministic given the systematic ratios, `incident_seed`). Because the HCM text itself states that "evaluating the same dataset and seed number in different software ... may produce results different from those shown [in the printed examples]. Each result, though different, will be equally valid," the published Example Problem 4 outputs are verified at the distribution-band level rather than as exact values, while the deterministic sub-computations (crash frequencies, demand ratios, adjustment factors) are verified exactly.
+Per the module doc comment, the HCM procedure is itself Monte Carlo ("A random number seed is used ... so that the sequence of random events can be reproduced"), and the module follows the Chapter 11 freeway-reliability implementation's convention of an in-crate seeded xorshift64* PRNG (`crate::hcm::freeway_reliability::scenario_generation::Prng`) with three independent seeds (`weather_seed`, `demand_seed` — unused directly since demand is deterministic given the systematic ratios, `incident_seed`). Because the HCM text itself states that "evaluating the same dataset and seed number in different software ... may produce results different from those shown [in the printed examples]. Each result, though different, will be equally valid," the published Example Problem 4 outputs are verified at the distribution-band level rather than as exact values, while the deterministic sub-computations (crash frequencies, demand ratios, adjustment factors) are verified exactly.
 
 ## Step-by-step walkthrough
 
@@ -21,30 +21,266 @@ Per the module doc comment, the HCM procedure is itself Monte Carlo ("A random n
 
 `generate_weather_events` walks a 2-year (730-day) record and, per day, follows Steps 1-8 of the Chapter 29 procedure: Step 1 (Eqs. 29-1/29-2) draws whether precipitation occurs from the monthly `days_with_precip / n_days` probability; Step 2 (Eqs. 29-3/29-4) draws a daily mean temperature via `normal_inverse` (`s_T = 5.0°F` fixed, `TEMPERATURE_SD_F`) and classifies rain vs. snow at the 32°F threshold; Steps 3/7 (Eqs. 29-5 through 29-8) draw a correlated precipitation rate and total depth via two calls to `gamma_inverse` sharing the same uniform draw `r_r` (so `R_td = R_rd`, "perfectly correlated" per the code comment), with snow statistics obtained by scaling the rain statistics by `SNOW_TO_RAIN_DEPTH_RATIO`; Step 4 (Eq. 29-9) derives duration as `total/rate` capped at 24 h; Step 5 (Eq. 29-10) places a start time rounded to the 15-minute analysis-period increment; Step 6 (Eqs. 29-11/29-12) computes the wet/snow-covered pavement duration as precipitation duration plus a runoff time (`RAIN_PAVEMENT_RUNOFF_H` for rain, the analyst-configurable `snow_runoff_h` for snow) plus a drying time `0.888 e^(−0.0070 T) + 0.19·I_night` (night bonus applied for rain only). This last point is a documented deviation: the code comment states Exhibit 29-66 "reproduces the night term for rain events only (its snow rows omit it)," and the implementation follows the exhibit rather than applying the +0.19 term uniformly, cross-referenced to `docs/hcm/VERIFICATION.md`.
 
+```
+Equation 29-1:  P(precip)_m = Ndp_m / Nd_m                                                [probability, unitless]
+Equation 29-2:  No precipitation if Rp_d,m ≥ P(precip)_m;  Precipitation if Rp_d,m < P(precip)_m
+  P(precip)_m = probability of precipitation on any given day of month m                    (unitless)
+  Ndp_m       = number of days with precipitation ≥ 0.01 in. in month m, analyst input `days_with_precip` (d)
+  Nd_m        = total number of days in month m                                             (d)
+  Rp_d,m      = uniform random number (0,1) for precipitation on day d of month m            (unitless)
+Implemented in: urban_reliability/urban_reliability.rs::generate_weather_events (Step 1: p_precip, r_pd)
+```
+
+```
+Equation 29-3:  T_d,m = normal⁻¹(p = Rg_d, μ = T̄_m, σ = s_T)                               [°F]
+Equation 29-4:  Rain if T_d,m ≥ 32°F;  Snow if T_d,m < 32°F
+  T_d,m = average temperature for day d of month m                                          (°F)
+  Rg_d  = uniform random number (0,1) for temperature on day d                               (unitless)
+  T̄_m   = normal daily mean temperature in month m, analyst input `mean_temp_f`               (°F)
+  s_T   = standard deviation of daily mean temperature in a month, TEMPERATURE_SD_F = 5.0     (°F)
+  normal⁻¹(p, μ, σ) = inverse standard-normal CDF scaled to μ, σ (Acklam's rational approximation, relative error < 1.15e-9)
+Implemented in: urban_reliability/urban_reliability.rs::normal_inverse (primitive); urban_reliability/urban_reliability.rs::generate_weather_events (Step 2: temp, is_snow)
+```
+
+```
+Equation 29-5:  rr_d,m = gamma⁻¹(p = Rr_d, μ = r̄r_m, σ = s_rr,m)                            [in./h]
+Equation 29-6:  tr_d,m = gamma⁻¹(p = Rt_d, μ = t̄r_m, σ = s_tr,m)     with Rt_d = Rr_d         [in./event]
+Equation 29-7:  t̄r_m = tp_m / Ndp_m                                                          [in./event]
+  rr_d,m = rainfall rate for the rain event on day d of month m                              (in./h)
+  Rr_d   = uniform random number (0,1) for rainfall rate on day d, shared with Rt_d           (unitless — "R_td = R_rd, perfectly correlated" per code comment)
+  r̄r_m   = average precipitation rate in month m, analyst input `precip_rate_in_h`            (in./h)
+  s_rr,m = standard deviation of precipitation rate in month m (= 1.0 × r̄r_m)                 (in./h)
+  tr_d,m = total rainfall for the rain event on day d of month m                              (in./event)
+  t̄r_m   = average total rainfall per event in month m                                       (in./event)
+  tp_m   = total normal precipitation in month m, analyst input `total_precip_in`             (in.)
+  Ndp_m  = number of days with precipitation in month m, analyst input `days_with_precip`      (d)
+  s_tr,m = standard deviation of total rainfall per event in month m (Equation 29-8)           (in.)
+  gamma⁻¹(p, μ, σ) = inverse gamma CDF parameterized by mean/sd, shape α = μ²/σ², scale β = σ²/μ (bisection on the regularized lower incomplete gamma function P(α, x/β); Lanczos ln-Γ plus Numerical Recipes series/continued-fraction `gammp`)
+  Step 7 (snow): r̄r_m and t̄r_m are the rain statistics scaled by SNOW_TO_RAIN_DEPTH_RATIO = 10.0 in./in. before applying Equations 29-5/29-6/29-7 unchanged.
+Implemented in: urban_reliability/urban_reliability.rs::gamma_inverse (primitive, via ln_gamma/gamma_p); urban_reliability/urban_reliability.rs::generate_weather_events (Steps 3/7: rate_mean, rate, total_mean, total)
+```
+
+```
+Equation 29-8:  s_tr,m = min(2.5 · t̄r_m, 0.65)                                              [in.]
+  s_tr,m = standard deviation of total rainfall per event in month m                          (in.)
+  t̄r_m   = average total rainfall per event in month m (Equation 29-7)                       (in.)
+  0.65   = published cap on the rain-event standard deviation                                 (in.)
+  For snow events the code scales both terms of the min() by SNOW_TO_RAIN_DEPTH_RATIO = 10.0, i.e. `total_sd = (2.5 * total_mean).min(0.65 * depth_ratio)`, since the HCM text states only that "the equations are the same" for snow without giving a snow-specific cap (see Deviations, item 3).
+Implemented in: urban_reliability/urban_reliability.rs::generate_weather_events (total_sd)
+```
+
+```
+Equation 29-9:  dr_d,m = tr_d,m / rr_d,m                                                    [h/event]
+  dr_d,m = rainfall duration for the rain event on day d of month m, capped at 24 h           (h/event)
+  tr_d,m = total rainfall for the event (Equation 29-6)                                       (in./event)
+  rr_d,m = rainfall rate for the event (Equation 29-5)                                        (in./h)
+Implemented in: urban_reliability/urban_reliability.rs::generate_weather_events (dur)
+```
+
+```
+Equation 29-10:  ts_d,m = (24 − dr_d,m) · R_s,d                                             [h after midnight]
+  ts_d,m = start time of the weather event on day d of month m, rounded to the analysis-period increment (h)
+  dr_d,m = event duration (Equation 29-9)                                                    (h)
+  R_s,d  = uniform random number (0,1) for start time on day d                                (unitless)
+Implemented in: urban_reliability/urban_reliability.rs::generate_weather_events (start)
+```
+
+```
+Equation 29-11:  dw_d,m = dr_d,m + do_d,m + dd_d,m                                          [h/event]
+Equation 29-12:  dd_d,m = 0.888 · e^(−0.0070·T_d,m) + 0.19·I_night
+  dw_d,m  = duration of wet (or snow-covered) pavement for the event on day d of month m       (h/event)
+  dr_d,m  = precipitation duration (Equation 29-9)                                             (h/event)
+  do_d,m  = pavement runoff duration: RAIN_PAVEMENT_RUNOFF_H = 0.083 for rain; analyst-configured `snow_runoff_h` (default DEFAULT_SNOW_PAVEMENT_RUNOFF_H = 0.5) for snow  (h/event)
+  dd_d,m  = drying-time duration                                                               (h/event)
+  T_d,m   = average temperature for the day (Equation 29-3)                                    (°F)
+  I_night = 1.0 if the event starts outside 6:00 a.m.-6:00 p.m., else 0.0                       (indicator, unitless)
+  dw_d,m is truncated so the event never extends past midnight (capped against the hours remaining from the start time to 24:00).
+  (See Deviations: Exhibit 29-66's snow rows omit the +0.19 night term that its rain rows include; the implementation follows the exhibit and applies the night bonus to rain events only.)
+Implemented in: urban_reliability/urban_reliability.rs::generate_weather_events (runoff, night, drying, wet_total)
+```
+
 ### Equivalent crash frequency and incident generation (Stage 1c)
 
 `equivalent_crash_frequency_dry` implements Equation 29-13 exactly. `UrbanReliability::generate_incidents` then, per reliability-reporting-period day and hour, computes the weather-adjusted crash frequency (`fc_wea = fc_dry × CFAF_wea`, Eq. 29-15's `Fi = CFAF_str × Fc,wea / p_c`, with `crash_proportion` supplying `p_c` from Exhibit 17-11/17-12 depending on shoulder presence), the hourly Poisson rate (Eq. 29-16, `fi_hour = fi_year/8,760 × 24 f_hod × f_dow × f_moy`), and for each of the 12 `INCIDENT_TYPES` (Exhibit 17-11 row order) draws occurrence via the no-incident probability `p0 = e^(−fi_hour·p_i)` (Eqs. 29-17/29-18) and, if it occurs, a gamma-distributed duration (Eq. 29-19, mean from `default_incident_duration_min` by severity/weather, sd = `INCIDENT_DURATION_CV × mean`) truncated at midnight and rounded to the analysis-period increment. Location assignment (Eqs. 29-20 through 29-24) draws whether the incident affects the subject direction from a volume-proportional probability: for segment incidents, `v_subject/(v_subject + v_opposing)`; for intersection incidents, the major-leg share of total intersection volume (`major/(2·major + 2·minor)`), where `minor` is the analyst-configured `minor_leg_volume_veh_h` applied uniformly to both minor legs of every intersection (a simplification the code does not separately number against a specific per-intersection HCM variable).
+
+```
+Equation 29-13:  Fc_dry = Fc · 8,760 · Ny / (Nh_dry + CFAF_rf·Nh_rf + CFAF_wp·Nh_wp + CFAF_sf·Nh_sf + CFAF_sp·Nh_sp)     [crashes/yr]
+  Fc      = expected (base) crash frequency for the street location                            (crashes/yr, analyst input)
+  Fc_dry  = equivalent crash frequency if every day were dry                                    (crashes/yr)
+  8,760   = hours per year                                                                      (h/yr)
+  Ny      = number of years spanned by the weather record (= 2.0, the 2-yr record)              (yr)
+  Nh_dry  = hours of dry weather in the record                                                  (h)
+  CFAF_rf/wp/sf/sp = crash frequency adjustment factors for rainfall / wet pavement / snowfall / snow-or-ice, Exhibit 17-9 defaults (`exhibit_17_9_cfaf`: 2.0 / 3.0 / 1.5 / 2.75)  (unitless)
+  Nh_rf/wp/sf/sp   = hours of each weather condition in the record (`weather_condition_hours`)   (h)
+Implemented in: urban_reliability/urban_reliability.rs::equivalent_crash_frequency_dry
+```
+
+```
+Equation 29-14:  Fc_wea = Fc_dry · CFAF_wea                                                    [crashes/yr]
+  Fc_wea   = equivalent crash frequency for weather condition wea (CFAF_dry = 1.0)               (crashes/yr)
+  Fc_dry   = equivalent dry-weather crash frequency (Equation 29-13)                             (crashes/yr)
+  CFAF_wea = crash frequency adjustment factor for condition wea, Exhibit 17-9                   (unitless)
+Implemented in: urban_reliability/urban_reliability.rs::UrbanReliability::generate_incidents (fc_wea, via the cfaf_of closure)
+```
+
+```
+Equation 29-15:  Fi_wea = CFAF_str · Fc_wea / pc_wea                                            [incidents/yr]
+  Fi_wea   = average incident frequency for the street location and weather condition            (incidents/yr)
+  CFAF_str = crash frequency adjustment factor for an active ATDM strategy/work zone/special event (default 1.0; the product of every active `AtdmStrategy::crash_frequency_adjustment`)  (unitless)
+  Fc_wea   = equivalent crash frequency for weather condition wea (Equation 29-14)               (crashes/yr)
+  pc_wea   = proportion of incidents that are crashes at the street location, Exhibit 17-11/17-12 (`crash_proportion`: 0.358 segment / 0.310 intersection)  (unitless)
+Implemented in: urban_reliability/urban_reliability.rs::UrbanReliability::generate_incidents (fi_year, strategy_cfaf)
+```
+
+```
+Equation 29-16:  fi_h,d = (Fi_wea / 8,760) · (24 · f_hod,h,d) · f_dow,d · f_moy,d                [incidents/h]
+  fi_h,d    = expected hourly incident frequency for hour h of day d                             (incidents/h)
+  Fi_wea    = average incident frequency (Equation 29-15)                                        (incidents/yr)
+  8,760     = hours per year                                                                     (h/yr)
+  f_hod,h,d = hour-of-day demand ratio, Exhibit 17-5 (`exhibit_17_5_hour_of_day_ratio`)           (unitless)
+  f_dow,d   = day-of-week demand ratio, Exhibit 17-6 (`exhibit_17_6_day_of_week_ratio`)           (unitless)
+  f_moy,d   = month-of-year demand ratio, Exhibit 17-7 (`exhibit_17_7_month_of_year_ratio`)       (unitless)
+Implemented in: urban_reliability/urban_reliability.rs::UrbanReliability::generate_incidents (fi_hour)
+```
+
+```
+Equation 29-17:  p0_h,d = e^(−fi_h,d · pi)                                                      [probability, unitless]
+Equation 29-18:  No incident if Ri_h,d ≤ p0_h,d;  Incident if Ri_h,d > p0_h,d
+  p0_h,d = probability of no incident of the given event type / lane location / severity         (unitless)
+  fi_h,d = expected hourly incident frequency (Equation 29-16)                                   (incidents/h)
+  pi     = joint proportion of incidents of type con/lan/sev at this street location, Exhibit 17-11/17-12 (`incident_joint_proportions`), one of the 12 `INCIDENT_TYPES` rows  (unitless)
+  Ri_h,d = uniform random number (0,1) for incident occurrence                                   (unitless)
+Implemented in: urban_reliability/urban_reliability.rs::UrbanReliability::generate_incidents (p0, `r <= p0` test)
+```
+
+```
+Equation 29-19:  di = gamma⁻¹(p = Rd, μ = d̄i, σ = s)                                            [h]
+  di   = incident duration                                                                      (h)
+  Rd   = uniform random number (0,1) for incident duration                                      (unitless)
+  d̄i   = mean incident duration = detection + response + clearance time (`default_incident_duration_min`), Exhibit 17-9/17-10  (min, converted to h)
+  s    = standard deviation of incident duration = INCIDENT_DURATION_CV · d̄i, INCIDENT_DURATION_CV = 0.8  (h)
+  The result is truncated at midnight and rounded to the nearest analysis-period increment (0.25 h).
+Implemented in: urban_reliability/urban_reliability.rs::UrbanReliability::generate_incidents (mean_h, sd_h, dur)
+```
+
+```
+Equation 29-20:  pv_2 = lv_2/(2·tv);  pv_4 = pv_2 + lv_4/(2·tv);  pv_6 = pv_4 + lv_6/(2·tv);  pv_8 = 1.0
+Equation 29-21:  tv = Σ_(j=1..12) v_input,j                                                      [veh/h]
+  pv_n = cumulative volume proportion for the leg served by NEMA phase n (n = 2, 4, 6, 8)         (unitless)
+  lv_n = two-way leg volume for NEMA phase n at the intersection                                 (veh/h)
+  tv   = total intersection volume, summed over the 12 input movement volumes                    (veh/h)
+  Code simplification: only the major-street through legs (phases 2/6, carrying the segment's two-way through demand `v_subj + v_opp`) and a single analyst-configured two-way minor-leg volume (`minor_leg_volume_veh_h`, applied identically to both minor legs, phases 4/8) are modeled, rather than 12 distinct per-movement input volumes.
+Implemented in: urban_reliability/urban_reliability.rs::UrbanReliability::generate_incidents (major, minor, tv2, p2 for `StreetLocation::Intersection`)
+```
+
+```
+Equation 29-22:  Incident on Phase 2 if Rv ≤ pv_2;  Phase 4 if pv_2 < Rv ≤ pv_4;  Phase 6 if pv_4 < Rv ≤ pv_6;  Phase 8 if pv_6 < Rv ≤ pv_8
+  Rv         = uniform random number (0,1) for incident leg assignment                           (unitless)
+  pv_2/4/6/8 = cumulative volume proportions (Equation 29-20)                                    (unitless)
+  Code simplification: only a binary subject-through vs. not draw is made (`rng.next_f64() <= p2` against the major-leg share), since the facility evaluation models only the subject through movement at each boundary intersection.
+Implemented in: urban_reliability/urban_reliability.rs::UrbanReliability::generate_incidents (`StreetLocation::Intersection` branch, affects_subject)
+```
+
+```
+Equation 29-23:  pv_2 = dv_2 / (dv_2 + dv_6);  pv_6 = 1.0                                       [proportion, unitless]
+  pv_2/pv_6 = cumulative volume proportion for the Phase 2 / Phase 6 direction of travel on the segment  (unitless)
+  dv_2, dv_6 = demand flow rate in the Phase 2 and Phase 6 directions of the segment              (veh/h)
+Implemented in: urban_reliability/urban_reliability.rs::UrbanReliability::generate_incidents (v_subj, v_opp, p2 for `StreetLocation::Segment`)
+```
+
+```
+Equation 29-24:  Incident in Phase 2 direction if Rv ≤ pv_2;  Phase 6 direction if pv_2 < Rv ≤ pv_6
+  Rv         = uniform random number (0,1) for direction assignment                              (unitless)
+  pv_2/pv_6  = cumulative volume proportions (Equation 29-23)                                    (unitless)
+  v_subj     = `through_demand_veh_h` of the subject direction on the segment                     (veh/h)
+  v_opp      = opposing-direction demand, analyst-configured `opposing_demand_veh_h` (defaults to v_subj)  (veh/h)
+Implemented in: urban_reliability/urban_reliability.rs::UrbanReliability::generate_incidents (`StreetLocation::Segment` branch, affects_subject)
+```
 
 ### Demand variation and scenario dataset generation (Stage 1b/1d, Stage 2)
 
 `UrbanReliabilityConfig::demand_ratio` composes the Exhibit 17-5 (hour-of-day), 17-6 (day-of-week), and 17-7 (month-of-year) default ratios by functional class; `generate_scenarios` computes each scenario's demand ratio as `demand_ratio(month, dow, hour) × weather_demand_change_factor / base_demand_ratio()` (Equation 29-29's structure, with the weather demand-change factor being Exhibit 17-8's rain/snow multiplier, `demand_change_rain`/`demand_change_snow`, applied only during rain/snow — not during wet-pavement or snow-on-pavement conditions). `evaluate_scenario` then applies, per segment: the demand ratio and any active ATDM strategy demand adjustment to `through_demand_veh_h`; the more-severe of any active segment/intersection incidents (`is_more_severe`/`worse`, ranked by `severity_rank`) with lane closures computed by `lanes_blocked` (always leaving at least one lane open, per the HCM text quoted in the doc comment); the Equation 29-35 adjusted base free-flow speed (`adjusted_base_ffs`) and Equation 29-34 additional running delay (`additional_delay_s`), added into the Chapter 18 `midsegment_other_delay_s` input rather than modifying the segment's own free-flow speed field; the Equation 29-27 incident saturation-flow-rate factor (`incident_sat_flow_factor`) combined multiplicatively with the Equation 29-25 weather saturation-flow factor (`weather_sat_flow_factor`) and any ATDM `sat_flow_adjustment`; and finally the Chapter 19 uniform + incremental delay equations (`common::delay::{progression_factor, uniform_delay, incremental_delay}`) recomputed on the adjusted demand/capacity/green to produce `through_control_delay_s`, before calling the segment's own Chapter 18 `analyze()`. Facility travel time, VMT, and oversaturation flag are accumulated across segments; `UrbanReliability::run` aggregates every scenario's travel-time-index observation (VMT-weighted by default, `vmt_weighted`) into a `TravelTimeDistribution` and reads off the Chapter 17 performance measures, including `reliability_rating_urban` — the percentage of the (VMT-weighted) distribution with TTI below the urban-street threshold `URBAN_RELIABILITY_RATING_TTI_THRESHOLD` (2.5), which the doc comment distinguishes from `ReliabilityMetrics::reliability_rating`'s freeway 1.33 threshold in the shared module.
 
+```
+Equation 29-29:  v_h,d = (v_input / (f_hod,input · f_dow,input · f_moy,input)) · f_hod,h,d · f_dow,d · f_moy,d     [veh/h]
+  v_h,d   = adjusted hourly flow rate for hour h of day d                                        (veh/h)
+  v_input = base-dataset traffic count volume                                                    (veh/h)
+  f_hod,input / f_dow,input / f_moy,input = systematic ratios at the count's month/day-of-week/hour, the denominator (`base_demand_ratio()`)  (unitless)
+  f_hod,h,d / f_dow,d / f_moy,d = systematic ratios at the scenario's month/day-of-week/hour (`demand_ratio()`)  (unitless)
+  Code restates this as a pure ratio (scenario ratio / base ratio) applied multiplicatively to `through_demand_veh_h`, with the Exhibit 17-8 weather demand-change factor (`demand_change_rain`/`demand_change_snow`) folded in as an additional multiplier on rain/snow analysis periods only (not wet-pavement/snow-on-pavement periods).
+Implemented in: urban_reliability/urban_reliability.rs::UrbanReliabilityConfig::demand_ratio, ::base_demand_ratio; ::UrbanReliability::generate_scenarios (ratio)
+```
+
+```
+Equation 29-25:  f_rs = 1 / (1 + 0.48·R_r + 0.39·R_s)                                            [unitless]
+  f_rs = saturation flow rate adjustment factor for rainfall/snowfall (0.95 for wet pavement not raining; 0.90 for snow/ice on pavement not snowing, applied as fixed constants rather than this formula)  (unitless)
+  R_r  = rainfall rate, water-equivalent                                                          (in./h)
+  R_s  = snowfall rate, water-equivalent                                                          (in./h)
+Implemented in: urban_reliability/exhibits.rs::weather_sat_flow_factor
+```
+
+```
+Equation 29-26:  f_s,rs = 1 / (1 + 0.48·R_r + 1.4·R_s)                                           [unitless]
+  f_s,rs = free-flow speed adjustment factor for rainfall/snowfall (0.95 for wet pavement not raining; 0.90 for snow/ice on pavement not snowing, fixed constants)  (unitless)
+  R_r / R_s = rainfall/snowfall rate, water-equivalent                                            (in./h)
+Implemented in: urban_reliability/exhibits.rs::weather_ffs_factor
+```
+
+```
+Equation 29-27:  f_ic = (1 − N_ic/N_n) · (1 − b_ic/ΣN_n) ≥ 0.10                                  [unitless]
+Equation 29-28:  b_ic = 0.58·I_fi + 0.42·I_pdo + 0.17·I_other
+  f_ic  = saturation flow rate adjustment factor for an incident on an intersection movement       (unitless, floored at 0.10)
+  N_ic  = number of lanes serving the movement blocked by the incident                             (ln)
+  N_n   = number of lanes serving the movement under normal conditions                             (ln)
+  ΣN_n  = total lanes on the approach across all movements (`approach_lanes`)                      (ln)
+  b_ic  = incident-severity calibration coefficient                                                (unitless)
+  I_fi/I_pdo/I_other = indicator (1/0) for fatal-injury / property-damage-only / other (noncrash) severity  (unitless)
+Implemented in: urban_reliability/exhibits.rs::incident_sat_flow_factor, ::incident_severity_coefficient
+```
+
+```
+Equation 29-34:  d_other = L · (1/S* − 1/S_fo)                                                  [s/veh]
+Equation 29-35:  S* = S_fo · f_s,rs · (1 − b_ic/N_o)                                              [mi/h]
+Equation 29-36:  b_ic = 0.58·I_fi + 0.42·I_pdo + 0.17·I_other
+  d_other = additional running delay from weather/incidents, added to the Chapter 18 `midsegment_other_delay_s` input  (s/veh)
+  L       = segment length                                                                        (ft; converted with 5,280/3,600 to consistent ft/s speeds)
+  S*      = adjusted base free-flow speed during the analysis period                              (mi/h)
+  S_fo    = base free-flow speed under base conditions                                            (mi/h)
+  f_s,rs  = weather free-flow-speed adjustment factor (Equation 29-26)                             (unitless)
+  b_ic    = incident-severity coefficient (Equation 29-28/29-36), 0 if no incident in the subject direction  (unitless)
+  N_o     = number of lanes serving the subject direction (`direction_lanes`)                      (ln)
+Implemented in: urban_reliability/exhibits.rs::adjusted_base_ffs, ::additional_delay_s, ::incident_severity_coefficient
+```
+
+Random 15-min demand variation (Equations 29-30 through 29-33, the randomized flow-rate element) is a documented deferral — see the "Deferred" section below — and is not implemented, so it is not written out here.
+
 ### ATDM strategy hook
 
 `AtdmStrategy` (name, month/day-of-week/period activation schedule, multiplicative `demand_adjustment`/`sat_flow_adjustment`/`ffs_adjustment`, additive `effective_green_adjustment_s`, multiplicative `crash_frequency_adjustment`) is applied per-scenario in `evaluate_scenario` when the scenario's month/day-of-week/period matches the strategy's (empty schedule fields = always active), and its `crash_frequency_adjustment` additionally multiplies the incident-generation crash frequency (Eq. 29-15's `CFAF_str`) in `generate_incidents`. This is documented as an input-hook level implementation of Chapter 17's ATDM strategy assessment concept ("geometric-configuration and signal-control ATDM strategies are evaluated ... by using scenarios ... for each desired lane configuration") rather than the Chapter 37 strategy-specific behavioral models, which remain deferred.
 
+```
+ATDM adjustment composition (input-hook level; not itself an HCM-numbered equation):
+  demand_ratio_scenario = demand_ratio(month,dow,hour) · Π(active AtdmStrategy.demand_adjustment)                   [unitless multiplier on through_demand_veh_h]
+  sat_flow_adjusted     = sat_flow_veh_h_ln · f_rs · f_ic · Π(active AtdmStrategy.sat_flow_adjustment)               [veh/h/ln]
+  green_adjusted        = clamp(effective_green_s + Σ(active AtdmStrategy.effective_green_adjustment_s), 1, cycle_length_s − 1)   [s]
+  ffs_adjusted          = base_ffs_mph · Π(active AtdmStrategy.ffs_adjustment)                                       [mi/h]
+  CFAF_str (Eq 29-15)   = Π(active AtdmStrategy.crash_frequency_adjustment)                                         [unitless]
+  where "active" = strategies whose months/days_of_week/periods schedule matches the scenario (empty list = always active); f_rs, f_ic are Equations 29-25/29-27.
+Implemented in: urban_reliability/urban_reliability.rs::UrbanReliability::evaluate_scenario (strat_demand, strat_sat, strat_green, strat_ffs); ::generate_incidents (strategy_cfaf)
+```
+
 ## Deviations (cross-referenced to `docs/hcm/VERIFICATION.md`)
 
-`docs/hcm/VERIFICATION.md` does not exist as a file at this branch's tip; its "Chapter 16/17 (feat/hcm-ch16-17-urban-facilities)" section, read from a later branch's history, records: (1) Exhibit 29-66's snow rows omit the +0.19 night-drying term of Equation 29-12 that its rain rows include; the implementation follows the exhibit (documented above); (2) Exhibit 29-70's printed shoulder-crash proportions (0.021/0.016) are typos for Exhibit 17-11's 0.020/0.160 — the exhibit's own p0 column back-computes to the latter, and `crash_proportion`/`incident_joint_proportions` in `exhibits.rs` use the corrected 0.020/0.160 values; (3) the Equation 29-8 standard-deviation cap for snow (`total_sd = (2.5 × total_mean).min(0.65 × depth_ratio)` in `generate_weather_events`) scales the printed 0.65-in rain cap by the 10:1 snow/rain depth ratio, matching Exhibit 29-66's magnitudes, since the HCM text is silent on a snow-specific cap; (4) the Chapter 29 Example Problem 4 fixture's published coordinated-actuated average phase duration is not printed in the extracted text, so the fixture's `BoundarySignal.effective_green_s` (45 s) was chosen to reproduce the published base condition rather than transcribed from an exhibit; (5) the Chapter 29 Example Problem 1 facility fixtures (`chapter16.md`'s `case1.json`/`case2.json`) have unpublished Segments 2-4, so facility-level speed/stop-rate differ slightly from the published aggregate (22.1 vs. 22.6 mi/h) — the fully-published Chapter 30 Example Problem 1 segment case (`case3.json`) reproduces exactly; (6) the Chapter 29 Example Problem 4 reliability distribution's TTI-80 is within 0.03 of the published value but the PTI (TTI-95) tail is lighter (1.73 computed vs. roughly 2.6-3.0 published) because residual-queue carryover between analysis periods (the d3 initial-queue delay term) is deferred — every analysis period is evaluated with an initial queue of zero, which the module doc comment calls out as "the main known gap." All six items are interpretation/reproduction notes rather than `VERIFY-HCM`-flagged code defects; a grep of `urban_reliability.rs` and `exhibits.rs` for `VERIFY-HCM` found no inline markers in either file (the deviations are documented in module/function doc comments instead).
+`docs/hcm/VERIFICATION.md` exists at this branch's tip; its "Chapter 16/17 (feat/hcm-ch16-17-urban-facilities)" section records: (1) Exhibit 29-66's snow rows omit the +0.19 night-drying term of Equation 29-12 that its rain rows include; the implementation follows the exhibit (documented above); (2) Exhibit 29-70's printed shoulder-crash proportions (0.021/0.016) are typos for Exhibit 17-11's 0.020/0.160 — the exhibit's own p0 column back-computes to the latter, and `crash_proportion`/`incident_joint_proportions` in `exhibits.rs` use the corrected 0.020/0.160 values; (3) the Equation 29-8 standard-deviation cap for snow (`total_sd = (2.5 × total_mean).min(0.65 × depth_ratio)` in `generate_weather_events`) scales the printed 0.65-in rain cap by the 10:1 snow/rain depth ratio, matching Exhibit 29-66's magnitudes, since the HCM text is silent on a snow-specific cap; (4) the Chapter 29 Example Problem 4 fixture's published coordinated-actuated average phase duration is not printed in the extracted text, so the fixture's `BoundarySignal.effective_green_s` (45 s) was chosen to reproduce the published base condition rather than transcribed from an exhibit; (5) the Chapter 29 Example Problem 1 facility fixtures (`chapter16.md`'s `case1.json`/`case2.json`) have unpublished Segments 2-4, so facility-level speed/stop-rate differ slightly from the published aggregate (22.1 vs. 22.6 mi/h) — the fully-published Chapter 30 Example Problem 1 segment case (`case3.json`) reproduces exactly; (6) the Chapter 29 Example Problem 4 reliability distribution's TTI-80 is within 0.03 of the published value but the PTI (TTI-95) tail is lighter (1.73 computed vs. roughly 2.6-3.0 published), originally attributed to the then-deferred residual-queue carryover between analysis periods (the d3 initial-queue delay term); per the VERIFICATION.md item's own update, carryover has since been implemented on `feat/hcm-reliability-enhancements` (see `reliability-enhancements.md` and VERIFICATION.md's "Reliability enhancements" section) — the PTI gap narrowed only modestly (1.73 → 1.75) and is now attributed to other still-deferred elements (random 15-minute demand variation, incident-duration defaults) rather than the carryover mechanism. All six items are interpretation/reproduction notes rather than `VERIFY-HCM`-flagged code defects; a grep of `urban_reliability.rs` and `exhibits.rs` for `VERIFY-HCM` found no inline markers in either file (the deviations are documented in module/function doc comments instead).
 
 ## Validation
 
 The fixture lives at `tests/ExampleCases/hcm/UrbanReliability/case1.json`, reproducing the HCM Chapter 29, Section 5, Example Problem 4 configuration (a 3-mi Lincoln, Nebraska principal arterial; weekdays for one year; 7-10 a.m. study period), exercised by `tests/chapter17_integration.rs` and mirrored by `tests/test_chapter17_integration.py`. `test_case1_example_problem_4` asserts the deterministic scenario count exactly (3,120 = 12 analysis periods x 260 weekdays), the base free-flow travel time within a ±10 s band of the published 262.9 s, and the Monte Carlo distribution measures (mean TTI, TTI-80, TTI-95/PTI, reliability rating) within bands around the published Exhibit 29-73 eastbound/westbound values (mean TTI 1.69/1.64, TTI-80 1.57/1.56, PTI 2.98/2.61, reliability rating 93.2/94.1), plus percentile-ordering (`tti_50 <= tti_80 <= tti_95`), positive total VHD, and more than 50 generated weather events and incidents. `test_case1_replication_with_different_seeds` reproduces the Exhibit 29-75 "replication" concept — different seeds should agree within a generous 10% band on mean travel time while remaining within the same TTI-mean band, mirroring the HCM's own published ~1.4% variation across replications. `test_case1_example_problem_5_strategy_1` reproduces the Example Problem 5 strategy-evaluation direction of effect (a +5 s split shift to the coordinated phase must reduce mean travel time, not increase PTI, and not degrade the reliability rating, mirroring the published 438.2 -> 400.7 s / 93.2 -> 96.8 rating shift) as a directional (not magnitude) check.
 
-Unit tests in `src/hcm/chapter17/tests.rs` spot-check individual equations and lookup tables against tabulated/derived values: `test_exhibit_17_5_hour_of_day`, `test_exhibit_17_6_day_of_week`, `test_exhibit_17_7_month_of_year`, `test_example_problem_4_demand_ratios` (composed ratio against Example Problem 4's own worked demand factors), `test_exhibit_17_9_defaults`, `test_exhibit_17_10_clearance_and_duration`, `test_incident_distribution_proportions` (Exhibit 17-11/17-12 tables, including the corrected shoulder-crash proportions), `test_equation_29_13_crash_frequency_by_weather`, `test_equations_29_15_through_29_17`, `test_normal_inverse` and `test_gamma_inverse` (the inverse-CDF primitives against known percentiles), `test_weather_adjustment_factors`, `test_incident_sat_flow_factor`, `test_additional_delay_equations`, `test_exhibit_29_5_lt_headway`, `test_weather_generation_deterministic_and_plausible` and `test_weather_at_timeline` (generation-pipeline sanity and determinism checks), `test_reliability_run_ep4_like_distribution` (a lighter-weight synthetic version of the integration test), `test_atdm_strategy_hooks`, and `test_validation_errors`.
+Unit tests in `src/hcm/urban_reliability/tests.rs` spot-check individual equations and lookup tables against tabulated/derived values: `test_exhibit_17_5_hour_of_day`, `test_exhibit_17_6_day_of_week`, `test_exhibit_17_7_month_of_year`, `test_example_problem_4_demand_ratios` (composed ratio against Example Problem 4's own worked demand factors), `test_exhibit_17_9_defaults`, `test_exhibit_17_10_clearance_and_duration`, `test_incident_distribution_proportions` (Exhibit 17-11/17-12 tables, including the corrected shoulder-crash proportions), `test_equation_29_13_crash_frequency_by_weather`, `test_equations_29_15_through_29_17`, `test_normal_inverse` and `test_gamma_inverse` (the inverse-CDF primitives against known percentiles), `test_weather_adjustment_factors`, `test_incident_sat_flow_factor`, `test_additional_delay_equations`, `test_exhibit_29_5_lt_headway`, `test_weather_generation_deterministic_and_plausible` and `test_weather_at_timeline` (generation-pipeline sanity and determinism checks), `test_reliability_run_ep4_like_distribution` (a lighter-weight synthetic version of the integration test), `test_atdm_strategy_hooks`, and `test_validation_errors`.
 
 `tests/test_chapter17_integration.py` exercises the PyO3 bindings against the same `case1.json`: `test_scenario_count`, `test_base_free_flow_travel_time`, `test_distribution_measures`, `test_results_json`, and `test_seeded_reproducibility`.
 
 ## Deferred
 
-Per the `urban_reliability.rs` module doc comment's "Documented deferrals" list: random 15-minute demand variation (Equations 29-30 through 29-33, the optional randomized flow-rate element — scenarios use only the systematic hour/day/month/weather demand factors); residual-queue carryover between analysis periods (each period is evaluated with zero initial queue, d3 = 0 — the "main known gap" affecting the PTI tail per the Deviations section above); full alternative HCM datasets for work zones and special events (only the `AtdmStrategy` input-hook-level adjustment is implemented, not distinct work-zone/special-event dataset generation); the Chapter 37 ATDM strategy-specific behavioral models (only the input-hook demand/saturation-flow/green-time/crash-frequency adjustment schedule is implemented); and the Exhibit 29-5 critical left-turn-headway weather adjustment's direct wiring into a left-turn engine (the factor is exposed via `exhibit_29_5_extra_lt_headway_s` for a caller to apply to the Chapter 19/20 engines, since the facility evaluation here models only the through movement, which the adjustment does not affect directly).
+Per the `urban_reliability.rs` module doc comment's "Documented deferrals" list: random 15-minute demand variation (Equations 29-30 through 29-33, the optional randomized flow-rate element — scenarios use only the systematic hour/day/month/weather demand factors); full alternative HCM datasets for work zones and special events (only the `AtdmStrategy` input-hook-level adjustment is implemented, not distinct work-zone/special-event dataset generation); the Chapter 37 ATDM strategy-specific behavioral models (only the input-hook demand/saturation-flow/green-time/crash-frequency adjustment schedule is implemented); and the Exhibit 29-5 critical left-turn-headway weather adjustment's direct wiring into a left-turn engine (the factor is exposed via `exhibit_29_5_extra_lt_headway_s` for a caller to apply to the Chapter 19/20 engines, since the facility evaluation here models only the through movement, which the adjustment does not affect directly).

--- a/docs/hcm/procedures/chapter18-computed.md
+++ b/docs/hcm/procedures/chapter18-computed.md
@@ -1,6 +1,6 @@
 # HCM Chapter 18/30 — Computed Platoon Dispersion and Access-Point Delay (Milestone 2)
 
-This document walks through the "milestone 2" computed procedures for HCM 7th Edition Chapter 18 urban street segments, implemented on branch `feat/hcm-ch18-platoon-dispersion`: the Chapter 30, Section 3 platoon-dispersion primitives (EPUB `235_Ch30_03.xhtml`) that let Step 3 (proportion arriving during green) be computed from an upstream signal's discharge flow profile instead of assumed uniform or taken from a supplied platoon ratio, and the Chapter 30, Section 4 delay-due-to-turns-at-access-points procedure (EPUB `236_Ch30_04.xhtml`) that lets Step 2's `Σ d_ap,i` term be computed from access-point geometry and turning volumes instead of supplied per-point delays or the Exhibit 18-13 planning estimate. The code lives in `src/hcm/chapter18/platoon_dispersion.rs` (Section 3) and `src/hcm/chapter18/access_point_delay.rs` (Section 4); both are wired into `UrbanSegment` in `src/hcm/chapter18/urban_segments.rs` (milestone 1, documented in `chapter18.md`) as optional, computed-vs-input mode switches. `docs/hcm/VERIFICATION.md` exists at this branch's tip and carries a "Chapter 18/30 computed procedures (feat/hcm-ch18-platoon-dispersion)" section that is the authoritative source for the deviations below.
+This document walks through the "milestone 2" computed procedures for HCM 7th Edition Chapter 18 urban street segments, implemented on branch `feat/hcm-ch18-platoon-dispersion`: the Chapter 30, Section 3 platoon-dispersion primitives (EPUB `235_Ch30_03.xhtml`) that let Step 3 (proportion arriving during green) be computed from an upstream signal's discharge flow profile instead of assumed uniform or taken from a supplied platoon ratio, and the Chapter 30, Section 4 delay-due-to-turns-at-access-points procedure (EPUB `236_Ch30_04.xhtml`) that lets Step 2's `Σ d_ap,i` term be computed from access-point geometry and turning volumes instead of supplied per-point delays or the Exhibit 18-13 planning estimate. The code lives in `src/hcm/urban_segments/platoon_dispersion.rs` (Section 3) and `src/hcm/urban_segments/access_point_delay.rs` (Section 4); both are wired into `UrbanSegment` in `src/hcm/urban_segments/urban_segments.rs` (milestone 1, documented in `chapter18.md`) as optional, computed-vs-input mode switches. `docs/hcm/VERIFICATION.md` exists at this branch's tip and carries a "Chapter 18/30 computed procedures (feat/hcm-ch18-platoon-dispersion)" section that is the authoritative source for the deviations below.
 
 ## Section 3 — Platoon dispersion and the arrival flow profile
 
@@ -16,6 +16,79 @@ The model represents one average signal cycle as `C' = cycle_s / time_step_s` di
 | Proportion arriving on green | (Step 3 definition; not separately numbered) | `proportion_arriving_green` | `platoon_dispersion.rs` | `arrival_profile: &[f64]`, `green_start_step`, `green_steps` | `P` (decimal, clamped to `[0, 1]`) |
 | Proportion of time blocked | Eq. 30-13, `p_b = t'_p d_t / C` | `proportion_time_blocked` | `platoon_dispersion.rs` | `blocked_period_steps`, `time_step_s`, `cycle_s` | `p_b` (decimal, clamped) |
 | Critical platoon flow rate | (Section 3 "Proportion of Time Blocked" discussion) `q_c = 3,600/t_c` | `critical_platoon_flow_rate` | `platoon_dispersion.rs` | `critical_headway_s` (t_c, s, Chapter 20) | `q_c` (veh/h) |
+
+### Section 3 equations in full
+
+```
+Equation 30-11:  F = 1 / (1 + 0.138·t'_R + 0.315/d_t)     [unitless]
+  t'_R = segment running time expressed in time steps    (steps; = t_R / d_t)
+  t_R  = segment running time                            (s)
+  d_t  = time step duration                              (s/step; Chapter 30 recommends 1.0)
+Implemented in: urban_segments/platoon_dispersion.rs::smoothing_factor
+```
+
+```
+Equation 30-12:  t' = t'_R − 1/F + 1.25     [steps]
+  t'_R = segment running time expressed in time steps    (steps; = t_R / d_t)
+  F    = smoothing factor                                (unitless, Equation 30-11)
+Implemented in: urban_segments/platoon_dispersion.rs::platoon_arrival_time_steps
+```
+
+```
+Equation 30-9:   q'_a|u,j = F·q'_u,i + (1 − F)·q'_a|u,j−1     [veh/step]
+Equation 30-10:  j = i + t'
+  q'_a|u,j = arrival flow rate at the downstream intersection, time step j, from upstream source u   (veh/step)
+  q'_u,i   = departure (discharge) flow rate at upstream source u, time step i                        (veh/step)
+  F        = smoothing factor                                                                         (unitless, Eq 30-11)
+  t'       = platoon arrival time                                                                      (steps, Eq 30-12)
+  i, j     = time-step indices, 0-based, cyclic modulo C' = cycle length in steps                      (steps)
+Code note: the recursion is iterated to its periodic steady state (up to 100 passes, L1 convergence < 1e-12 on the wrap-around seam) rather than solved in one closed pass, and t' is rounded to the nearest integer step for the index lag j = i + t' — the fractional remainder is absorbed by the (1 − F) smoothing memory rather than by interpolation. The module doc comment flags this as a discretization choice, not a literal transcription of Equation 30-10.
+Implemented in: urban_segments/platoon_dispersion.rs::disperse_profile
+```
+
+```
+Discharge flow profile construction (Chapter 30 §3 "Discharge Flow Profile" narrative; not separately numbered):
+  during the queue service time g_s:        rate = s·d_t/3,600                                              [veh/step]
+  during the remainder of green (g − g_s):  rate = back-solved so Σ(profile over the cycle) = V·(C'·d_t)/3,600  [veh/step]
+  outside of green:                         rate = 0
+  g   = effective green duration                                    (s)
+  g_s = queue service time, clamped to [0, g]                       (s)
+  s   = saturation flow rate of the movement's lane group           (veh/h)
+  V   = adjusted discharge volume for the movement                  (veh/h)
+  C'  = cycle length in time steps, d_t = time step duration        (steps, s/step)
+Code note: both the green and queue-service intervals are discretized to whole steps first, then the post-queue-service rate is back-solved from the remaining vehicle count, so the profile integrates exactly to V with no continuous-vs-discrete rounding drift (per the function's doc comment).
+Implemented in: urban_segments/platoon_dispersion.rs::MovementDischarge::to_profile
+```
+
+```
+Combined arrival flow profile (Equation 30-9 applied per upstream movement and summed, plus a uniform midblock term per Chapter 30 §3 "Arrival Flow Profile": midsegment arrivals "are assumed to have a uniform arrival flow profile"; not separately numbered):
+  q'_a,j(combined) = Σ_u disperse(q'_u,•)_j  +  v_unif·d_t/3,600     [veh/step]
+  disperse(q'_u,•)_j = the Equation 30-9/30-10 dispersed profile for upstream movement u, at step j   (veh/step)
+  v_unif = uniform (midblock/access-point) arrival volume entering the cycle uniformly                 (veh/h)
+Implemented in: urban_segments/platoon_dispersion.rs::combined_arrival_profile
+```
+
+```
+Proportion of vehicles arriving during green (Step 3 definition; not separately numbered):
+  P = ( Σ_{j∈green} q'_a,j ) / ( Σ_{j=1}^{C'} q'_a,j )     [decimal, clamped to [0, 1]]
+  green = the green_steps time steps starting at green_start_step, indices wrapped modulo C'
+Implemented in: urban_segments/platoon_dispersion.rs::proportion_arriving_green
+```
+
+```
+Equation 30-13:  p_b = t'_p·d_t / C     [decimal, clamped to [0, 1]]
+  t'_p = blocked period duration                    (steps)
+  d_t  = time step duration                         (s/step)
+  C    = cycle length                               (s)
+Implemented in: urban_segments/platoon_dispersion.rs::proportion_time_blocked
+```
+
+```
+Critical platoon flow rate (Chapter 30 §3 "Proportion of Time Blocked" discussion; not separately numbered):
+  q_c = 3,600 / t_c     [veh/h]
+  t_c = critical headway of the minor movement (Chapter 20, TWSC)     (s)
+Implemented in: urban_segments/platoon_dispersion.rs::critical_platoon_flow_rate
+```
 
 `disperse_profile` implements the cyclic steady-state recursion by iterating the periodic `(1−F)`-memory update up to 100 passes with an L1 convergence check at `1e-12`; the platoon arrival time `t'` is rounded to the nearest integer step for the index lag (the fractional remainder is absorbed by the smoothing recursion rather than by interpolation), which the module doc comment flags as a discretization choice rather than a literal transcription of Equation 30-10.
 
@@ -42,6 +115,138 @@ The procedure computes the delay imposed on major-street through vehicles by sam
 | Delay due to right turns d_ap,r | Eq. 30-55 | `access_point_through_delay` (right-turn branch, `I_t = 0.00001`) | `access_point_delay.rs` |
 | Total delay | `d_ap = d_ap,l + d_ap,r` | `access_point_through_delay` (public entry point) | `access_point_delay.rs` |
 
+### Section 4 equations in full
+
+```
+Equation 30-15:  L_h = L_pc·(1 − 0.01·P_HV) + 0.01·L_HV·P_HV     [ft/veh]
+  L_pc = stored passenger-car lane length      (ft, default 25.0)
+  L_HV = stored heavy-vehicle lane length      (ft, default 45.0)
+  P_HV = percent heavy vehicles in the movement group      (%, 0-100)
+Implemented in: urban_segments/access_point_delay.rs::stationary_queue_spacing
+```
+
+```
+Equation 30-32:  P_lc = 1 − [(2·v_app/s_lc) − 1]²  ≥ 0.0     [unitless]
+Equation 30-33:  v_app = (v_lt + v_th + v_rt) / (N_sl + N_t + N_sr)     [veh/h/ln]
+  s_lc = maximum flow rate at which a lane change can occur = 3,600/t_lc     (veh/h/ln)
+  t_lc = critical merge headway = 3.7                                       (s)
+  v_lt, v_th, v_rt = left-turn / through / right-turn demand flow rates     (veh/h)
+  N_sl, N_t, N_sr  = lane counts: shared left-turn/through, exclusive through, shared right-turn/through   (ln)
+Note: per the Chapter 30 text, if v_app/s_lc exceeds 1.0 it is capped at 1.0 before squaring.
+Implemented in: urban_segments/access_point_delay.rs::probability_lane_change (v_app itself is computed inline in access_point_through_delay)
+```
+
+```
+Equation 30-34:  E_L1 = 1,800 / c_l     [through-car-equivalents/veh] (used as 1.0 directly when a left-turn bay is present)
+Equation 30-35:  c_l = v_o·e^(−v_o·t_cg/3,600) / (1 − e^(−v_o·t_fh/3,600))     [veh/h]
+  v_o  = opposing demand flow rate (opposing through plus opposing right turn)     (veh/h)
+  t_fh = follow-up headway for a permitted left turn = 2.2                        (s)
+  t_cg = critical headway for a permitted left turn = 4.1                         (s)
+Implemented in: urban_segments/access_point_delay.rs::permitted_left_capacity (Equation 30-35); the Equation 30-34 division (e_l1 = 1,800.0 / c_l) is inlined at the call site in access_point_through_delay
+```
+
+```
+Equations 30-36 through 30-46: the lane split (grouped per the code's `lane_split` function; I_t = indicator, 1.0 for the left-turn branch, 0.00001 for the right-turn branch; I_lt, I_rt = 1.0 if no left-/right-turn bay else 0.0; E_R,ap = 2.20 if no right-turn bay else 1.0):
+
+  Eq 30-36:  E_L1,m = (E_L1 − 1)·P_lc + 1                                    [through-car-equivalents]  modified permitted-left equivalent
+  Eq 30-37:  E_R,m  = (E_R,ap − 1)·P_lc + 1                                  [through-car-equivalents]  modified protected-right equivalent
+  Eq 30-41:  R = 1 + I_rt·P_rt·(E_R,m − 1)                                   [unitless]                 intermediate
+  Eq 30-39:  b = R − I_lt·P_lt·{ I_t + (N_sl+N_t+N_sr−1)·[(1+I_t)·E_L1,m − 1] }   [unitless]             intermediate
+  Eq 30-40:  c = −I_lt·P_lt·(N_sl+N_t+N_sr)                                  [unitless]                 intermediate
+  Eq 30-38:  P_L = [ −b + √(b² − 4·I_t·R·c) ] / (2·I_t·R)  ≤ 1.0             [decimal]                  proportion of left turns in the inside lane
+             (if N_sl+N_t+N_sr = 1, P_L = P_lt instead)
+  Eq 30-43:  s_1 = 1,800·(1 + P_L·I_t) / (1 + P_L·(E_L1,m − 1) + P_L·E_L1,m·I_t)   [veh/h/ln]           inside-lane saturation flow rate
+  Eq 30-42:  P_R = I_rt·P_rt·(s_1/1,800 + N_through − 1) / (1 − I_rt·P_rt·(s_1/1,800 + N_through − 2)·(E_R,m − 1))  ≤ 1.0   [decimal]   proportion of right turns in the outside lane
+             (if N_through = 1, P_R = P_rt instead; N_through = N_sl+N_t+N_sr)
+  Eq 30-44:  v_1 = v_lt / P_L                                                [veh/h/ln]                 inside-lane flow rate
+  Eq 30-45:  v_n = v_rt/P_R  if P_R > 0.0;  else (v_lt+v_th+v_rt−v_1)/(N_through−1)   [veh/h/ln]         outside-lane flow rate
+  Eq 30-46:  v_2 (v_i for intermediate lanes) = (v_lt+v_th+v_rt−v_1−v_n)/(N_through−2)  if N_through > 2;  else v_2 = v_n   [veh/h/ln]
+
+  P_lt, P_rt = proportion of left-/right-turning vehicles on the approach (decimal) = v_lt/(v_lt+v_th+v_rt), v_rt/(v_lt+v_th+v_rt)
+Implemented in: urban_segments/access_point_delay.rs::lane_split (private); returns the LaneSplit{p_l, p_r, v_1, v_n, v_2} struct
+```
+
+```
+Equations 30-47 through 30-52: merge and non-merge capacity/delay for the inside lane, and the min-of-two-forms rule (T = analysis period duration, h):
+
+  Eq 30-47:  c_mg = v_2·e^(−v_2·t_lc/3,600) / (1 − e^(−v_2·t_lc/3,600))     [veh/h]     merge capacity (t_lc = 3.7 s)
+  Eq 30-49:  v_mg = max(v_1 − v_lt, 0.0)                                    [veh/h/ln]  merge flow rate
+  Eq 30-48:  d_mg = 3,600·(1/c_mg − 1/1,800) + 900·T·[ v_mg/c_mg − 1 + √((v_mg/c_mg − 1)² + 8·v_mg/(c_mg²·T)) ]     [s/veh]   merge delay
+  Eq 30-50:  c_nm = 1,800·(1 + P_L) / (1 + P_L·(E_L1 − 1) + P_L·E_L1)       [veh/h]     non-merge capacity (uses the unadjusted E_L1, not E_L1,m)
+  Eq 30-51:  d_nm = 3,600·(1/c_nm − 1/1,800) + 900·T·[ v_1/c_nm − 1 + √((v_1/c_nm − 1)² + 8·v_1/(c_nm²·T)) ]        [s/veh]   non-merge delay
+  Eq 30-52:  d_t,1 = min(d_nm, d_mg)                                        [s/veh]     delay to through vehicles in the inside lane
+
+Code note: the 3,600(1/c − 1/1,800) + 900T[...] shape of Eq 30-48/30-51 is shared and factored into one helper; for a single-lane approach (no adjacent lane to merge into) the code uses only the non-merge form (d_t,1 = d_nm, computed with c_nm as above), since through vehicles there cannot merge by definition.
+Implemented in: urban_segments/access_point_delay.rs::incremental_delay (private, the shared Eq 30-48/30-51 term) and the left-turn branch of access_point_through_delay (Eq 30-47, 30-49, 30-50, 30-52)
+```
+
+```
+Equation 30-53:  p_ov = (v_lt / c_l)^(N_qx,lt + 1)     [decimal]
+Equation 30-54:  N_qx,lt = N_lt·L_a,lt / L_h     [veh]  (= 0.0 for an undivided cross section / no left-turn bay)
+  v_lt    = left-turn demand flow rate                                   (veh/h)
+  c_l     = permitted left-turn capacity                                 (veh/h, Equation 30-35)
+  N_lt    = number of lanes in the left-turn bay                         (ln)
+  L_a,lt  = available left-turn bay storage distance                     (ft/ln)
+  L_h     = average vehicle spacing in stationary queue                  (ft/veh, Equation 30-15)
+Implemented in: urban_segments/access_point_delay.rs::probability_left_bay_overflow (Eq 30-53); N_qx,lt (Eq 30-54) is computed inline in access_point_through_delay
+```
+
+```
+Equation 30-31:  d_ap,l = p_ov·d_t,1·(1/P_L − 1)·P_lt / (1 − P_lt − P_rt)     [s/veh]
+  p_ov  = probability of left-turn bay overflow            (decimal, Equation 30-53)
+  d_t,1 = delay to through vehicles in the inside lane      (s/veh, Equation 30-52)
+  P_L   = proportion of left turns in the inside lane       (decimal, Equation 30-38)
+  P_lt, P_rt = proportion of left-/right-turning vehicles on the approach   (decimal)
+Implemented in: urban_segments/access_point_delay.rs::access_point_through_delay (left-turn branch, evaluated at I_t = 1.0)
+```
+
+```
+Equation 30-55:  d_ap,r = 0.67·d_t|r·P_rt / (1 − P_lt − P_rt)     [s/veh]
+  d_t|r = through-vehicle delay per right-turn maneuver     (s/veh, Equations 30-56 through 30-68)
+  0.67  = field-data calibration constant (Chapter 30 §4 text)
+  P_lt, P_rt = proportion of left-/right-turning vehicles on the approach   (decimal)
+Code note: a right-turn bay short-circuits d_ap,r to 0.0 s/veh (the Exhibit 18-13 "both bays adequate ⇒ 0.0" convention), since the printed §4 equations have no explicit bay term for this case.
+Implemented in: urban_segments/access_point_delay.rs::access_point_through_delay (right-turn branch, evaluated at I_t = 0.00001, forced P_lc = 1.0)
+```
+
+```
+Equations 30-56 through 30-60: minimum speed and conditional delay to the first delayed through vehicle (λ from Eq 30-59; the h̄ function is shared by Eq 30-57/30-62/30-65):
+
+  Eq 30-59:  λ = 1 / (1/q_n − Δ)                                                          [veh/s]   flow-rate parameter
+  Eq 30-57:  h̄|Δ<h<H_1 = 1/λ + (Δ − H_1·e^(−λ(H_1−Δ))) / (1 − e^(−λ(H_1−Δ)))              [s/veh]   mean headway between Δ and H_1
+  Eq 30-58:  H_1 = (1.47·S_f − u_rt)/r_d + t_cl + L_h/(1.47·S_f)  ≥ Δ                      [s/veh]   max headway for the first vehicle to still be delayed
+  Eq 30-56:  u_m = max( 1.47·S_f − r_d·(H_1 − h̄|Δ<h<H_1),  u_rt )                         [ft/s]    minimum speed of the delayed first through vehicle
+  Eq 30-60:  d_1 = [ (1.47·S_f − u_m)² / (2·1.47·S_f) ] · (1/r_d + 1/r_a)                  [s/veh]   conditional delay to the first through vehicle
+
+  q_n   = outside-lane flow rate = v_n/3,600                              (veh/s)
+  S_f   = approaching through-vehicle speed ("free-flow speed" per the printed text — see "The posted-speed-vs-FFS finding" above)   (mi/h)
+  u_rt  = right-turn speed = 20.0                                         (ft/s)
+  r_d   = deceleration rate = 6.7                                         (ft/s²)
+  r_a   = acceleration rate = 3.5                                         (ft/s²)
+  t_cl  = clearance time of the right-turn vehicle = 0.6                  (s)
+  L_h   = average vehicle spacing in stationary queue (Equation 30-15)    (ft/veh)
+  Δ     = headway of the bunched vehicle stream = 1.5                     (s/veh)
+  1.47  = mi/h → ft/s conversion factor
+
+Equation 30-60 grouping: see "The Eq 30-60 grouping finding" above — the printed (1/r_d + 1/r_a) term is a multiplier on the squared-speed-deficit fraction, not its denominator, confirmed from the raw MathML `<mfrac>` structure.
+Implemented in: urban_segments/access_point_delay.rs::through_delay_per_right_turn (private)
+```
+
+```
+Equations 30-61 through 30-68: geometric-decay sum of delay to the second and subsequent through vehicles, iterated (in code) up to 50 terms or until an individual d_i falls below 0.1 s:
+
+  Eq 30-63 (i=2) / Eq 30-66 (i≥3):  H_i = d_(i−1) + Δ                                                          [s/veh]
+  Eq 30-62 (i=2) / Eq 30-65 (i≥3):  h̄|Δ<h<H_i = 1/λ + (Δ − H_i·e^(−λ(H_i−Δ))) / (1 − e^(−λ(H_i−Δ)))            [s/veh]
+  Eq 30-61 (i=2) / Eq 30-64 (i≥3):  d_i = d_(i−1) − (h̄|Δ<h<H_i − Δ)                                            [s/veh]
+  Eq 30-67 (closed form, first two vehicles) / Eq 30-68 (general form, any number of vehicles):
+    d_t|r = Σ_{i=1}^{∞} [ d_i × Π_{j=1}^{i} (1 − e^(−λ(H_j−Δ))) × (1 − P_R)^i ]                                 [s/veh]
+
+  d_i    = conditional delay to through vehicle i (i = 1 is Equation 30-60's d_1)     (s/veh)
+  λ, Δ   = as in the Eq 30-56 through 30-60 block above
+  P_R    = proportion of right turns in the outside lane                              (decimal, Equation 30-42)
+Implemented in: urban_segments/access_point_delay.rs::through_delay_per_right_turn (private)
+```
+
 `access_point_through_delay(ap: &AccessPointApproach, speed_mph: f64, analysis_period_h: f64) -> AccessPointDelay` is the single public entry point; `AccessPointApproach` carries the per-approach geometry and turning volumes (`v_lt`/`v_th`/`v_rt` veh/h, `n_sl`/`n_t`/`n_sr` lane counts, `opposing_flow_veh_h` veh/h, `left_turn_bay`/`right_turn_bay` bools, `n_lt_lanes`, `left_bay_storage_ft` ft, `pct_heavy_veh` %); `AccessPointDelay` returns `delay_left_s`, `delay_right_s`, `delay_total_s` (all s/veh) and `prob_inside_lane_blocked` (p_ov, unitless). The left-turn branch computes the modified through-car equivalent `E_L1` from the permitted-left capacity (1.0 when a left-turn bay is present), evaluates the lane split at `I_t = 1.0`, computes the merge capacity/delay (Eq. 30-47 through 30-49) and non-merge capacity/delay (Eq. 30-50/30-51), takes the lesser (Eq. 30-52), and scales by the bay-overflow probability and turning proportions (Eq. 30-31). The right-turn branch re-solves the lane split at a near-zero `I_t` (`0.00001`, matching the printed indicator convention for that branch) and forced `P_lc = 1.0`, then calls `through_delay_per_right_turn`, which implements the full first-vehicle delay (Eq. 30-56 through 30-60) and the geometric-decay sum over subsequent delayed vehicles (Eq. 30-61 through 30-68, iterated up to 50 terms or until an individual delay term drops below 0.1 s) — a right-turn bay short-circuits this branch to 0.0 s/veh per the Exhibit 18-13 "both bays adequate ⇒ 0.0" convention, since the code's docstring notes the printed §4 equations have no explicit bay term for this case.
 
 `UrbanSegment` wires this into Step 2 (`step_2_running_time` in `urban_segments.rs`) as the highest-priority of a three-way mode switch on the `Σ d_ap,i` term: (1) computed, when `access_point_approaches: Option<Vec<AccessPointApproach>>` is supplied — each approach is evaluated via `access_point_through_delay` at `access_point_turn_delay_speed_mph.unwrap_or(speed_limit_mph)` and `analysis_period_h`, and results are stored on `access_point_delays_computed: Option<Vec<AccessPointDelay>>`; (2) input, when `access_point_delays_s: Option<Vec<f64>>` is supplied instead (summed directly); (3) the Exhibit 18-13 planning estimate (milestone 1, `chapter18.md`) otherwise.
@@ -62,7 +267,7 @@ Both Section 3 and Section 4 follow the same pattern used elsewhere in Chapter 1
 
 The primary fixture remains HCM Chapter 30, Example Problem 1 (Exhibits 30-26 through 30-36), reused from `chapter18.md`'s milestone-1 validation but extended with a third fixture, `tests/ExampleCases/hcm/UrbanSegments/case3.json`, which is identical to `case1.json` except that `access_point_delays_s` (the milestone-1 input hook) is replaced by `access_point_approaches` (two active access points, AP1 and AP2, with their turning volumes, opposing flow, and undivided/no-bay geometry taken from Exhibit 30-35). `tests/chapter18_integration.rs::test_case3_example_problem_1_computed_access_point_delay` asserts: the computed per-access-point `delay_total_s` for AP1 and AP2 match the published 0.193 and 0.194 s/veh at ±0.001; and every downstream Step 2-10 performance measure (base FFS, running time, running speed, travel speed, v/c, LOS) reproduces the same published Exhibit 30-36 values as `case1.json`, at the same tolerances documented in `chapter18.md` (e.g., ±0.01 s running time, ±0.01 mi/h travel speed, exact LOS).
 
-Unit tests in `src/hcm/chapter18/tests.rs` cover the equations directly: `test_equation_30_15_queue_spacing`, `test_equation_30_35_permitted_left_capacity`, `test_equation_30_32_probability_lane_change`, and `test_equation_30_53_overflow_probability` at tight (≤1e-9 to 1e-12) tolerances on closed-form arithmetic; `test_access_point_delay_example_problem_1` reproduces the published AP1 eastbound/westbound delay and blockage probability (±0.001) and additionally asserts the free-flow-speed alternative (0.217 s/veh, ±0.002) as a documented sensitivity check, not a pass/fail regression; `test_access_point_delay_single_lane` and `test_access_point_delay_turn_bays` are synthetic sanity checks (finite/non-negative delay for a single-lane approach; near-zero delay and near-zero overflow probability when both turn bays are adequate). For Section 3: `test_equation_30_11_smoothing_factor` and `test_equation_30_12_platoon_arrival_time` check the two closed-form equations against Example Problem 1's own running time (33.54 s) at ±0.0001-0.005; `test_equation_30_9_dispersion_conserves_and_smooths`, `test_proportion_arriving_green_uniform`, `test_equation_30_13_proportion_time_blocked`, and `test_critical_platoon_flow_rate` are synthetic checks of the dispersion recursion's conservation property and the two remaining closed-form equations; `test_movement_discharge_profile_integrates_to_volume` and `test_combined_arrival_profile_and_P` are synthetic checks that the discharge-profile constructor integrates exactly to the input volume and that the combined-profile-to-`P` pipeline runs end to end. `test_serde_round_trip` covers `AccessPointApproach`/`MovementDischarge` serde symmetry. There is no unit or integration test that reproduces the published `P = 0.493` end-to-end value, consistent with the documented "not reproducible from the published intermediates alone" finding above.
+Unit tests in `src/hcm/urban_segments/tests.rs` cover the equations directly: `test_equation_30_15_queue_spacing`, `test_equation_30_35_permitted_left_capacity`, `test_equation_30_32_probability_lane_change`, and `test_equation_30_53_overflow_probability` at tight (≤1e-9 to 1e-12) tolerances on closed-form arithmetic; `test_access_point_delay_example_problem_1` reproduces the published AP1 eastbound/westbound delay and blockage probability (±0.001) and additionally asserts the free-flow-speed alternative (0.217 s/veh, ±0.002) as a documented sensitivity check, not a pass/fail regression; `test_access_point_delay_single_lane` and `test_access_point_delay_turn_bays` are synthetic sanity checks (finite/non-negative delay for a single-lane approach; near-zero delay and near-zero overflow probability when both turn bays are adequate). For Section 3: `test_equation_30_11_smoothing_factor` and `test_equation_30_12_platoon_arrival_time` check the two closed-form equations against Example Problem 1's own running time (33.54 s) at ±0.0001-0.005; `test_equation_30_9_dispersion_conserves_and_smooths`, `test_proportion_arriving_green_uniform`, `test_equation_30_13_proportion_time_blocked`, and `test_critical_platoon_flow_rate` are synthetic checks of the dispersion recursion's conservation property and the two remaining closed-form equations; `test_movement_discharge_profile_integrates_to_volume` and `test_combined_arrival_profile_and_P` are synthetic checks that the discharge-profile constructor integrates exactly to the input volume and that the combined-profile-to-`P` pipeline runs end to end. `test_serde_round_trip` covers `AccessPointApproach`/`MovementDischarge` serde symmetry. There is no unit or integration test that reproduces the published `P = 0.493` end-to-end value, consistent with the documented "not reproducible from the published intermediates alone" finding above.
 
 `tests/test_chapter18_integration.py` was not extended with a `case3` Python-binding test as of this branch (it still exercises only `case1.json`, per `chapter18.md`).
 
@@ -70,4 +275,4 @@ Unit tests in `src/hcm/chapter18/tests.rs` cover the equations directly: `test_e
 
 Per the `platoon_dispersion.rs` module doc comment: driving Section 3 for a full coordinated system requires the upstream signal's phase durations, saturation flows, and queue service times from the Chapter 19 coordinated-actuated engine, together with the Chapter 30, Section 2 origin-destination distribution; this full wiring (which would let Step 3 reproduce Example Problem 1's published `P = 0.493` from raw signal inputs rather than from an analyst-supplied discharge profile) is deferred. The Chapter 30, Section 2 demand-adjustment procedure itself (origin-destination estimation, volume balancing, spillback checks) remains deferred per `chapter18.md`. No new pedestrian/bicycle/transit scope is added by this branch.
 
-The companion Section 3 output — the *proportion of time blocked* p_b consumed by Chapter 20 TWSC Step 5b — is now wired on the `feat/hcm-ch20-computed-pb` branch: `src/hcm/chapter20/computed_pb.rs` reuses these same dispersion primitives (`combined_arrival_profile`, plus the `blocked_period_steps` / q_c = 3,600/t_c blocked-period logic) to build the TWSC `PlatoonBlockage` from upstream-signal descriptors (Equation 30-13). See `docs/hcm/procedures/chapter20.md`, "Step 5b input: computed proportion of time blocked". The same "not reproducible from published intermediates alone" caveat applies to its end-to-end p_b values (0.170 / 0.260 in Chapter 32 Exhibit 32-12, from Chapter 30 Example Problem 1); that module is validated by mechanism tests rather than a published-target regression.
+The companion Section 3 output — the *proportion of time blocked* p_b consumed by Chapter 20 TWSC Step 5b — is now wired on the `feat/hcm-ch20-computed-pb` branch: `src/hcm/twsc/computed_pb.rs` reuses these same dispersion primitives (`combined_arrival_profile`, plus the `blocked_period_steps` / q_c = 3,600/t_c blocked-period logic) to build the TWSC `PlatoonBlockage` from upstream-signal descriptors (Equation 30-13). See `docs/hcm/procedures/chapter20.md`, "Step 5b input: computed proportion of time blocked". The same "not reproducible from published intermediates alone" caveat applies to its end-to-end p_b values (0.170 / 0.260 in Chapter 32 Exhibit 32-12, from Chapter 30 Example Problem 1); that module is validated by mechanism tests rather than a published-target regression.

--- a/docs/hcm/procedures/chapter18.md
+++ b/docs/hcm/procedures/chapter18.md
@@ -1,28 +1,225 @@
 # Chapter 18 — Urban Street Segments
 
-This document walks through the Rust translation of HCM 7th Edition Chapter 18, Section 3 ("Motorized Vehicle Mode"), which is the computational core evaluated per direction of travel for one urban street segment, together with the Exhibit 18-1 LOS criteria of Section 2 and the Equations 18-17 through 18-22 automobile traveler perception score. The implementation lives in `src/hcm/chapter18/urban_segments.rs` (the `UrbanSegment` struct and its ten-step pipeline) and `src/hcm/chapter18/exhibits.rs` (Exhibit 18-1, 18-7, 18-11, and 18-13 lookups), with `src/hcm/chapter18/mod.rs` re-exporting both modules. The module doc comment states this covers "milestone 1": per-direction segment evaluation with analyst-supplied boundary-intersection performance inputs, while the Chapter 30 supplemental procedures for demand balancing (Section 2), platoon dispersion (Section 3), and access-point delay (Section 4) are deferred to a milestone 2, and the pedestrian/bicycle/transit methodologies of Chapter 18 are out of scope entirely for this branch. Boundary-intersection outputs (through control delay, through capacity, and full stop rate) are treated as "HCM method output" inputs per Exhibit 18-5, meaning this module does not itself run the Chapter 19 (signalized), 21 (AWSC), 20 (TWSC), or 22 (roundabout) engines — it expects their results to be supplied through the `UrbanSegment` fields described below, though `shared_lane_through_delay` (Equation 18-10) is provided to help an analyst combine per-lane-group delay outputs from those engines before handing the segment its `through_control_delay_s` input.
+This document walks through the Rust translation of HCM 7th Edition Chapter 18, Section 3 ("Motorized Vehicle Mode"), which is the computational core evaluated per direction of travel for one urban street segment, together with the Exhibit 18-1 LOS criteria of Section 2 and the Equations 18-17 through 18-22 automobile traveler perception score. The implementation lives in `src/hcm/urban_segments/urban_segments.rs` (the `UrbanSegment` struct and its ten-step pipeline) and `src/hcm/urban_segments/exhibits.rs` (Exhibit 18-1, 18-7, 18-11, and 18-13 lookups), with `src/hcm/urban_segments/mod.rs` re-exporting both modules. The module doc comment states this covers "milestone 1": per-direction segment evaluation with analyst-supplied boundary-intersection performance inputs, while the Chapter 30 supplemental procedures for demand balancing (Section 2), platoon dispersion (Section 3), and access-point delay (Section 4) are deferred to a milestone 2, and the pedestrian/bicycle/transit methodologies of Chapter 18 are out of scope entirely for this branch. Boundary-intersection outputs (through control delay, through capacity, and full stop rate) are treated as "HCM method output" inputs per Exhibit 18-5, meaning this module does not itself run the Chapter 19 (signalized), 21 (AWSC), 20 (TWSC), or 22 (roundabout) engines — it expects their results to be supplied through the `UrbanSegment` fields described below, though `shared_lane_through_delay` (Equation 18-10) is provided to help an analyst combine per-lane-group delay outputs from those engines before handing the segment its `through_control_delay_s` input.
 
 ## Step-by-step walkthrough
 
 Step 1, "Determine Traffic Demand Adjustments," is implemented by `UrbanSegment::step_1_demand_adjustment` in `urban_segments.rs`. It is a simplified version of the manual step: flow rates are supplied by the analyst rather than balanced by the module, and the function's only computation is a capacity-constraint check that flags but does not meter demand in excess of capacity. It reads `through_capacity_veh_h` (`Option<f64>`, veh/h) and `through_demand_veh_h` (`f64`, veh/h) and writes `demand_exceeds_capacity` (`Option<bool>`); it also returns the midsegment flow rate `v_m` (veh/h) computed by `midsegment_flow_rate`, which is `midsegment_flow_veh_h` when supplied or else defaults to `through_demand_veh_h` per the Exhibit 18-5 default. The full Chapter 30, Section 2 origin–destination, volume-balance, and spillback-check procedure is out of scope here; the module docs are explicit that analysts must supply already-balanced demand flow rates.
 
+```
+Step 1 has no dedicated HCM equation number — the manual's Section 2 demand-adjustment procedure (origin-destination estimation, volume balancing, spillback checks) is deferred, and this step is only the capacity-constraint flag plus the Exhibit 18-5 midsegment-flow default:
+  demand_exceeds_capacity = c_th.is_some() AND c_th > 0 AND v_th > c_th     [bool, None if c_th absent]
+  v_m = midsegment_flow_veh_h if supplied, else v_th                       [veh/h]  (Exhibit 18-5 default)
+    v_th = through_demand_veh_h, through-demand flow rate at the downstream boundary intersection   (veh/h)
+    c_th = through_capacity_veh_h, through-movement capacity at the downstream boundary intersection (veh/h)
+    v_m  = midsegment demand flow rate, all movements traveling along the segment                    (veh/h)
+  Note: the flag is descriptive only — demand in excess of capacity is not metered (Chapter 30 §2 volume-balance procedure deferred).
+Implemented in: urban_segments/urban_segments.rs::UrbanSegment::step_1_demand_adjustment
+```
+
 Step 2, "Determine Running Time," is the largest step and is implemented by `UrbanSegment::step_2_running_time` in `urban_segments.rs`, which orchestrates several helper functions from `exhibits.rs` and `urban_segments.rs`. The base free-flow speed (Equation 18-3, `S_fo = S_calib + S_0 + f_CS + f_A + f_pk`) is assembled from `speed_constant_s0` (Exhibit 18-11 note a, `S_0 = 25.6 + 0.47 S_pl` from `speed_limit_mph`, mi/h), `cross_section_adjustment` (Exhibit 18-11 note b, `f_CS`, mi/h, from `proportion_restrictive_median()` and `proportion_with_curb`), `access_point_adjustment` (Exhibit 18-11 note c, `f_A`, mi/h, driven by `access_point_density` — points/mi — computed from `n_access_points_subject`, `n_access_points_opposing`, `segment_length_ft`, and `upstream_intersection_width_ft`), and `parking_adjustment` (Exhibit 18-11 note d, `f_pk`, mi/h, from `proportion_on_street_parking`); all four helpers live in `exhibits.rs`. The signal-spacing adjustment (Equation 18-4, `f_L = 1.02 − 4.7(S_fo − 19.5)/max(L_s, 400) ≤ 1.0`) is `signal_spacing_adjustment` in `urban_segments.rs`, taking `base_ffs_mph` (mi/h) and `signal_spacing_ft` (ft, defaulting to `segment_length_ft`) and returning the dimensionless factor `f_L`. Free-flow speed (Equation 18-5, `S_f = max(S_fo f_L, S_pl)`) is computed inline in `step_2_running_time`, mi/h, and is overridden entirely by `free_flow_speed_override_mph` (mi/h) when the analyst supplies a field-measured value. Vehicle proximity (Equation 18-6, `f_v = 2/(1 + (1 − v_m/(52.8 N_th S_f))^0.21)`) is `proximity_adjustment` in `urban_segments.rs`, taking midsegment demand `v_m` (veh/h), `n_through_lanes` (ln), and `S_f` (mi/h) and returning the dimensionless factor `f_v`; the ratio inside the exponent is clamped to `[0, 0.999999]` to keep the exponentiation real for out-of-range demand, a defensive clamp not explicit in the manual text. Delay due to turning vehicles at access points is either the sum of an analyst-supplied `access_point_delays_s` (`Vec<f64>`, s/veh per access point — the Chapter 30, Section 4 procedure output) or, when absent, the Exhibit 18-13 planning estimate via `exhibit_18_13_turn_delay_adjusted` in `exhibits.rs`, which looks up `exhibit_18_13_turn_delay` (s/veh/pt, by midsegment volume per lane and lane count) and applies the turn-percentage and turn-bay adjustments described in the Chapter 18 text (percentage scaling by `(pct_left + pct_right)/20`, and a 0.5/0.0 multiplier for one/two adequate turn bays). Segment running time itself (Equations 18-7 and 18-8, `t_R = (6 − l1)/(0.0025 L) f_X + (3600 L)/(5280 S_f) f_v + Σd_ap,i + d_other`) is computed inline: start-up lost time `l1` and the first-term multiplier `f_X` are chosen by `control` (2.0 s / 1.0 for `Signalized`, 2.5 s / 1.0 for `AllWayStop`, 2.5 s / v/c-capped-at-1.0 for `YieldControlled`/`Roundabout`, 2.5 s / 0.0 for `Uncontrolled`), and `midsegment_other_delay_s` (s/veh) is added as `d_other`. The step writes `speed_constant_mph`, `f_cs_mph`, `f_a_mph`, `f_pk_mph`, `base_ffs_mph`, `f_l`, `free_flow_speed_mph`, `f_v`, `access_point_delay_total_s`, `running_time_s` (t_R, s), and `running_speed_mph` (mi/h, `= 3,600 L/(5,280 t_R)`, per the Chapter 18 Step 2 discussion of Exhibit 18-12). Two spec gaps are cross-referenced to the VERIFICATION.md Chapter 18 entry: `exhibit_18_13_turn_delay` clamps its midsegment-volume input to 200–700 veh/h/ln because the exhibit is undefined outside that range, and `access_point_density`/related lookups have no analogous manual guidance for degenerate (zero or negative) link lengths beyond the `link <= 0.0 → 0.0` guard in the code.
 
-Step 3, "Determine the Proportion of Vehicles Arriving During Green," is `UrbanSegment::step_3_proportion_arriving_green` in `urban_segments.rs`. It applies HCM Equation 19-15, `P = R_p g/C`, using `effective_green_s` (g, s) and `cycle_length_s` (C, s), with the platoon ratio `R_p` taken from `platoon_ratio` (`Option<f64>`) if supplied, else mapped from `arrival_type` (`Option<u8>`, 1–6) via `platoon_ratio_for_arrival_type` in `crate::hcm::chapter19::exhibits` (the Exhibit 19-13 arrival-type-to-platoon-ratio mapping), else defaulting to `R_p = 1.0` (uniform arrivals, `P = g/C`) per the Chapter 18 Step 3 text for a noncoordinated upstream intersection. It returns `None` — and leaves `proportion_arriving_green` as `None` — when `control` is not `Signalized` or when `effective_green_s`/`cycle_length_s` are absent. The result `P` (decimal, 0–1, capped at 1.0) is stored in `proportion_arriving_green`; the Chapter 30, Section 3 platoon-dispersion arrival-profile procedure for coordinated systems, which would otherwise supply `P` directly, is deferred to milestone 2.
+```
+Equation 18-3:  S_fo = S_calib + S_0 + f_CS + f_A + f_pk     [mi/h]
+  S_fo    = base free-flow speed                                                  (mi/h)
+  S_calib = base free-flow speed calibration factor (default 0.0; field-calibrated per Chapter 30 §6) (mi/h)
+  S_0     = speed constant (Exhibit 18-11, note a)                                (mi/h)
+  f_CS    = adjustment for cross section (Exhibit 18-11, note b)                  (mi/h)
+  f_A     = adjustment for access points (Exhibit 18-11, note c)                  (mi/h)
+  f_pk    = adjustment for on-street parking (Exhibit 18-11, note d)              (mi/h)
+
+  Exhibit 18-11, note a:  S_0 = 25.6 + 0.47·S_pl     [mi/h]
+    S_pl = posted speed limit                                                    (mi/h)
+  Implemented in: urban_segments/exhibits.rs::speed_constant_s0
+
+  Exhibit 18-11, note b:  f_CS = 1.5·p_rm − 0.47·p_curb − 3.7·p_curb·p_rm     [mi/h]
+    p_rm   = proportion of link length with a restrictive median                 (decimal)
+    p_curb = proportion of segment with curb on the right-hand side, within 4 ft of the traveled way (decimal; Exhibit 18-5 default 1.0)
+  Implemented in: urban_segments/exhibits.rs::cross_section_adjustment (p_rm via urban_segments.rs::UrbanSegment::proportion_restrictive_median)
+
+  Exhibit 18-11, note c:  D_a = 5,280·(N_ap,s + N_ap,o) / (L − W_i)     [points/mi]
+                          f_A = −0.078·D_a / N_th                       [mi/h]
+    N_ap,s = access point approaches on the right side, subject direction of travel (points)
+    N_ap,o = access point approaches on the right side, opposing direction of travel (points)
+    L      = segment length                                                      (ft)
+    W_i    = width of the upstream signalized intersection                       (ft)
+    N_th   = number of through lanes on the segment in the subject direction     (ln)
+  Implemented in: urban_segments/exhibits.rs::access_point_density, urban_segments/exhibits.rs::access_point_adjustment
+
+  Exhibit 18-11, note d:  f_pk = −3.0 · p_pk     [mi/h]
+    p_pk = proportion of link length with on-street parking available on the right-hand side (decimal)
+  Implemented in: urban_segments/exhibits.rs::parking_adjustment
+Implemented in: urban_segments/urban_segments.rs::UrbanSegment::step_2_running_time
+
+Equation 18-4:  f_L = 1.02 − 4.7·(S_fo − 19.5) / max(L_s, 400)  ≤ 1.0     [unitless]
+  S_fo = base free-flow speed (Eq. 18-3)                                          (mi/h)
+  L_s  = distance between the two intersections that bracket the subject segment and can legally require the through movement to stop or yield; defaults to segment_length_ft (ft)
+Implemented in: urban_segments/urban_segments.rs::signal_spacing_adjustment
+
+Equation 18-5:  S_f = max(S_fo · f_L, S_pl)     [mi/h]
+  S_fo = base free-flow speed (Eq. 18-3)                                          (mi/h)
+  f_L  = signal spacing adjustment factor (Eq. 18-4)                              (unitless)
+  S_pl = posted speed limit                                                       (mi/h)
+  Note: overridden entirely by free_flow_speed_override_mph when the analyst supplies a field-measured value (Chapter 30 §6 field procedure).
+Implemented in: urban_segments/urban_segments.rs::UrbanSegment::step_2_running_time (inline)
+
+Equation 18-6:  f_v = 2 / (1 + (1 − v_m/(52.8·N_th·S_f))^0.21)     [unitless]
+  v_m  = midsegment demand flow rate                                              (veh/h)
+  N_th = number of through lanes in the subject direction of travel               (ln)
+  S_f  = free-flow speed (Eq. 18-5)                                               (mi/h)
+  Note: the ratio inside the exponent is clamped to [0, 0.999999] in code, a defensive clamp not explicit in the manual text (VERIFICATION.md Chapter 18 entry).
+Implemented in: urban_segments/urban_segments.rs::proximity_adjustment
+
+Equation 18-7:  t_R = (6.0 − l1)/(0.0025·L)·f_X + (3,600·L)/(5,280·S_f)·f_v + Σ_{i=1}^{N_ap} d_ap,i + d_other     [s]
+  l1      = start-up lost time: 2.0 if signalized; 2.5 if STOP or YIELD controlled                     (s)
+  L       = segment length                                                                              (ft)
+  f_X     = control-type adjustment factor (Eq. 18-8)                                                   (unitless)
+  S_f     = free-flow speed (Eq. 18-5)                                                                  (mi/h)
+  f_v     = proximity adjustment factor (Eq. 18-6)                                                      (unitless)
+  d_ap,i  = delay due to left and right turns from the street into access point intersection i (analyst-supplied, computed via the Chapter 30 §4 procedure, or the Exhibit 18-13 planning estimate — see the discussion above; the Exhibit 18-13 lookup clamps its midsegment-volume input to 200-700 veh/h/ln, a documented spec gap) (s/veh)
+  N_ap    = number of influential access point approaches = N_ap,s + p_ap,lt·N_ap,o                     (points)
+  d_other = delay due to other midsegment sources (e.g., curb parking, pedestrians)                      (s/veh)
+Implemented in: urban_segments/urban_segments.rs::UrbanSegment::step_2_running_time (inline)
+
+Equation 18-8:  f_X = 1.00                     if signalized or STOP-controlled through movement
+                    = 0.00                     if uncontrolled through movement
+                    = min(v_th/c_th, 1.00)      if YIELD-controlled through movement     [unitless]
+  v_th = through-demand flow rate                                                        (veh/h)
+  c_th = through-movement capacity                                                       (veh/h)
+  Code detail: (l1, f_X) pairs by `control` are Signalized (2.0, 1.0), AllWayStop (2.5, 1.0) — both fall under the manual's "signalized or STOP-controlled" f_X = 1.00 case, differing only in l1 per the Eq. 18-7 where-clause — YieldControlled/Roundabout (2.5, min(v_th/c_th, 1.0), defaulting to 1.0 when capacity is unknown), Uncontrolled (2.5, 0.0).
+Implemented in: urban_segments/urban_segments.rs::UrbanSegment::step_2_running_time (inline)
+```
+
+Step 3, "Determine the Proportion of Vehicles Arriving During Green," is `UrbanSegment::step_3_proportion_arriving_green` in `urban_segments.rs`. It applies HCM Equation 19-15, `P = R_p g/C`, using `effective_green_s` (g, s) and `cycle_length_s` (C, s), with the platoon ratio `R_p` taken from `platoon_ratio` (`Option<f64>`) if supplied, else mapped from `arrival_type` (`Option<u8>`, 1–6) via `platoon_ratio_for_arrival_type` in `crate::hcm::signalized::exhibits` (the Exhibit 19-13 arrival-type-to-platoon-ratio mapping), else defaulting to `R_p = 1.0` (uniform arrivals, `P = g/C`) per the Chapter 18 Step 3 text for a noncoordinated upstream intersection. It returns `None` — and leaves `proportion_arriving_green` as `None` — when `control` is not `Signalized` or when `effective_green_s`/`cycle_length_s` are absent. The result `P` (decimal, 0–1, capped at 1.0) is stored in `proportion_arriving_green`; the Chapter 30, Section 3 platoon-dispersion arrival-profile procedure for coordinated systems, which would otherwise supply `P` directly, is deferred to milestone 2.
+
+```
+Equation 19-15:  P = R_p · g / C     [decimal, 0-1]
+  R_p = platoon ratio: from `platoon_ratio` if supplied, else the Exhibit 19-13 arrival-type mapping (`arrival_type`, 1-6), else 1.0 (uniform arrivals) per the Chapter 18 Step 3 text for a noncoordinated upstream intersection (unitless)
+  g   = effective green time for the phase serving the through movement at the downstream signal   (s)
+  C   = cycle length at the downstream signal                                                       (s)
+  Note: P is capped at 1.0 in code; the step returns None entirely when `control` is not Signalized or when g/C are absent.
+Implemented in: urban_segments/urban_segments.rs::UrbanSegment::step_3_proportion_arriving_green
+```
 
 Step 4, "Determine Signal Phase Duration," is not implemented as a computation. `cycle_length_s` and `effective_green_s` are plain analyst-supplied input fields on `UrbanSegment`; the module docs direct the analyst to the Chapter 19 pretimed/coordinated timing engine to obtain them, and note that the actuated average-phase-duration loop is deferred along with it.
 
+```
+Step 4 has no HCM equation implemented here — the manual directs pretimed signals to use an input phase duration directly, and actuated signals to the Section 3 (Chapter 19) average-phase-duration procedure, iterating Steps 1-4 to convergence when the boundary intersections are coordinated. This module takes `cycle_length_s` (C, s) and `effective_green_s` (g, s) as plain analyst-supplied fields rather than computing or iterating them; the Chapter 19 actuated timing engine and the Steps 1-4 convergence loop are deferred to milestone 2.
+Implemented in: (input fields only) urban_segments/urban_segments.rs::UrbanSegment::cycle_length_s, ::effective_green_s
+```
+
 Step 5, "Determine Through Delay," is `UrbanSegment::step_5_through_delay` in `urban_segments.rs`. For any controlled boundary it passes through `through_control_delay_s` (`Option<f64>`, s/veh, defaulting to 0.0 if absent) as the through delay `d_t`; for `BoundaryControlType::Uncontrolled` it hard-codes `d_t = 0.0` s/veh per the Chapter 18 text (the major-street through movement at a TWSC boundary intersection is uncontrolled). The result is written to `through_delay_s`. As noted above, this is where the Chapter 19/20/21/22 signalized/unsignalized delay engines are expected to feed in — `through_control_delay_s` is documented as "HCM method output" — and `shared_lane_through_delay` (Equation 18-10, `d_t = (d_th v_t N_t + d_sl v_sl(1 − P_L) + d_sr v_sr(1 − P_R))/v_th`) is available as a standalone helper to combine exclusive-through and shared-lane delay outputs from those engines into the single `through_control_delay_s` scalar before it is assigned. Delay imposed on the major street by turning traffic at a TWSC boundary is explicitly not modeled in this step (per the module docs it "appears midsegment via the access-point delay terms" from Step 2 instead).
+
+```
+Step 5 pass-through (no dedicated HCM equation number for the step itself — control delay is the "HCM method output" of Chapters 19/21/22, or 0.0 s/veh for an uncontrolled through movement per the Chapter 18 text):
+  d_t = 0.0                                          if control == Uncontrolled
+      = through_control_delay_s, default 0.0         otherwise     [s/veh]
+Implemented in: urban_segments/urban_segments.rs::UrbanSegment::step_5_through_delay
+
+Equation 18-10:  d_t = (d_th·v_t·N_t + d_sl·v_sl·(1 − P_L) + d_sr·v_sr·(1 − P_R)) / v_th     [s/veh]
+  d_th, v_t, N_t = delay (s/veh), demand flow rate per lane (veh/h/ln), and lane count of the exclusive-through lane group
+  d_sl, v_sl, P_L = delay (s/veh), demand flow rate (veh/h), and proportion of left-turning vehicles in the shared left-turn/through lane group
+  d_sr, v_sr, P_R = same for the shared right-turn/through lane group
+  v_th = through-demand flow rate                                                                        (veh/h)
+  Note: a standalone helper for an analyst to combine per-lane-group delay outputs from the Chapter 19/21/22 engines into the single through_control_delay_s scalar before Step 5 reads it; not called by step_5_through_delay itself.
+Implemented in: urban_segments/urban_segments.rs::shared_lane_through_delay
+```
 
 Step 6, "Determine Through Stop Rate," is `UrbanSegment::step_6_stop_rate` in `urban_segments.rs`. If `full_stop_rate_override` (`Option<f64>`, stops/veh) is set, it is returned directly. Otherwise, for `Signalized` control the step evaluates Equation 18-11 via `full_stop_rate_signalized` in `urban_segments.rs`, `h = 3,600[N_f/(min(1, v_th C/(N_th s g)) g s) + N_th Q_2+3/(v_th C)]`, using `stopped_vehicles_veh_ln` (N_f, veh/ln), `queue2_veh_ln` + `queue3_veh_ln` (Q_2, Q_3, veh/ln, summed to Q_2+3), `effective_green_s` (g, s), `sat_flow_veh_h_ln` (s, veh/h/ln), `through_demand_veh_h` (v_th, veh/h), `cycle_length_s` (C, s), and `n_through_lanes` (N_th, ln); it returns `None` if any required Chapter 31 input is missing. For `AllWayStop` it returns 1.0 stops/veh; for `Uncontrolled` it returns 0.0 stops/veh; for `YieldControlled` and `Roundabout` it returns the through-movement v/c ratio (`through_demand_veh_h / through_capacity_veh_h`, or `None` if capacity is unavailable) — all per the Chapter 18 text defaults documented in the code. When the through movement is served across multiple lane groups, `weighted_through_lane_value` (Equations 18-12, 18-13, and 18-14, a shared per-lane weighting formula for N_f, adjusted saturation flow rate, and back-of-queue size) is provided as a standalone helper to compute the weighted N_f/s/Q_2+3 inputs before calling `full_stop_rate_signalized`. The result is written to `full_stop_rate` (h, stops/veh).
 
+```
+Equation 18-11:  h = 3,600·[ N_f / (min(1, v_th·C/(N_th·s·g))·g·s) + N_th·Q_2+3/(v_th·C) ]     [stops/veh]
+  N_f    = number of fully stopped vehicles (Chapter 31 §4 output; Eq. 18-12 weighting for multiple lane groups)  (veh/ln)
+  Q_2+3  = Q_2 + Q_3, second- plus third-term back-of-queue size (Chapter 31 output; Eq. 18-14 weighting)          (veh/ln)
+  g      = effective green time                                                                                   (s)
+  s      = adjusted saturation flow rate of the through lane group (Eq. 18-13 weighting)                          (veh/h/ln)
+  v_th   = through-demand flow rate                                                                               (veh/h)
+  C      = cycle length                                                                                           (s)
+  N_th   = number of through lanes, shared or exclusive                                                           (ln)
+Implemented in: urban_segments/urban_segments.rs::full_stop_rate_signalized
+
+Equations 18-12 / 18-13 / 18-14 (shared per-lane weighting formula):
+  x = (x_t·N_t + x_sl·(1 − P_L) + x_sr·(1 − P_R)) / N_th
+    Eq. 18-12:  x = N_f (number of fully stopped vehicles)                (veh/ln)
+    Eq. 18-13:  x = s (adjusted saturation flow rate)                     (veh/h/ln)
+    Eq. 18-14:  x = Q_2+3 (back-of-queue size)                            (veh/ln)
+  x_t, N_t = per-lane value and lane count of the exclusive-through lane group
+  x_sl, P_L = per-lane value of the shared left/through lane group and proportion of left-turning vehicles in it
+  x_sr, P_R = same for the shared right/through lane group
+  N_th = number of through lanes, shared or exclusive                     (ln)
+Implemented in: urban_segments/urban_segments.rs::weighted_through_lane_value
+
+Unsignalized/YIELD defaults (Chapter 18 text, no equation number):
+  h = 1.0            AllWayStop
+    = 0.0            Uncontrolled
+    = v_th / c_th    YieldControlled | Roundabout (returns None if c_th is unavailable)     [stops/veh]
+Implemented in: urban_segments/urban_segments.rs::UrbanSegment::step_6_stop_rate
+```
+
 Step 7, "Determine Travel Speed," is `UrbanSegment::step_7_travel_speed` in `urban_segments.rs`, implementing Equation 18-15, `S_T,seg = 3,600 L/(5,280(t_R + d_t))`. It requires `running_time_s` (t_R, s, from Step 2) and `through_delay_s` (d_t, s/veh, from Step 5), combines them with `segment_length_ft` (L, ft), and writes `travel_speed_mph` (S_T,seg, mi/h); it returns `None` if either prerequisite step has not run.
+
+```
+Equation 18-15:  S_T,seg = 3,600·L / (5,280·(t_R + d_t))     [mi/h]
+  L   = segment length                                            (ft)
+  t_R = segment running time (Step 2, Eq. 18-7)                   (s)
+  d_t = through delay (Step 5)                                    (s/veh)
+Implemented in: urban_segments/urban_segments.rs::UrbanSegment::step_7_travel_speed
+```
 
 Step 8, "Determine Spatial Stop Rate," is `UrbanSegment::step_8_spatial_stop_rate` in `urban_segments.rs`, implementing Equation 18-16, `H_seg = 5,280(h + h_other)/L`. It requires `full_stop_rate` (h, stops/veh, from Step 6), adds `stop_rate_other` (h_other, stops/veh), divides by `segment_length_ft` (L, ft), and writes `spatial_stop_rate_stops_mi` (H_seg, stops/mi).
 
+```
+Equation 18-16:  H_seg = 5,280·(h + h_other) / L     [stops/mi]
+  h       = full stop rate (Step 6)                                  (stops/veh)
+  h_other = stop rate due to other midsegment sources                (stops/veh)
+  L       = segment length                                           (ft)
+Implemented in: urban_segments/urban_segments.rs::UrbanSegment::step_8_spatial_stop_rate
+```
+
 Step 9, "Determine LOS," is `UrbanSegment::step_9_los` in `urban_segments.rs`, delegating the table lookup to `exhibit_18_1_los` in `exhibits.rs`. It requires `travel_speed_mph` (S_T,seg, mi/h, Step 7) and `base_ffs_mph` (S_fo, mi/h, Step 2), computes the through-movement v/c ratio from `through_capacity_veh_h` and `through_demand_veh_h` (writing it to `vc_ratio`), and passes `vc_ratio > 1.0` as a flag that forces LOS F regardless of speed. `exhibit_18_1_los` interpolates the Exhibit 18-1 travel-speed thresholds for LOS A–E via `exhibit_18_1_speed_thresholds`, which linearly interpolates between the tabulated base-free-flow-speed column headings `{55, 50, 45, 40, 35, 30, 25}` mi/h as directed by the Chapter 18 text, and clamps `base_ffs_mph` to `[25, 55]` mi/h when it falls outside the tabulated range — a spec gap cross-referenced to the VERIFICATION.md Chapter 18 entry, since Exhibit 18-1 does not define thresholds beyond its column headings. When no capacity input is available, `vc_ratio` remains `None` and the v/c > 1.0 rule is simply not evaluated (treated as v/c ≤ 1.0), which is a code-level default rather than an HCM-specified behavior. The result is written to `los` (`LevelOfService`, from `crate::hcm::common`).
 
+```
+Exhibit 18-1 interpolation mechanism (no HCM equation number; the Chapter 18 text: "The threshold value is interpolated when the base free-flow speed is between the values shown in the column headings"):
+  frac = (S_fo − BFFS_lo) / (BFFS_hi − BFFS_lo)
+  threshold[LOS] = row[BFFS_lo] + frac · (row[BFFS_hi] − row[BFFS_lo])     [mi/h]
+    S_fo          = base free-flow speed (Eq. 18-3)                                          (mi/h)
+    BFFS_hi, BFFS_lo = the two tabulated base-free-flow-speed column headings from
+                       {55, 50, 45, 40, 35, 30, 25} mi/h that bracket S_fo
+    row[BFFS_hi], row[BFFS_lo] = the Exhibit 18-1 tabulated travel-speed threshold cell values
+                       for a given LOS letter (A-E) at those two column headings — copyrighted
+                       exhibit data, cited by function name only, not transcribed here
+  Note: S_fo is clamped to [25, 55] mi/h before interpolating when it falls outside the tabulated range — a documented spec gap (VERIFICATION.md Chapter 18 entry), since Exhibit 18-1 does not define thresholds beyond its column headings. The Chapter 18 text's own worked example (S_fo = 42 mi/h) rounds its interpolated LOS A threshold to 34 mi/h in prose; the code's unrounded arithmetic gives 33.6 mi/h, matched by `test_exhibit_18_1_interpolation_chapter_text_example`.
+Implemented in: urban_segments/exhibits.rs::exhibit_18_1_speed_thresholds
+
+LOS assignment:
+  LOS = F                                    if vc_ratio > 1.0   (through-movement v/c at the downstream boundary, forces LOS F regardless of speed)
+      = A                                    if S_T,seg > threshold[A]
+      = B                                    if S_T,seg > threshold[B]
+      = C                                    if S_T,seg > threshold[C]
+      = D                                    if S_T,seg > threshold[D]
+      = E                                    if S_T,seg > threshold[E]
+      = F                                    otherwise
+    vc_ratio = through_demand_veh_h / through_capacity_veh_h                                 (unitless)
+    S_T,seg  = travel speed (Step 7, Eq. 18-15)                                              (mi/h)
+Implemented in: urban_segments/exhibits.rs::exhibit_18_1_los; urban_segments/urban_segments.rs::UrbanSegment::step_9_los
+```
+
 Step 10, "Determine Automobile Traveler Perception Score," is `UrbanSegment::step_10_perception_score` in `urban_segments.rs`, implementing Equations 18-17 through 18-22 via the free function `traveler_perception_score` in the same file: `I_a,seg = 1 + P_BCDEF + P_CDEF + P_DEF + P_EF + P_F`, with each `P_x = (1 + e^(a_x − 0.253 H_seg + 0.3434 P_LTL,seg))^-1` and intercepts `a = {−1.1614, 0.6234, 1.7389, 2.7047, 3.8044}`. It requires `spatial_stop_rate_stops_mi` (H_seg, stops/mi, from Step 8) and the input `prop_left_turn_lanes` (P_LTL,seg, decimal proportion of segment intersections with a left-turn lane or bay), and writes the dimensionless score to `perception_score`.
+
+```
+Equation 18-17:  I_a,seg = 1 + P_BCDEF + P_CDEF + P_DEF + P_EF + P_F     [unitless score]
+
+Equation 18-18:  P_BCDEF = (1 + e^(−1.1614 − 0.253·H_seg + 0.3434·P_LTL,seg))^-1
+Equation 18-19:  P_CDEF  = (1 + e^( 0.6234 − 0.253·H_seg + 0.3434·P_LTL,seg))^-1
+Equation 18-20:  P_DEF   = (1 + e^( 1.7389 − 0.253·H_seg + 0.3434·P_LTL,seg))^-1
+Equation 18-21:  P_EF    = (1 + e^( 2.7047 − 0.253·H_seg + 0.3434·P_LTL,seg))^-1
+Equation 18-22:  P_F     = (1 + e^( 3.8044 − 0.253·H_seg + 0.3434·P_LTL,seg))^-1
+
+  H_seg      = spatial stop rate (Step 8, Eq. 18-16)                                        (stops/mi)
+  P_LTL,seg  = proportion of segment intersections with a left-turn lane or bay (`prop_left_turn_lanes`) (decimal)
+  Intercepts a = {−1.1614, 0.6234, 1.7389, 2.7047, 3.8044} for P_BCDEF, P_CDEF, P_DEF, P_EF, P_F respectively.
+Implemented in: urban_segments/urban_segments.rs::traveler_perception_score
+```
 
 `UrbanSegment::analyze`, also in `urban_segments.rs`, runs Steps 1, 2, 3, 5, 6, 7, 8, 9, and 10 in that order (Step 4 is skipped because it is an input, not a computation), mutating the struct's `Option` result fields in place.
 
@@ -30,27 +227,44 @@ The following table summarizes the step-to-implementation mapping:
 
 | HCM Step | Equations / Exhibits | Rust function | File |
 |---|---|---|---|
-| 1. Traffic demand adjustments | (simplified; Ch. 30 §2 deferred) | `UrbanSegment::step_1_demand_adjustment` | `src/hcm/chapter18/urban_segments.rs` |
-| 2. Running time | Eq. 18-3–18-8, Exhibits 18-11, 18-13 | `UrbanSegment::step_2_running_time` (+ `speed_constant_s0`, `cross_section_adjustment`, `access_point_density`, `access_point_adjustment`, `parking_adjustment` in `exhibits.rs`; `signal_spacing_adjustment`, `proximity_adjustment` in `urban_segments.rs`; `exhibit_18_13_turn_delay(_adjusted)` in `exhibits.rs`) | `src/hcm/chapter18/urban_segments.rs`, `src/hcm/chapter18/exhibits.rs` |
-| 3. Proportion arriving on green | Eq. 19-15, Exhibit 19-13 | `UrbanSegment::step_3_proportion_arriving_green` (+ `platoon_ratio_for_arrival_type` in `chapter19::exhibits`) | `src/hcm/chapter18/urban_segments.rs` |
-| 4. Signal phase duration | (input; Ch. 19 engine) | not implemented — `cycle_length_s`, `effective_green_s` fields | `src/hcm/chapter18/urban_segments.rs` |
-| 5. Through delay | Eq. 18-10 (weighting helper) | `UrbanSegment::step_5_through_delay` (+ `shared_lane_through_delay`) | `src/hcm/chapter18/urban_segments.rs` |
-| 6. Through stop rate | Eq. 18-11–18-14 | `UrbanSegment::step_6_stop_rate` (+ `full_stop_rate_signalized`, `weighted_through_lane_value`) | `src/hcm/chapter18/urban_segments.rs` |
-| 7. Travel speed | Eq. 18-15 | `UrbanSegment::step_7_travel_speed` | `src/hcm/chapter18/urban_segments.rs` |
-| 8. Spatial stop rate | Eq. 18-16 | `UrbanSegment::step_8_spatial_stop_rate` | `src/hcm/chapter18/urban_segments.rs` |
-| 9. LOS | Exhibit 18-1 | `UrbanSegment::step_9_los` (+ `exhibit_18_1_los`, `exhibit_18_1_speed_thresholds`) | `src/hcm/chapter18/urban_segments.rs`, `src/hcm/chapter18/exhibits.rs` |
-| 10. Traveler perception score | Eq. 18-17–18-22 | `UrbanSegment::step_10_perception_score` (+ `traveler_perception_score`) | `src/hcm/chapter18/urban_segments.rs` |
+| 1. Traffic demand adjustments | (simplified; Ch. 30 §2 deferred) | `UrbanSegment::step_1_demand_adjustment` | `src/hcm/urban_segments/urban_segments.rs` |
+| 2. Running time | Eq. 18-3–18-8, Exhibits 18-11, 18-13 | `UrbanSegment::step_2_running_time` (+ `speed_constant_s0`, `cross_section_adjustment`, `access_point_density`, `access_point_adjustment`, `parking_adjustment` in `exhibits.rs`; `signal_spacing_adjustment`, `proximity_adjustment` in `urban_segments.rs`; `exhibit_18_13_turn_delay(_adjusted)` in `exhibits.rs`) | `src/hcm/urban_segments/urban_segments.rs`, `src/hcm/urban_segments/exhibits.rs` |
+| 3. Proportion arriving on green | Eq. 19-15, Exhibit 19-13 | `UrbanSegment::step_3_proportion_arriving_green` (+ `platoon_ratio_for_arrival_type` in `signalized::exhibits`) | `src/hcm/urban_segments/urban_segments.rs` |
+| 4. Signal phase duration | (input; Ch. 19 engine) | not implemented — `cycle_length_s`, `effective_green_s` fields | `src/hcm/urban_segments/urban_segments.rs` |
+| 5. Through delay | Eq. 18-10 (weighting helper) | `UrbanSegment::step_5_through_delay` (+ `shared_lane_through_delay`) | `src/hcm/urban_segments/urban_segments.rs` |
+| 6. Through stop rate | Eq. 18-11–18-14 | `UrbanSegment::step_6_stop_rate` (+ `full_stop_rate_signalized`, `weighted_through_lane_value`) | `src/hcm/urban_segments/urban_segments.rs` |
+| 7. Travel speed | Eq. 18-15 | `UrbanSegment::step_7_travel_speed` | `src/hcm/urban_segments/urban_segments.rs` |
+| 8. Spatial stop rate | Eq. 18-16 | `UrbanSegment::step_8_spatial_stop_rate` | `src/hcm/urban_segments/urban_segments.rs` |
+| 9. LOS | Exhibit 18-1 | `UrbanSegment::step_9_los` (+ `exhibit_18_1_los`, `exhibit_18_1_speed_thresholds`) | `src/hcm/urban_segments/urban_segments.rs`, `src/hcm/urban_segments/exhibits.rs` |
+| 10. Traveler perception score | Eq. 18-17–18-22 | `UrbanSegment::step_10_perception_score` (+ `traveler_perception_score`) | `src/hcm/urban_segments/urban_segments.rs` |
 
-Two additional free functions exist outside the numbered pipeline but are part of the Chapter 18 equation set: `default_access_point_count` (Equation 18-1, `N_ap,s = 0.5 D_a L/5,280`) and `through_capacity_uncontrolled` (Equation 18-2, `c_th = 1,800(N_th − 1 + p*_0,j)`, for the uncontrolled through movement's capacity at a TWSC boundary). The doc comment on `through_capacity_uncontrolled` notes, and the VERIFICATION.md Chapter 18 entry confirms, that the Chapter 18 text cites "Equation 20-43" for `p*_0,j`, which is an HCM 6th Edition equation number; the HCM 7th Edition equivalents are Equations 20-29 through 20-34 (computed elsewhere by `Twsc::prob_queue_free_shared_major`), and 7th-edition Equation 20-43 is instead the Rank 4 movement capacity equation — a citation mismatch in the manual text rather than in this code.
+Two additional free functions exist outside the numbered pipeline but are part of the Chapter 18 equation set: `default_access_point_count` (Equation 18-1, `N_ap,s = 0.5 D_a L/5,280`) and `through_capacity_uncontrolled` (Equation 18-2, `c_th = 1,800(N_th − 1 + p*_0,j)`, for the uncontrolled through movement's capacity at a TWSC boundary). The doc comment on `through_capacity_uncontrolled` notes, and the VERIFICATION.md Chapter 18 entry confirms, that the Chapter 18 text cites "Equation 20-43" for `p*_0,j`, which is an HCM 6th Edition equation number; the HCM 7th Edition equivalents are Equations 20-29 through 20-34 (computed elsewhere by `Twsc::prob_queue_free_shared_major` in `src/hcm/twsc/twsc.rs`), and 7th-edition Equation 20-43 is instead the Rank 4 movement capacity equation — a citation mismatch in the manual text rather than in this code.
+
+```
+Equation 18-1:  N_ap,s = 0.5 · D_a · L / 5,280     [points]
+  D_a = access point density on the segment (e.g., the Exhibit 18-7 default)   (points/mi)
+  L   = segment length                                                         (ft)
+  Note: a default estimate used only when the actual access point count is not known.
+Implemented in: urban_segments/urban_segments.rs::default_access_point_count
+
+Equation 18-2:  c_th = 1,800 · (N_th − 1 + p*_0,j)     [veh/h]
+  N_th    = number of through lanes, shared or exclusive                       (ln)
+  p*_0,j  = probability that there will be no queue in the inside through lane; equal to 1.0
+            if a left-turn bay is provided for left turns from the major street, otherwise
+            computed with `Twsc::prob_queue_free_shared_major` (HCM 7th Edition Equations
+            20-29 through 20-34 — the Chapter 18 text's "Equation 20-43" citation is the
+            HCM 6th Edition number for this same quantity; see the discrepancy note above)
+Implemented in: urban_segments/urban_segments.rs::through_capacity_uncontrolled; p*_0,j via twsc/twsc.rs::Twsc::prob_queue_free_shared_major
+```
 
 ## Validation
 
 The primary validation fixture is HCM 7th Edition Chapter 30 ("Urban Street Segments: Supplemental"), Section 8, Example Problem 1 ("Motorized Vehicle LOS"), Exhibits 30-26 through 30-36. Two directions of that example are reproduced as JSON fixtures under `tests/ExampleCases/hcm/UrbanSegments/`: `case1.json` (eastbound, using the published Chapter 30 Section 4 per-access-point turning delays from Exhibit 30-35 as direct inputs) and `case2.json` (westbound, using the Exhibit 18-13 planning-level turning-delay estimate instead of the Section 4 procedure, to exercise that code path). Both are exercised by the Rust integration tests in `tests/chapter18_integration.rs`: `test_case1_example_problem_1_eastbound` and `test_case2_example_problem_1_westbound_planning_estimate`, plus a serde-round-trip check `test_fixture_round_trip`. For `case1.json`, tolerances are ±0.01 mi/h for base FFS/free-flow speed, ±0.01 s for running time, ±0.01 mi/h for running speed and travel speed, ±0.001 s/veh for through delay, ±0.001 stops/veh for stop rate, ±0.01 stops/mi for spatial stop rate, ±0.005 for v/c, exact match for LOS, and ±0.01 for perception score, with intermediate Step 2 chain values (S_0, f_CS, f_A at ±0.001, f_L at ±0.0005, f_v at ±0.0005) also checked; the Step 3 proportion arriving on green is checked at ±0.001 against the milestone-1 uniform-arrival value of 0.486, with the test comment noting the published (platoon-dispersion) engine value is 0.493 — a documented, expected deviation since Chapter 30 Section 3 dispersion is deferred. For `case2.json`, the access-point delay total is checked against the Exhibit 18-13 estimate (0.540 s, ±0.005) rather than the published Section 4 value (0.387 s), and running time and travel speed are each asserted twice: once loosely against the published Exhibit 30-36 values (±0.5 s / ±0.5 mi/h, acknowledging the estimate-vs-procedure deviation) and once tightly against the module's own computed values (33.70 s and 23.60 mi/h, ±0.01) — all other Exhibit 30-36 measures (through delay, spatial stop rate, v/c, LOS, perception score) reproduce exactly within the same tolerances as case1.
 
-Unit-level coverage lives in `src/hcm/chapter18/tests.rs`, which builds the same Example Problem 1 eastbound segment programmatically (`example_problem_1_segment`) and checks each step's intermediates individually — e.g., `test_step_2_base_free_flow_speed_example_problem_1` (S_0, f_CS, f_A, f_pk, S_fo, f_L, S_f, each within 0.001–0.005 depending on the quantity), `test_step_2_running_time_example_problem_1` (f_v ±0.0005, running time ±0.01 s, running speed ±0.01 mi/h), `test_step_3_proportion_arriving_green` (platoon-ratio, arrival-type, and uniform-arrival paths, each ±0.001 or ±0.0001), `test_equation_18_11_stop_rate` (a hand-computed check of `full_stop_rate_signalized` against a magnitude consistent with the published 0.547 stops/veh, ±0.0005), `test_step_6_stop_rate_defaults` (STOP/uncontrolled/YIELD defaults), and `test_steps_7_to_10_example_problem_1` (travel speed, spatial stop rate, v/c, LOS, and perception score, at the same tolerances as the integration test). Additional unit tests hand-verify the free functions in isolation, e.g. `test_equation_18_2_uncontrolled_capacity`, `test_equation_18_10_shared_lane_delay`, `test_equations_18_12_to_18_14_weighting`, and `test_equation_18_1_default_access_points`, all at tight (≤1e-9) tolerances since they check closed-form arithmetic rather than published example values. `src/hcm/chapter18/exhibits.rs` additionally carries its own `#[cfg(test)]` module validating the Exhibit 18-1, 18-7, 18-11, and 18-13 lookup tables directly against tabulated HCM values and two textual worked examples (the Chapter 18 text's 42 mi/h BFFS interpolation example, and Chapter 30 Example Problem 1's 40.78 mi/h BFFS thresholds), at tolerances ranging from 0.05 mi/h down to exact equality for table-boundary values.
+Unit-level coverage lives in `src/hcm/urban_segments/tests.rs`, which builds the same Example Problem 1 eastbound segment programmatically (`example_problem_1_segment`) and checks each step's intermediates individually — e.g., `test_step_2_base_free_flow_speed_example_problem_1` (S_0, f_CS, f_A, f_pk, S_fo, f_L, S_f, each within 0.001–0.005 depending on the quantity), `test_step_2_running_time_example_problem_1` (f_v ±0.0005, running time ±0.01 s, running speed ±0.01 mi/h), `test_step_3_proportion_arriving_green` (platoon-ratio, arrival-type, and uniform-arrival paths, each ±0.001 or ±0.0001), `test_equation_18_11_stop_rate` (a hand-computed check of `full_stop_rate_signalized` against a magnitude consistent with the published 0.547 stops/veh, ±0.0005), `test_step_6_stop_rate_defaults` (STOP/uncontrolled/YIELD defaults), and `test_steps_7_to_10_example_problem_1` (travel speed, spatial stop rate, v/c, LOS, and perception score, at the same tolerances as the integration test). Additional unit tests hand-verify the free functions in isolation, e.g. `test_equation_18_2_uncontrolled_capacity`, `test_equation_18_10_shared_lane_delay`, `test_equations_18_12_to_18_14_weighting`, and `test_equation_18_1_default_access_points`, all at tight (≤1e-9) tolerances since they check closed-form arithmetic rather than published example values. `src/hcm/urban_segments/exhibits.rs` additionally carries its own `#[cfg(test)]` module validating the Exhibit 18-1, 18-7, 18-11, and 18-13 lookup tables directly against tabulated HCM values and two textual worked examples (the Chapter 18 text's 42 mi/h BFFS interpolation example, and Chapter 30 Example Problem 1's 40.78 mi/h BFFS thresholds), at tolerances ranging from 0.05 mi/h down to exact equality for table-boundary values.
 
 `tests/test_chapter18_integration.py` additionally exercises the PyO3 Python bindings against `case1.json` (skipped if the bindings are not built with `UrbanSegment` support), with looser tolerances than the Rust tests — ±0.01 mi/h for free-flow speeds, ±0.5 s/mi/h for running time/speed and through delay/travel speed, ±0.01 for stop rates, ±0.005 for v/c, exact LOS ("C"), and ±0.01 for perception score — confirming the same Exhibit 30-36 answers are reachable through the language binding.
 
 ## Deferred
 
-Per the module docs in `src/hcm/chapter18/mod.rs` and `urban_segments.rs`, the following are explicitly out of scope for this branch (milestone 1) and deferred to a milestone 2: the Chapter 30, Section 2 demand-adjustment procedure (origin–destination estimation, volume balancing, and spillback checks — Step 1 here only performs a capacity-constraint flag on analyst-supplied, already-balanced flow rates); the Chapter 30, Section 3 platoon-dispersion arrival-profile and coordinated-system convergence loop (Steps 3–4 — Step 3 falls back to a supplied platoon ratio/arrival type or assumes uniform arrivals, and Step 4 signal phase duration is a plain input rather than a computed loop); and the Chapter 30, Section 4 access-point delay procedure (probability of inside-lane blockage and per-movement platoon interaction — an analyst can supply its output per access point via `access_point_delays_s`, or fall back to the Exhibit 18-13 planning-level estimate, which the code implements in full). The pedestrian, bicycle, and transit mode methodologies of Chapter 18 (LOS scores and supporting equations for those modes) are out of scope entirely and are not present in this module. Per the VERIFICATION.md Chapter 18 entry, there are no VERIFY-HCM items on this branch — the deviations are the two documented spec gaps (Exhibit 18-13 clamping outside 200–700 veh/h/ln, and Exhibit 18-1 clamping outside 25–55 mi/h base free-flow speed, both because the respective exhibits do not define values beyond their tabulated ranges) and the Chapter 18 text's "Equation 20-43" citation, which is an HCM 6th Edition equation number rather than the 7th Edition's Equations 20-29 through 20-34. A grep of `urban_segments.rs` and `exhibits.rs` for `// VERIFY-HCM` found no such markers in either file.
+Per the module docs in `src/hcm/urban_segments/mod.rs` and `urban_segments.rs`, the following are explicitly out of scope for this branch (milestone 1) and deferred to a milestone 2: the Chapter 30, Section 2 demand-adjustment procedure (origin–destination estimation, volume balancing, and spillback checks — Step 1 here only performs a capacity-constraint flag on analyst-supplied, already-balanced flow rates); the Chapter 30, Section 3 platoon-dispersion arrival-profile and coordinated-system convergence loop (Steps 3–4 — Step 3 falls back to a supplied platoon ratio/arrival type or assumes uniform arrivals, and Step 4 signal phase duration is a plain input rather than a computed loop); and the Chapter 30, Section 4 access-point delay procedure (probability of inside-lane blockage and per-movement platoon interaction — an analyst can supply its output per access point via `access_point_delays_s`, or fall back to the Exhibit 18-13 planning-level estimate, which the code implements in full). The pedestrian, bicycle, and transit mode methodologies of Chapter 18 (LOS scores and supporting equations for those modes) are out of scope entirely and are not present in this module. Per the VERIFICATION.md Chapter 18 entry, there are no VERIFY-HCM items on this branch — the deviations are the two documented spec gaps (Exhibit 18-13 clamping outside 200–700 veh/h/ln, and Exhibit 18-1 clamping outside 25–55 mi/h base free-flow speed, both because the respective exhibits do not define values beyond their tabulated ranges) and the Chapter 18 text's "Equation 20-43" citation, which is an HCM 6th Edition equation number rather than the 7th Edition's Equations 20-29 through 20-34. A grep of `urban_segments.rs` and `exhibits.rs` for `// VERIFY-HCM` found no such markers in either file.

--- a/docs/hcm/procedures/chapter19-actuated.md
+++ b/docs/hcm/procedures/chapter19-actuated.md
@@ -1,6 +1,6 @@
 # HCM Chapter 19 — Milestone 2: Actuated Phase Duration, Left-Turn ADP Back of Queue, and RTOR Estimation
 
-This document walks the milestone-2 extensions to the Chapter 19 signalized-intersection implementation on branch `feat/hcm-ch19-actuated`: the HCM 7th Edition Chapter 31, Section 2 "Actuated Phase Duration" procedure (Equations 31-1 through 31-45), the Chapter 31, Section 4 left-turn arrival–departure-polygon (ADP) first-term back of queue (Exhibits 31-26 through 31-31 with Equation 31-141), and the Chapter 31, Section 8 right-turn-on-red (RTOR) volume estimate. The new code lives in `src/hcm/chapter19/actuated.rs` (equation-level pure functions plus the `estimate_fully_actuated` driver for the eight-phase dual-ring NEMA structure of Exhibit 19-2) and in additions to `src/hcm/chapter19/signalized.rs` (`adp_first_term_left`, `SignalizedIntersection::estimate_actuated_timings`, `estimate_rtor_volume`, `apply_rtor_estimates`, and new optional `PhaseTiming` fields `min_green_s`, `detector_length_ft`, `recall_max`). The fixed-timing milestone-1 pipeline documented in `chapter19.md` remains the default analysis path; the actuated estimator is a separate, non-mutating entry point that consumes the analyzed operating point (per the `mod.rs` module doc on this branch). Milestone-1 code already present in `signalized.rs` and `src/hcm/common/delay.rs` supplies the k-factor and available-capacity plumbing (Eqs. 19-22 through 19-25) that lets converged actuated durations feed the incremental delay d2; that hand-off is documented in Part 4 below. Deviations carry `// VERIFY-HCM` comments in code and are consolidated in `docs/hcm/VERIFICATION.md`, section "Chapter 19 milestone 2 (feat/hcm-ch19-actuated)".
+This document walks the milestone-2 extensions to the Chapter 19 signalized-intersection implementation on branch `feat/hcm-ch19-actuated`: the HCM 7th Edition Chapter 31, Section 2 "Actuated Phase Duration" procedure (Equations 31-1 through 31-45), the Chapter 31, Section 4 left-turn arrival–departure-polygon (ADP) first-term back of queue (Exhibits 31-26 through 31-31 with Equation 31-141), and the Chapter 31, Section 8 right-turn-on-red (RTOR) volume estimate. The new code lives in `src/hcm/signalized/actuated.rs` (equation-level pure functions plus the `estimate_fully_actuated` driver for the eight-phase dual-ring NEMA structure of Exhibit 19-2) and in additions to `src/hcm/signalized/signalized.rs` (`adp_first_term_left`, `SignalizedIntersection::estimate_actuated_timings`, `estimate_rtor_volume`, `apply_rtor_estimates`, and new optional `PhaseTiming` fields `min_green_s`, `detector_length_ft`, `recall_max`). The fixed-timing milestone-1 pipeline documented in `chapter19.md` remains the default analysis path; the actuated estimator is a separate, non-mutating entry point that consumes the analyzed operating point (per the `mod.rs` module doc on this branch). Milestone-1 code already present in `signalized.rs` and `src/hcm/common/delay.rs` supplies the k-factor and available-capacity plumbing (Eqs. 19-22 through 19-25) that lets converged actuated durations feed the incremental delay d2; that hand-off is documented in Part 4 below. Deviations carry `// VERIFY-HCM` comments in code and are consolidated in `docs/hcm/VERIFICATION.md`, section "Chapter 19 milestone 2 (feat/hcm-ch19-actuated)". Every equation written out below has been cross-checked against both the Rust function body and the HCM 7th Edition EPUB MathML source (`resources/epub/OEBPS/245_Ch31_02.xhtml` for the Section 2 procedure, `247_Ch31_04.xhtml` for the Section 4 ADP material, `251_Ch31_08.xhtml` for the Section 8 RTOR guidance); newly found code-vs-book disagreements are flagged inline as **DISCREPANCY** blocks.
 
 ## Part 1 — Average phase duration convergence loop (Eqs. 31-1 through 31-45)
 
@@ -18,28 +18,302 @@ The procedure estimates each phase's average duration from controller settings (
 
 The facility-level wrapper `SignalizedIntersection::estimate_actuated_timings(simultaneous_gap_out)` in `signalized.rs` builds the `ActuatedPhaseInput` list from the *analyzed* intersection: it groups the milestone-1 lane groups by controlling phase number, maps each `LaneGroupKind`/`LeftTurnMode` pair to a `MahLaneGroup` category, reads v and s from the converged Step 3/4 results, g_u from the Step 4 permitted-green state, and detection/pedestrian/speed inputs from the owning `PhaseTiming` (defaults when absent: detector length 40 ft, min green 5 s, passage time 2 s) and `SignalApproach`. It requires `analyze()` to have been run first and does not mutate `self` — the fixed-timing pipeline stays the default path. Two wrapper simplifications worth noting when reviewing: it passes `f_rpb: 1.0` for every lane group (the Eq. 31-19 shared-right MAH form is reachable with a non-unit f_Rpb only through the lower-level `ActuatedLaneGroupInput` API, even though the analyzed state carries a computed f_Rpb), and it passes platoon ratio 1.0 (random arrivals) to the driver regardless of the approaches' input platoon ratios.
 
+### Equation reference — queue service (Steps C/D)
+
+The effective green used throughout the loop follows the Equation 19-3 / 31-2 relationship. With the HCM defaults l₁ = e = 2.0 s the two corrections cancel, so the driver's effective green equals the displayed green exactly:
+
+```
+Equation 31-2:  g = D_p − l₁ − l₂ = g_s + g_e + e     [s]
+  g   = effective green time                                          [s]
+  D_p = phase duration = G + Y + R_c                                  [s]
+  l₁  = start-up lost time: 2.0 s (START_UP_LOST_TIME)
+  l₂  = clearance lost time = Y + R_c − e                             [s]
+  e   = extension of effective green: 2.0 s (EXTENSION_OF_EFFECTIVE_GREEN)
+  g_s = queue service time (Eq. 31-9)                                 [s]
+  g_e = green extension time (Eq. 31-30)                              [s]
+Implemented in: src/hcm/signalized/actuated.rs::estimate_fully_actuated (g_eff = G − l₁ + e, floored at 0.1 s)
+```
+
+```
+Equation 31-9:  g_s = q·C·(1 − P) ÷ (s/3,600 − q·C·(P/g))     [s]
+  g_s = queue service time, capped at the effective green g           [s]
+  q   = arrival flow rate = v ÷ (N × 3,600)                           [veh/s/ln]
+  C   = cycle length                                                  [s]
+  P   = proportion of vehicles arriving during green = R_p·g/C, capped at 1.0   [decimal]
+  R_p = platoon ratio: 1.0 (random arrivals) from the facility wrapper
+  s   = adjusted saturation flow rate                                 [veh/h/ln]
+  g   = effective green time (g_u at s_l for a permitted left-turn lane group)   [s]
+Implemented in: src/hcm/signalized/actuated.rs::queue_service
+```
+
+The code short-circuits to g_s = g when the lane group is oversaturated (arrivals per cycle q·C reach the served capacity s·g/3,600) or when the denominator is non-positive, and takes the phase g_s as the maximum over its lane groups; permitted-left lane groups (`LeftPermittedExclusive`, `LeftPermittedShared`) are served over their unblocked green g_u at the permitted saturation flow s_l instead of the phase green at s.
+
+**DISCREPANCY:** the denominator of Eq. 31-9 as implemented omits the cycle-length factor on its second term. The book's denominator is `s/3,600 − q·C·(P/g)`; substituting P = R_p·g/C, the book's subtracted term algebraically collapses to `q·R_p` (the arrival rate during green, independent of C and g). The code computes `denom = s/3,600 − q·P/g` — missing the `C` — which collapses instead to `q·R_p/C`, smaller than the book's term by a factor of the cycle length. The denominator therefore comes out too large and g_s too small: at an EP1-like operating point (v = 239 veh/h, s = 1,643 veh/h/ln, g ≈ 30 s, C ≈ 90 s, R_p = 1.0) the code's denominator is ≈ 0.456 versus the book-correct ≈ 0.390, understating queue service time by roughly 15% (≈ 8.8 s versus ≈ 10.2 s). This is a distinct root cause from the two residuals already documented in Deviations item 1 below (combined-flow max-out and protected-left demand charging) and likely compounds them; the numerator `q·C·(1 − P)` is correct. Per the documentation-only scope of this pass the code is left unchanged and the issue is recorded here.
+
+### Equation reference — maximum allowable headway (Steps A/E/G)
+
+```
+Equation 31-12:  S_a = 0.90 × (25.6 + 0.47 × S_pl)     [mi/h]
+  S_a  = average speed on the intersection approach                   [mi/h]
+  S_pl = posted speed limit                                           [mi/h]
+Implemented in: src/hcm/signalized/actuated.rs::average_approach_speed
+```
+
+```
+Equation 31-11:  L_v = L_pc × (1 − 0.01·P_HV) + 0.01 × L_HV × P_HV − D_sv     [ft]
+  L_v  = detected length of the vehicle                               [ft]
+  L_pc = stored passenger-car lane length: 25 ft (STORED_PASSENGER_CAR_LENGTH_FT)
+  P_HV = percentage heavy vehicles in the movement group              [%]
+  L_HV = stored heavy-vehicle lane length: 45 ft (STORED_HEAVY_VEHICLE_LENGTH_FT)
+  D_sv = distance between stored vehicles: 8 ft (DISTANCE_BETWEEN_STORED_VEHICLES_FT)
+Implemented in: src/hcm/signalized/actuated.rs::detected_vehicle_length
+```
+
+The MAH family (Eqs. 31-13 through 31-19) shares one presence-mode base form (Eq. 31-10) — passage time plus the time for a detected vehicle length to traverse the detection zone — to which each lane-group category adds a turn-penalty term:
+
+```
+Equation 31-10 (general form):  MAH = PT + (L_ds + L_v) ÷ (1.47 × S_a) + ⟨turn-penalty term⟩     [s/veh]
+  MAH  = maximum allowable headway (presence-mode stop-line detection)   [s/veh]
+  PT   = passage time setting                                            [s]
+  L_ds = length of the stop-line detection zone: 40 ft wrapper default   [ft]
+  L_v  = detected vehicle length (Eq. 31-11)                             [ft]
+  S_a  = average approach speed (Eq. 31-12)                              [mi/h]
+  (in pulse mode MAH = PT directly; pulse substitution is left to the call site)
+Implemented in: src/hcm/signalized/actuated.rs::max_allowable_headway
+```
+
+The fully worked representative case is the through lane group, whose turn-penalty term is zero:
+
+```
+Equation 31-13 (Through):  MAH_th = PT_th + (L_ds,th + L_v) ÷ (1.47 × S_a)     [s/veh]
+  MAH_th  = maximum allowable headway for through vehicles               [s/veh]
+  PT_th   = passage time setting for the phase serving through vehicles  [s]
+  L_ds,th = stop-line detection zone length in the through lanes         [ft]
+Implemented in: src/hcm/signalized/actuated.rs::max_allowable_headway (MahLaneGroup::Through)
+```
+
+The remaining six rows follow the same base-plus-penalty pattern; see the `MahLaneGroup` match in `max_allowable_headway` in `src/hcm/signalized/actuated.rs` for the exact per-branch arithmetic. Their penalty terms as transcribed in code are: Eq. 31-14 (LeftProtectedExclusive) adds `(E_L − 1)/(s_o/3,600)` with E_L = 1.05 (`E_L_PROTECTED_LEFT`); Eq. 31-15 (LeftProtectedShared) adds the same E_L term to MAH_th; Eq. 31-16 (LeftPermittedExclusive) adds `3,600/s_l − t_fh` with t_fh = 2.5 s (`FOLLOW_UP_HEADWAY_PERMITTED_LEFT`); Eq. 31-17 (RightProtectedExclusive) adds `(E_R − 1)/(s_o/3,600)` with E_R = 1.18 (`E_R_PROTECTED_RIGHT`); Eq. 31-18 (LeftPermittedShared) adds `3,600/s_l − t_fh` to MAH_th; Eq. 31-19 (RightPermittedShared) adds `((E_R/f_Rpb) − 1)/(s_o/3,600)` to MAH_th.
+
+The per-phase MAH is then formed as the flow-weighted mean over the phase's lane groups, `MAH_phase = Σ(MAH_i·λ_i)/Σλ_i`, which reproduces the book's all-exclusive-lane combination (Eq. 31-23) exactly.
+
+**DISCREPANCY:** the phase-level MAH* aggregation does not implement the shared-lane splits of Equations 31-20 through 31-25. For a phase serving a shared-lane lane group, the book splits that lane group's flow-rate parameter λ between its turning proportion (P_L or P_R, weighted by MAH_lt,s or MAH_rt,s) and its through proportion (1 − P_L or 1 − P_R, weighted by MAH_th) — e.g. Eq. 31-20's numerator is `P_L·λ_sl·MAH_lt,s + [(1−P_L)·λ_sl + λ_t + (1−P_R)·λ_sr]·MAH_th + P_R·λ_sr·MAH_rt,s`. The driver instead weights each lane group's entire λ by the single MAH of its `mah_kind` category and carries no P_L/P_R input at all (`ActuatedLaneGroupInput` has no turning-proportion field). This coincides with the book only when every lane group is an exclusive lane (Eqs. 31-23/31-24); whenever a shared lane group's through proportion is non-trivial the code overstates the turning movement's influence on MAH* and understates the through movement's. The code is left unchanged; recorded here as a new finding from this documentation pass.
+
+```
+Equation 31-26:  MAH* = (MAH_i × Σλ_i + MAH_c × Σλ_c,i) ÷ (Σλ_i + Σλ_c,i)     [s/veh]
+  MAH*   = equivalent maximum allowable headway for the phase (simultaneous gap-out)   [s/veh]
+  MAH_i  = phase MAH computed above for the subject phase              [s/veh]
+  MAH_c  = phase MAH computed above for the concurrent barrier partner (2↔6, 4↔8)   [s/veh]
+  λ_i    = flow rate parameter, lane group i of the subject phase      [veh/s]
+  λ_c,i  = flow rate parameter, lane group i of the concurrent phase   [veh/s]
+Implemented in: src/hcm/signalized/actuated.rs::equivalent_mah_simultaneous
+```
+
+### Equation reference — bunched-arrival flow parameters (Step F)
+
+Lane-group terms first (each lane group's arrival stream is modeled as a bunched Poisson process):
+
+```
+Equation 31-5:  φ_i = e^(−b_i × Δ_i × q_i)     [decimal]
+Equation 31-4:  λ_i = φ_i × q_i ÷ (1 − Δ_i × q_i)     [veh/s]
+  φ_i = proportion of free (unbunched) vehicles in lane group i
+  λ_i = flow rate parameter for lane group i                           [veh/s]
+  q_i = arrival flow rate for lane group i = v_i ÷ 3,600               [veh/s]
+  v_i = demand flow rate for lane group i                              [veh/h]
+  Δ_i = bunched-stream headway: 1.5 s (single-lane group), 0.5 s otherwise
+  b_i = bunching factor: 0.6 (1 lane), 0.5 (2 lanes), 0.8 (3+ lanes)
+Implemented in: src/hcm/signalized/actuated.rs::lane_group_flow_terms (Δ, b from bunching_params)
+```
+
+Then the phase-level aggregation over the m lane groups the phase serves:
+
+```
+Equation 31-3:  λ* = Σᵢ λ_i     [veh/s]
+Equation 31-6:  φ* = e^(−Σᵢ b_i·Δ_i·q_i)     [decimal]
+Equation 31-7:  Δ* = Σᵢ(λ_i·Δ_i) ÷ λ*     [s/veh]
+Equation 31-8:  q* = Σᵢ q_i     [veh/s]
+  λ* = flow rate parameter for the phase                               [veh/s]
+  φ* = combined proportion of free (unbunched) vehicles for the phase  [decimal]
+  Δ* = equivalent headway of the bunched stream served by the phase    [s/veh]
+  q* = arrival (call) flow rate for the phase                          [veh/s]
+Implemented in: src/hcm/signalized/actuated.rs::phase_flow_parameters
+```
+
+### Equation reference — green extension and max-out (Steps H/I)
+
+```
+Equation 31-28:  n = max(q* × [G_max − (g_s + l₁)], 0)     [extensions]
+  n     = average number of extensions before max-out
+  q*    = phase call rate (Eq. 31-8)                                   [veh/s]
+  G_max = maximum green setting                                        [s]
+  g_s   = queue service time (Eq. 31-9)                                [s]
+  l₁    = start-up lost time: 2.0 s
+Implemented in: src/hcm/signalized/actuated.rs::number_of_extensions
+```
+
+```
+Equation 31-29:  p = 1 − φ* × e^(−λ*·(MAH* − Δ*))     [decimal]
+  p = probability that a call headway is less than MAH* (green is extended), clamped to [0, 1]
+Implemented in: src/hcm/signalized/actuated.rs::prob_green_extension
+```
+
+```
+Equation 31-30:  g_e = p² × (1 − pⁿ) ÷ (q* × (1 − p))     [s]
+  g_e = average green extension time                                   [s]
+  n   = number of extensions (Eq. 31-28)
+Implemented in: src/hcm/signalized/actuated.rs::green_extension_time
+```
+
+```
+Equation 31-45:  h = [Δ* + φ*/λ* − (MAH* + 1/λ*) × φ* × e^(−λ*·(MAH*−Δ*))] ÷ [1 − φ* × e^(−λ*·(MAH*−Δ*))]     [s]
+Equation 31-44:  n_x = max((G_max − MAH* − (g_s + l₁)) ÷ h, 0)     [calls]
+Equation 31-43:  p_x = p^(n_x)     [decimal]
+  h   = average call headway for calls shorter than MAH*               [s]
+  n_x = number of calls necessary to extend the green to max-out
+  p_x = probability of phase termination by max-out
+Implemented in: src/hcm/signalized/actuated.rs::prob_max_out
+```
+
+### Equation reference — phase call probability and unbalanced green (Steps J through N)
+
+```
+Equation 31-32:  p_v = 1 − e^(−q_v*·C)     [decimal]
+Equation 31-33:  p_p = 1 − e^(−q_p*·P_p·C)     [decimal]
+Equation 31-31:  p_c = p_v·(1 − p_p) + p_p·(1 − p_v) + p_v·p_p     [decimal]
+  p_c  = probability that the subject phase is called
+  p_v  = probability of a call by vehicle detection
+  p_p  = probability of a call by pedestrian detection
+  q_v* = activating vehicular call rate for the phase                  [veh/s]
+  q_p* = activating pedestrian call rate for the phase                 [p/s]
+  P_p  = probability a pedestrian presses the detector button: 0.51 (PROB_PEDESTRIAN_PUSH)
+  C    = cycle length                                                  [s]
+Implemented in: src/hcm/signalized/actuated.rs::prob_phase_call (recall-to-max phases get p_c = 1.0 in the driver)
+```
+
+```
+Equation 31-35:  G|veh = max(l₁ + g_s + g_e, G_min)     [s]
+Equation 31-36:  G|ped = Walk + PC     [s]
+Equation 31-34:  G_u = G|veh·p_v·(1 − p_p) + G|ped·p_p·(1 − p_v) + max(G|veh, G|ped)·p_v·p_p, capped at G_max     [s]
+  G_u   = unbalanced green interval duration for the phase             [s]
+  G|veh = green duration given a vehicle call                          [s]
+  G|ped = green duration given a pedestrian call                       [s]
+  G_min = minimum green setting: 5 s wrapper default                   [s]
+  Walk, PC = pedestrian walk and pedestrian-clear settings             [s]
+Implemented in: src/hcm/signalized/actuated.rs::unbalanced_green
+```
+
+When the phase has no pedestrian service (Walk + PC absent or zero, or a protected-left phase, which suppresses the pedestrian term in the driver) the code takes G_u = G|veh directly. The unbalanced phase duration is then D_up = G_u + Y + R_c inline in the driver (Steps M/N).
+
+### Equation reference — barrier balancing and equilibrium cycle (Steps O through R)
+
+```
+Equation 31-38 (major street):  D_p,b = max(D_up,1 + D_up,2, D_up,5 + D_up,6) − D_p,a     [s]
+Equation 31-39 (minor street):  D_p,b = max(D_up,3 + D_up,4, D_up,7 + D_up,8) − D_p,a     [s]
+  D_p,a  = duration of the phase that occurs first in the barrier's phase pair (its unbalanced duration D_up,a)   [s]
+  D_p,b  = duration of the phase that follows phase a before the barrier (absorbs the barrier slack)              [s]
+  D_up,i = unbalanced phase duration for phase i (Steps M/N)           [s]
+Implemented in: src/hcm/signalized/actuated.rs::estimate_fully_actuated (the set_dp closure; Ring 1 = phases 1,2,3,4; Ring 2 = 5,6,7,8; major-street barrier {1,2,5,6}, minor-street barrier {3,4,7,8})
+```
+
+In the driver, `major`/`minor` are the two max(...) terms; phases 2 and 6 receive `major − D_p,1` and `major − D_p,5` (Eq. 31-38 applied to each ring), phase 4 receives `minor − D_p,3` (leading-left arrangement, 3 leads 4) and phase 7 receives `minor − D_p,8` (lagging-left arrangement, 8 leads 7), matching the book's worked examples for Eq. 31-39.
+
+```
+Equation 31-42:  C_e = Σᵢ₌₁⁴ D_p,i     [s]
+  C_e   = equilibrium cycle length, summed over the Ring 1 phases (1, 2, 3, 4)
+  D_p,i = balanced duration of Ring 1 phase i                          [s]
+Implemented in: src/hcm/signalized/actuated.rs::estimate_fully_actuated (the in-loop new_cycle and the returned cycle, relaxed 50% per pass)
+```
+
 ## Part 2 — Left-turn ADP first-term back of queue (Exhibits 31-26..31-31, Eq. 31-141)
 
 Milestone 1 approximated Q1 for permitted and protected-permitted left-turn lane groups by the maximum instantaneous queue of the Step 8 queue accumulation polygon. Milestone 2 replaces that with `adp_first_term_left(intervals, cycle_s, d_a)` in `signalized.rs`, called from `step_8_delay`'s QAP branch (the same `QapInterval` list built by `build_left_turn_qap` feeds both d1 and Q1). The function counts *full stops* N_f rather than the peak queue: it first iterates the polygon to its steady-state starting queue (fixed point of the cycle map, up to 80 passes), then walks two concatenated cycles at a 0.02 s step so a busy period spanning the cycle boundary is captured in full, takes the longest contiguous busy period (queue > 0, with sneaker removals able to end a busy period), and returns `q × max_busy − q × d_a/2` (veh/ln) — the arrival count over the longest busy period minus the partial-stop window of Equations 31-139/31-141 (the fully-stopped departure "dashed line" of Section 4, Step 3 leads the solid departure by d_a/2, with d_a from `accel_decel_delay`, Eq. 31-131, in s). This follows the Section 4, Step 6 rule for complex left-turn ADPs whose queue dissipates at two or more points per cycle: N_f,i is computed per period between dissipation points and the largest governs. Inputs are the polygon intervals (durations s, discharge veh/h/ln, arrivals veh/s/ln, sneakers veh), cycle length (s), and d_a (s); the output Q1 (veh/ln) is stored on `lg.q1_veh` and consumed unchanged by `step_10_queue_storage` for permitted/protected-permitted left-turn lane groups. For a lane group served in two batches per cycle (protected phase plus permitted/sneaker service) N_f exceeds the peak queue because it counts every vehicle that stops — exactly the published SB-left case (4.9 veh/ln, where the milestone-1 QAP peak gave 3.2).
 
+The acceleration–deceleration delay that positions the partial-stop window comes from the Section 4 speed model:
+
+```
+Equation 31-132:  S_a = 0.90 × (25.6 + 0.47 × S_pl)     [mi/h]
+Equation 31-131:  d_a = [1.47 × (S_a − S_s)]² ÷ (2 × 1.47 × S_a) × (1/r_a + 1/r_d)     [s]
+  d_a  = acceleration–deceleration delay per full stop                 [s]
+  S_a  = average (unimpeded) speed on the intersection approach        [mi/h]
+  S_pl = posted speed limit                                            [mi/h]
+  S_s  = threshold speed defining a stopped vehicle: 5.0 mi/h (STOP_THRESHOLD_SPEED_MPH)
+  r_a  = acceleration rate: 3.5 ft/s² (QUEUE_ACCELERATION_RATE)
+  r_d  = deceleration rate: 4.0 ft/s² (QUEUE_DECELERATION_RATE)
+Implemented in: src/hcm/signalized/signalized.rs::accel_decel_delay
+```
+
+For the basic single-dissipation-point polygon (Exhibit 31-25 — through movements, protected turns, shared through+right), the book's closed-form full-stop accounting is transcribed exactly in `first_term_back_of_queue` and is documented in `chapter19.md`'s Step 10 section (Eqs. 31-137 through 31-140, with Q1 = N_f per Eqs. 31-136/31-141). The left-turn ADP family extends that polygon to six left-turn-specific geometries: Exhibit 31-26 (permitted, exclusive lane), 31-27 (permitted, shared lane), 31-28 (leading protected-permitted, exclusive), 31-29 (lagging protected-permitted, exclusive), 31-30 (leading protected-permitted, shared), and 31-31 (lagging protected-permitted, shared). Each introduces the permitted-period variables g_p, g_u, g_f, the protected green g_l, the permitted saturation flow s_p, the protected left-turn saturation flow s_lt = s_th/E_L, and the shared-lane left proportion P_L. The book gives no closed-form N_f for these shapes — only the Step 6 rule quoted above (compute N_f,i per period between queue dissipation points; the largest governs):
+
+```
+Equation 31-141:  Q1 = N_f     [veh/ln]
+  Q1  = first-term back-of-queue size                                  [veh/ln]
+  N_f = number of fully stopped vehicles; for complex left-turn polygons, the largest N_f,i over the periods between queue dissipation points   [veh/ln]
+Implemented in: src/hcm/signalized/signalized.rs::adp_first_term_left (left-turn path; returns q × max_busy − q × d_a/2, floored at 0); src/hcm/signalized/signalized.rs::first_term_back_of_queue (basic Exhibit 31-25 path)
+```
+
+`build_left_turn_qap` reproduces the Exhibit 31-26/31-27 (permitted) and 31-28..31-31 (protected-permitted, leading/lagging, exclusive/shared) geometries as ordered `QapInterval` lists (durations, discharge rates s_left_perm/s_left_prot and the shared-lane rates derived from s_th_curb, arrival rate q, sneaker counts), and `adp_first_term_left` evaluates the max-over-dissipation-points rule numerically on that list. The single-formula collapse `q × max_busy − q × d_a/2` stands in for the book's per-interval d_a-shifted counting (Eqs. 31-137..31-140 applied per dissipation interval); this approximation and its ~0.1–0.3 veh/ln residual are the already-documented Deviations item 2 below.
+
 ## Part 3 — RTOR estimation (Ch. 31 §8)
 
-`SignalizedIntersection::estimate_rtor_volume(direction)` in `signalized.rs` implements the Chapter 31, Section 8 suggestion that an exclusive right-turn lane's RTOR volume can be estimated as the demand of the complementary cross-street left-turn movement whenever that movement is provided a left-turn phase. The complementary movement is identified by the private `cross_street_left_shadow` as the approach 90° counterclockwise of the subject (EB→NB, NB→WB, WB→SB, SB→EB), i.e. the cross-street left that discharges into the subject right turn's receiving lanes and whose protected phase clears the conflicting through movement. The estimate returns 0.0 when the subject has no exclusive right-turn lane, when the shadow approach is absent, or when the shadow's left-turn mode is not `Protected`/`ProtectedPermitted`; otherwise it returns the shadow approach's PHF-adjusted left-turn flow rate (veh/h) capped at the subject's PHF-adjusted right-turn flow rate (veh/h). `apply_rtor_estimates()` populates `volume_rtor` on every approach that has none supplied (a nonzero field-measured `volume_rtor` is left untouched) and is meant to be called before `analyze()`, which subtracts RTOR from the right-turn demand in Step 2 (see `chapter19.md`). Shared-lane RTOR is left at 0.0 — the HCM offers no estimate for that case and recommends field data or an alternative tool. Both RTOR methods and `estimate_actuated_timings` are exposed to Python in `src/copython/chapter19.rs` (the actuated results are returned as a JSON array of per-phase records).
+`SignalizedIntersection::estimate_rtor_volume(direction)` in `signalized.rs` implements the Chapter 31, Section 8 suggestion that an exclusive right-turn lane's RTOR volume can be estimated as the demand of the complementary cross-street left-turn movement whenever that movement is provided a left-turn phase. The complementary movement is identified by the private `cross_street_left_shadow` as the approach 90° counterclockwise of the subject (EB→NB, NB→WB, WB→SB, SB→EB), i.e. the cross-street left that discharges into the subject right turn's receiving lanes and whose protected phase clears the conflicting through movement. The estimate returns 0.0 when the subject has no exclusive right-turn lane, when the shadow approach is absent, or when the shadow's left-turn mode is not `Protected`/`ProtectedPermitted`; otherwise it returns the shadow approach's PHF-adjusted left-turn flow rate (veh/h) capped at the subject's PHF-adjusted right-turn flow rate (veh/h). `apply_rtor_estimates()` populates `volume_rtor` on every approach that has none supplied (a nonzero field-measured `volume_rtor` is left untouched) and is meant to be called before `analyze()`, which subtracts RTOR from the right-turn demand in Step 2 (see `chapter19.md`). Shared-lane RTOR is left at 0.0 — the HCM offers no estimate for that case and recommends field data or an alternative tool. Both RTOR methods and `estimate_actuated_timings` are exposed to Python in `src/copython/signalized.rs` (the actuated results are returned as a JSON array of per-phase records).
+
+The book states this rule in prose only — Section 8's "Effect of Right-Turn-on-Red Operation" subsection (inside the "Use of Alternative Tools" section, EPUB `251_Ch31_08.xhtml`) carries no numbered equation: "the methodology suggests RTOR volume can be estimated as equal to the left-turn demand of the complementary cross street left-turn movement, whenever this movement is provided a left-turn phase." The book gives no formal movement map for "complementary" (the 90°-counterclockwise reading is the implemented interpretation, Deviations item 3), no explicit cap, and no shared-lane estimate; the code's cap at the subject's own right-turn flow rate is a physical bound filled in by the implementation (RTOR volume cannot exceed the right-turn demand it is drawn from) rather than a book statement. Implemented in: `src/hcm/signalized/signalized.rs::estimate_rtor_volume`, `src/hcm/signalized/signalized.rs::cross_street_left_shadow`, `src/hcm/signalized/signalized.rs::apply_rtor_estimates`.
 
 ## Part 4 — How k and c_a feed d2
 
-The incremental-delay hand-off from actuated timing to Step 8 lives in milestone-1 code paths that milestone 2 makes fully usable. When `SignalizedIntersection.control` is `ActuatedSignal`/`SemiActuatedSignal` and the governing phase carries both `passage_time_s` and `max_green_s`, `step_8_delay` in `signalized.rs` computes the incremental delay factor as k = `incremental_delay_factor_actuated(v/c_a, k_min)` (Eq. 19-22, clamped to [k_min, 0.50]) with k_min = `incremental_delay_factor_min(PT)` (Eq. 19-23, floored at 0.04 via `K_MIN_LOWER_BOUND`), both in `src/hcm/common/delay.rs`; otherwise k falls back to `K_PRETIMED` = 0.50 (pretimed, coordinated, and recall-to-max phases per the Chapter 19, Step 8C text). The available capacity c_a comes from Step 7 (`step_7_capacity_and_vc`): the generic lane-group form is c_a = N·s·g_a/C with g_a = `PhaseTiming::available_effective_green_s()` (Eq. 19-25, G_max + Y + R_c − l₁ − l₂), and the permitted / protected-permitted left-turn arms use the Eq. 31-120 / 31-125 available-capacity forms. The resulting k and the Step 7 capacity then enter d2 = `incremental_delay_signalized(T, X_A, c_A, k, I)` (Eq. 19-26, s/veh). The intended workflow for an actuated intersection is therefore: run `analyze()` at an initial timing, run `estimate_actuated_timings` to converge the average phase durations, write those durations back into the `PhaseTiming.duration_s` inputs (the caller's responsibility — the estimator does not mutate the facility), and re-run `analyze()` so capacities, k, and d2 reflect the converged timings.
+The incremental-delay hand-off from actuated timing to Step 8 lives in milestone-1 code paths that milestone 2 makes fully usable. When `SignalizedIntersection.control` is `ActuatedSignal`/`SemiActuatedSignal` and the governing phase carries both `passage_time_s` and `max_green_s`, `step_8_delay` in `signalized.rs` computes the incremental delay factor as k = `incremental_delay_factor_actuated(v/c_a, k_min)` (Eq. 19-22, clamped to [k_min, 0.50]) with k_min = `incremental_delay_factor_min(PT)` (Eq. 19-23, floored at 0.04 via `K_MIN_LOWER_BOUND`), both in `src/hcm/common/delay.rs`; otherwise k falls back to `K_PRETIMED` = 0.50 (pretimed, coordinated, and recall-to-max phases per the Chapter 19, Step 8C text).
+
+```
+Equation 19-23:  k_min = −0.375 + 0.354·PT − 0.0910·PT² + 0.00889·PT³, floored at 0.04     [unitless]
+  k_min = minimum incremental delay factor
+  PT    = passage time setting                                         [s]
+Implemented in: src/hcm/common/delay.rs::incremental_delay_factor_min (K_MIN_LOWER_BOUND = 0.04)
+```
+
+```
+Equation 19-22:  k = (1 − 2·k_min) × (v/c_a − 0.5) + k_min, clamped to [k_min, 0.50]     [unitless]
+  k     = incremental delay factor for actuated operation
+  v/c_a = ratio of demand flow rate to available capacity (Eq. 19-24)
+Implemented in: src/hcm/common/delay.rs::incremental_delay_factor_actuated (K_PRETIMED = 0.50 for the non-actuated fallback)
+```
+
+The available capacity c_a comes from Step 7 (`step_7_capacity_and_vc`): the generic lane-group form is c_a = N·s·g_a/C with g_a = `PhaseTiming::available_effective_green_s()`:
+
+```
+Equation 19-25:  g_a = G_max + Y + R_c − l₁ − l₂  (= G_max − l₁ + e)     [s]
+  g_a   = available effective green time for an actuated lane group     [s]
+  G_max = maximum green setting                                         [s]
+  Y     = yellow change interval                                        [s]
+  R_c   = red clearance interval                                        [s]
+  l₁    = start-up lost time: 2.0 s
+  l₂    = clearance lost time = Y + R_c − e; e = 2.0 s
+Implemented in: src/hcm/signalized/signalized.rs::PhaseTiming::available_effective_green_s
+```
+
+and the permitted / protected-permitted left-turn arms use the Eq. 31-120 / 31-125 available-capacity forms (written out in `chapter19.md`'s Step 7 section). The resulting k and the Step 7 capacity then enter d2:
+
+```
+Equation 19-26:  d2 = 900 × T × [(X_A − 1) + √((X_A − 1)² + 8·k·I·X_A ÷ (c_A·T))]     [s/veh]
+  d2  = incremental delay                                              [s/veh]
+  T   = analysis period duration: 0.25 default                         [h]
+  X_A = average volume-to-capacity ratio v/c_A                         [unitless]
+  c_A = average lane group capacity                                    [veh/h]
+  k   = incremental delay factor (Eq. 19-22, or K_PRETIMED = 0.50)     [0.04–0.50]
+  I   = upstream filtering adjustment factor: 1.0 isolated (I_ISOLATED), floored at 0.090 (I_MIN)
+Implemented in: src/hcm/common/delay.rs::incremental_delay_signalized
+```
+
+The intended workflow for an actuated intersection is therefore: run `analyze()` at an initial timing, run `estimate_actuated_timings` to converge the average phase durations, write those durations back into the `PhaseTiming.duration_s` inputs (the caller's responsibility — the estimator does not mutate the facility), and re-run `analyze()` so capacities, k, and d2 reflect the converged timings.
 
 ## Deviations (cross-referenced to `docs/hcm/VERIFICATION.md`, "Chapter 19 milestone 2")
 
-1. **Actuated convergence vs the published EP1 durations (VERIFICATION.md item 1; `VERIFY-HCM` comment at the green-extension step inside `estimate_fully_actuated`).** Driven from the Example Problem 1 controller settings with the Steps 1–5 operating point held at the published values, the procedure reproduces the equivalent MAH exactly (3.4 s EB/WB, 3.1 s minor street) and the barrier balance exactly, and estimates the minor-street through phases within about 4 s (Ph8 ≈ 51–54 vs 54.0 s; Ph4 ≈ 54 vs 57.6 s; SB-T g_e ≈ 9.5 vs 7.8 s). Two residuals remain: (a) the major-street phases 2/6 under-extend (~23 vs 34 s) because the HCM computational engine's combined-flow max-out model holds them at max green while the transcribed Eq. 31-29/31-30 green-extension model gaps them out; (b) the leading protected left phases 3/7 are charged the full left-turn demand for queue service rather than only the demand not served in the following permitted period. The estimated cycle is ~13 s short of the published 101.8 s. Closing both requires embedding the full Steps 1–5 recomputation and the engine's combined-flow extension calibration inside every actuated iteration (a Section 7 computational-engine detail).
+1. **Actuated convergence vs the published EP1 durations (VERIFICATION.md item 1; `VERIFY-HCM` comment at the green-extension step inside `estimate_fully_actuated`).** Driven from the Example Problem 1 controller settings with the Steps 1–5 operating point held at the published values, the procedure reproduces the equivalent MAH exactly (3.4 s EB/WB, 3.1 s minor street) and the barrier balance exactly, and estimates the minor-street through phases within about 4 s (Ph8 ≈ 51–54 vs 54.0 s; Ph4 ≈ 54 vs 57.6 s; SB-T g_e ≈ 9.5 vs 7.8 s). Two residuals remain: (a) the major-street phases 2/6 under-extend (~23 vs 34 s) because the HCM computational engine's combined-flow max-out model holds them at max green while the transcribed Eq. 31-29/31-30 green-extension model gaps them out; (b) the leading protected left phases 3/7 are charged the full left-turn demand for queue service rather than only the demand not served in the following permitted period. The estimated cycle is ~13 s short of the published 101.8 s. Closing both requires embedding the full Steps 1–5 recomputation and the engine's combined-flow extension calibration inside every actuated iteration (a Section 7 computational-engine detail). The two **DISCREPANCY** blocks in Part 1 above (the missing cycle-length factor in Eq. 31-9's denominator, and the missing Eq. 31-20..31-25 shared-lane MAH* split) are new findings from this documentation pass, distinct from and additional to these previously documented residuals.
 2. **Left-turn ADP first-term partial-stop offset (VERIFICATION.md item 2; `VERIFY-HCM` comment in `adp_first_term_left`).** Q1 is computed as the largest per-busy-period arrival count less q·d_a/2, standing in for the engine's exact multi-segment N_f accounting (Eqs. 31-137..31-140 applied per dissipation interval). This reproduces EP1 EB-left 1.8 exactly and SB-left 4.9 → 5.0 (previously 3.2 under the QAP peak) and keeps NB-left within the published queue-storage tolerance; the exact accounting would remove a ~0.1–0.3 veh/ln residual on the more complex polygons.
 3. **RTOR complementary-movement identification (VERIFICATION.md item 3; `VERIFY-HCM` comment in `cross_street_left_shadow`).** The HCM text says "the left-turn demand of the complementary cross street left-turn movement" without a formal movement map; the 90°-counterclockwise rotation is the implemented reading (the receiving-lane match). Shared-lane RTOR is 0.0 by design (no HCM estimate exists).
 4. **Deferred controller-emulation details (VERIFICATION.md item 4).** Permissive-period modeling; the coordinated-actuated force-off/yield-point emulation beyond the equivalent-maximum-green abstraction (Eqs. 31-27, 31-40); Dallas left-turn phasing; dual-entry activation edge cases; and pulse-mode detection (in pulse mode MAH equals PT; the presence-mode form is implemented and pulse substitution is left to the call site, per the `max_allowable_headway` doc comment).
 
 ## Validation
 
-Fixture: `tests/ExampleCases/hcm/Signalized/case1.json` (HCM Chapter 31, Section 10, Example Problem 1; controller settings of Exhibit 31-72, published lane-group demand of Exhibit 31-76, adjusted saturation flows of Exhibit 31-77, converged durations and permitted g_u of Exhibit 31-79, back-of-queue values of Exhibit 31-82). Three test layers cover milestone 2. (1) Unit tests in `actuated.rs`'s `#[cfg(test)]` module: `test_average_approach_speed` (Eq. 31-12, S_a = 37.845 mi/h at 35 mi/h, tolerance 1e-3), `test_detected_vehicle_length` (Eq. 31-11, 18.0 / 17.4 ft at 5% / 2% HV, exact), `test_through_mah_ep1` (Eqs. 31-13/31-10, through MAH ≈ 3.03 ±0.05 s for the EP1 40-ft zone at PT = 2 s), `test_flow_rate_parameter_monotonic`, `test_green_extension`, and `test_actuated_phase_duration_ep1` — the milestone acceptance test that hand-builds the six EP1 phases at the published operating point and asserts the barrier balance to 1e-6, MAH within 0.15–0.2 s of the published values, Ph8 duration 54.0 ±3.5 s, Ph4 duration 57.6 ±4.5 s, Ph4 green extension 7.8 ±2.5 s, Ph3/Ph7 durations ±3.0 s, Ph8 max-out probability > 0.5 (published 1.00), and cycle within 14 s of the published 101.8 s (the documented engine gap). (2) Unit tests added to `src/hcm/chapter19/tests.rs`: `test_adp_first_term_left_full_stops` (a single protected batch reduces N_f to the peak queue; a permitted lane group whose queue is held most of the cycle and released by sneakers counts nearly every arrival), `test_rtor_estimate_exclusive_right_lane` (EP1 modified so an eastbound exclusive right lane is shadowed by the northbound protected-permitted left), `test_rtor_no_left_phase_no_estimate` (rotation consistency — no fixed points — and the zero estimate without a protected shadow phase), `test_estimate_actuated_timings_from_facility` (the facility wrapper reproduces the EP1 minor-street through phases within the documented tolerance), plus the updated `test_step_10_back_of_queue` asserting the Exhibit 31-82 left-turn values via the ADP path (±0.5 veh/ln; oversaturated NB through groups ±0.8). (3) Integration tests appended to `tests/chapter19_integration.rs`: `test_m2_sb_left_back_of_queue` (SB-left 4.9 ±0.5, EB-left 1.8 ±0.4, NB-left 1.4 ±0.5 veh/ln vs Exhibit 31-82), `test_m2_actuated_phase_durations` (barrier balance to 1e-6, MAH Ph2 3.4 ±0.1 and Ph8 3.1 ±0.2 s, Ph8 54.0 ±4.0 s, Ph4 57.6 ±5.0 s), and `test_m2_rtor_estimate` (zero-estimate guards for permitted-only shadow lefts and shared right lanes).
+Fixture: `tests/ExampleCases/hcm/Signalized/case1.json` (HCM Chapter 31, Section 10, Example Problem 1; controller settings of Exhibit 31-72, published lane-group demand of Exhibit 31-76, adjusted saturation flows of Exhibit 31-77, converged durations and permitted g_u of Exhibit 31-79, back-of-queue values of Exhibit 31-82). Three test layers cover milestone 2. (1) Unit tests in `actuated.rs`'s `#[cfg(test)]` module: `test_average_approach_speed` (Eq. 31-12, S_a = 37.845 mi/h at 35 mi/h, tolerance 1e-3), `test_detected_vehicle_length` (Eq. 31-11, 18.0 / 17.4 ft at 5% / 2% HV, exact), `test_through_mah_ep1` (Eqs. 31-13/31-10, through MAH ≈ 3.03 ±0.05 s for the EP1 40-ft zone at PT = 2 s), `test_flow_rate_parameter_monotonic`, `test_green_extension`, and `test_actuated_phase_duration_ep1` — the milestone acceptance test that hand-builds the six EP1 phases at the published operating point and asserts the barrier balance to 1e-6, MAH within 0.15–0.2 s of the published values, Ph8 duration 54.0 ±3.5 s, Ph4 duration 57.6 ±4.5 s, Ph4 green extension 7.8 ±2.5 s, Ph3/Ph7 durations ±3.0 s, Ph8 max-out probability > 0.5 (published 1.00), and cycle within 14 s of the published 101.8 s (the documented engine gap). (2) Unit tests added to `src/hcm/signalized/tests.rs`: `test_adp_first_term_left_full_stops` (a single protected batch reduces N_f to the peak queue; a permitted lane group whose queue is held most of the cycle and released by sneakers counts nearly every arrival), `test_rtor_estimate_exclusive_right_lane` (EP1 modified so an eastbound exclusive right lane is shadowed by the northbound protected-permitted left), `test_rtor_no_left_phase_no_estimate` (rotation consistency — no fixed points — and the zero estimate without a protected shadow phase), `test_estimate_actuated_timings_from_facility` (the facility wrapper reproduces the EP1 minor-street through phases within the documented tolerance), plus the updated `test_step_10_back_of_queue` asserting the Exhibit 31-82 left-turn values via the ADP path (±0.5 veh/ln; oversaturated NB through groups ±0.8). (3) Integration tests appended to `tests/chapter19_integration.rs`: `test_m2_sb_left_back_of_queue` (SB-left 4.9 ±0.5, EB-left 1.8 ±0.4, NB-left 1.4 ±0.5 veh/ln vs Exhibit 31-82), `test_m2_actuated_phase_durations` (barrier balance to 1e-6, MAH Ph2 3.4 ±0.1 and Ph8 3.1 ±0.2 s, Ph8 54.0 ±4.0 s, Ph4 57.6 ±5.0 s), and `test_m2_rtor_estimate` (zero-estimate guards for permitted-only shadow lefts and shared right lanes).
 
 ## Deferred
 

--- a/docs/hcm/procedures/chapter19.md
+++ b/docs/hcm/procedures/chapter19.md
@@ -1,6 +1,6 @@
 # HCM Chapter 19 — Signalized Intersections, Motorized Vehicle Method (Steps 1–10)
 
-This document walks the HCM 7th Edition Chapter 19 motorized-vehicle methodology for signalized intersections as implemented on branch `feat/hcm-ch19-signalized` (milestone 1: pretimed and coordinated/fixed-timing operation; the actuated phase-duration convergence loop is milestone 2, documented separately in `chapter19-actuated.md`). The methodology follows Chapter 19, Section 3 ("Motorized Vehicle Core Methodology," Exhibit 19-18's ten steps) together with the supplemental procedures of Chapter 31 ("Signalized Intersections: Supplemental") that Chapter 19 incorporates by reference for lane-group flow distribution (Chapter 31, Section 2), the permitted/protected-permitted left-turn saturation-flow and opposing-queue procedures (Chapter 31, Section 3), and back-of-queue/queue-storage-ratio (Chapter 31, Section 4). The two source files are `src/hcm/chapter19/signalized.rs` (input model, the `SignalizedIntersection` facility struct, and the full ten-step pipeline) and `src/hcm/chapter19/exhibits.rs` (coefficient tables and saturation-flow adjustment factors transcribed with per-exhibit citations). Shared delay/LOS primitives used by this chapter (and re-used by Chapters 20–23) live in `src/hcm/common/delay.rs` and `src/hcm/common/los_tables.rs`. `docs/hcm/VERIFICATION.md` does not exist yet as a file at this branch's tip — it is added later by `feat/hcm-ch19-actuated` — so the interpretation notes below are cited from that file's "Chapter 19 (feat/hcm-ch19-signalized)" section as read from the later commit's history, not from a file present in this branch's working tree.
+This document walks the HCM 7th Edition Chapter 19 motorized-vehicle methodology for signalized intersections as implemented on branch `feat/hcm-ch19-signalized` (milestone 1: pretimed and coordinated/fixed-timing operation; the actuated phase-duration convergence loop is milestone 2, documented separately in `chapter19-actuated.md`). The methodology follows Chapter 19, Section 3 ("Motorized Vehicle Core Methodology," Exhibit 19-18's ten steps) together with the supplemental procedures of Chapter 31 ("Signalized Intersections: Supplemental") that Chapter 19 incorporates by reference for lane-group flow distribution (Chapter 31, Section 2), the permitted/protected-permitted left-turn saturation-flow and opposing-queue procedures (Chapter 31, Section 3), and back-of-queue/queue-storage-ratio (Chapter 31, Section 4). The two source files are `src/hcm/signalized/signalized.rs` (input model, the `SignalizedIntersection` facility struct, and the full ten-step pipeline) and `src/hcm/signalized/exhibits.rs` (coefficient tables and saturation-flow adjustment factors transcribed with per-exhibit citations). Shared delay/LOS primitives used by this chapter (and re-used by Chapters 20–23) live in `src/hcm/common/delay.rs` and `src/hcm/common/los_tables.rs`. `docs/hcm/VERIFICATION.md` does not exist yet as a file at this branch's tip — it is added later by `feat/hcm-ch19-actuated` — so the interpretation notes below are cited from that file's "Chapter 19 (feat/hcm-ch19-signalized)" section as read from the later commit's history, not from a file present in this branch's working tree. Every equation written out in the Equation reference below has been cross-checked against both the Rust function body and the HCM 7th Edition EPUB MathML source (`resources/epub/OEBPS/136_Ch19_02.xhtml`–`138_Ch19_04.xhtml` for the Chapter 19 body, `245_Ch31_02.xhtml`–`247_Ch31_04.xhtml` for the Chapter 31 supplemental procedures); newly found code-vs-book disagreements are flagged inline as **DISCREPANCY** blocks.
 
 The public entry point is `SignalizedIntersection::analyze(&mut self)` in `signalized.rs`, which runs Steps 1–4 (jointly iterated), 5, 7, 8, 9, and 10 in sequence and stores results back onto `self.lane_groups`, `self.approach_results`, `self.intersection_delay_s`, `self.intersection_los`, and `self.critical_vc_ratio`. Step 6 (signal phase duration) is treated as an *input* for pretimed/coordinated control per the HCM's own Step 6 text — callers supply `PhaseTiming` (duration, yellow, red clearance, and optionally max green / passage time / walk / pedestrian clear) on each `SignalApproach`; the Chapter 31, Section 2 pretimed-design free functions (`cycle_length_for_target_xc`, `pretimed_effective_green`) are provided separately for callers who want to *derive* a timing plan rather than supply one.
 
@@ -24,13 +24,518 @@ The public entry point is `SignalizedIntersection::analyze(&mut self)` in `signa
 
 Steps 1–4 are not run as four independent passes: `compute_states` seeds an even lane-flow assignment (`assign_flows_simple`), then iterates the Step 4 static factors (`f_w`, `f_hvg`, `f_a`, `f_bb`, `f_p`, `f_lu`), the permitted-left/pedestrian-bicycle state (`update_permitted_state`), the lane-group saturation flows (`update_lane_group_sat_flows`), and the Step 3 lane-flow distribution (`distribute_lane_flows`) up to 25 times, because `g_u` (unblocked permitted green) depends on the opposing approach's queue-service time `g_s`, which in turn depends on that approach's own converged lane flows and saturation flows (`opposing_queue_data`, using `queue_service_time`). The opposing-queue Case 1/Case 2 gap-acceptance selection (`opposing_right_turn_influences_gaps` on `SignalApproach`) implements Chapter 31, Section 3, Step 3. `permitted_green_times` transcribes all seven rows of Exhibit 31-12 (`LeadLead`, `LeadLag`, `LagLead`, `LagLag`, `PermLead`, `PermLag`, `PermPerm`) including the note-b/note-c start-up-lost-time and extension corrections for `LeadLead` and `LagLag`.
 
+## Equation reference
+
+The blocks below write out, per pipeline step, every HCM equation the code implements, with all variables, units, and code defaults, and the implementing function. Where a family of near-identical equations is large (the Exhibit 31-12 g_u rows, the Eq. 31-46..31-66 lane-flow sub-cases), the general form plus one fully worked representative case is given and the remaining rows are cited to the code.
+
+### Step 2 — Movement group flow rate
+
+Step 2 carries no standalone numbered equation beyond the peak-hour-factor conversion: each movement volume V (veh/h) is divided by the peak hour factor to yield the analysis flow rate v = V/PHF (veh/h; PHF defaults to 1.0 when `peak_hour_factor` is `None`), and the right-turn movement additionally subtracts the right-turn-on-red volume, `v_rt = max(V_r/PHF − v_RTOR, 0)`, per the Chapter 19 Step 2 text (RTOR vehicles are removed from the right-turn demand because they do not consume green). Implemented in: `src/hcm/signalized/signalized.rs::SignalApproach::flow_rates` and the Step-2 block of `src/hcm/signalized/signalized.rs::compute_states`. The RTOR estimate itself (when no field measurement is supplied) is milestone 2, `chapter19-actuated.md` Part 3.
+
+### Step 3 — Lane group flow rate (Ch. 31 §2 lane-flow equalization, Eqs. 31-46..31-66)
+
+The governing principle is that drivers distribute themselves across the through-serving lanes of an approach so that every lane carries the same flow ratio:
+
+```
+Equation 31-46 (equalization principle):  v_i ÷ s_i = (Σᵢ v_i) ÷ (Σᵢ s_i), for each of the N_th through-serving lanes i     [unitless]
+  v_i  = demand flow rate in lane i                                    [veh/h/ln]
+  s_i  = saturation flow rate in lane i                                [veh/h/ln]
+  N_th = number of through-serving lanes (shared or exclusive)         [ln]
+Implemented in: src/hcm/signalized/signalized.rs::distribute_lane_flows (iterative equalization); src/hcm/signalized/signalized.rs::through_serving_lanes (N_th)
+```
+
+The procedure's fully worked representative sub-equations are the Step F/G/H closing trio — the approach flow ratio and the revised turn-lane flows it implies:
+
+```
+Equation 31-64:  y* = (v_l·N_l + v_sl·N_sl + v_t·N_t + v_sr·N_sr + v_r·N_r + v_lr·N_lr) ÷ (s_l·N_l + s_sl·N_sl + s_t·N_t + s_sr·N_sr + s_r·N_r + s_lr·N_lr)     [unitless]
+Equation 31-65:  v_l = s_l × y*     [veh/h/ln]
+Equation 31-66:  v_sl,lt = max(v_lt − v_l, 0)     [veh/h/ln]
+  y*      = approach flow ratio
+  v_x, s_x, N_x = demand flow rate (veh/h/ln), saturation flow rate (veh/h/ln), and lane count (ln) for lane group x ∈ {l exclusive left, sl shared left+through, t exclusive through, sr shared right+through, r exclusive right, lr shared left+right}
+  v_l     = revised exclusive-left per-lane flow rate                  [veh/h/ln]
+  v_sl,lt = left-turn flow remaining in the shared lane                [veh/h/ln]
+Implemented in: src/hcm/signalized/signalized.rs::distribute_lane_flows
+```
+
+The upstream sub-equations of the same procedure are transcribed in the same function and verified term-for-term against the book: the modified through-car equivalents Eq. 31-47 (E_L,m = (E_L − 1)·P_lc + 1), Eqs. 31-48/31-49 (E_L1,m/E_L2,m = (E_L1 or E_L2 / f_Lpb − 1)·P_lc + 1), the lane-change probability Eq. 31-50 (P_lc = max(1 − (2·v_app/s_lc − 1)², 0)) with Eq. 31-51 (v_app = (v_lt + v_th + v_rt)/(N_sl + N_t + N_sr)), Eq. 31-53 (E_R,m = (E_R/f_Rpb − 1)·P_lc + 1), the per-lane exclusive flows Eqs. 31-55/31-56, the shared-lane turn proportions Eqs. 31-57/31-58 (P_L, P_R), the shared-lane saturation flows Eqs. 31-59/31-60 (written out under Step 4 below), Eq. 31-61 (s_sr = s_th/(1 + P_R·(E_R,m − 1))), and Eq. 31-62 (the 0.91 through-lane factor when a permitted shared left is present). The remaining sub-cases (the shared left+right lane group Eq. 31-63 and the per-geometry variants) follow the same pattern; see `distribute_lane_flows` in `src/hcm/signalized/signalized.rs`. Convergence is iterated jointly with Step 4 as described in the Notes above.
+
+### Step 4 — Adjusted saturation flow rate (Eq. 19-8 and the Ch. 31 factor procedures)
+
+```
+Equation 19-8:  s = s_o × f_w × f_HVg × f_p × f_bb × f_a × f_LU × f_LT × f_RT × f_Lpb × f_Rpb × f_wz × f_ms × f_sp     [veh/h/ln]
+  s     = adjusted saturation flow rate                                 [veh/h/ln]
+  s_o   = base saturation flow rate: 1,900 (metro, BASE_SATURATION_FLOW_METRO) or 1,750 (non-metro, BASE_SATURATION_FLOW_NON_METRO)   [pc/h/ln]
+  f_w   = lane width adjustment factor
+  f_HVg = heavy-vehicle and grade adjustment factor
+  f_p   = parking adjustment factor
+  f_bb  = bus blockage adjustment factor
+  f_a   = area type adjustment factor
+  f_LU  = lane utilization adjustment factor
+  f_LT, f_RT   = left-/right-turn adjustment factors (protected)
+  f_Lpb, f_Rpb = pedestrian–bicycle adjustment factors for left/right turns
+  f_wz, f_ms, f_sp = work zone / downstream lane blockage / sustained spillback factors: 1.0 (not wired into the product; see note)
+Implemented in: src/hcm/signalized/signalized.rs::update_lane_group_sat_flows and ::compute_states (the Step-4 static-factor block)
+```
+
+The code builds two through-lane saturation flows per approach, each a subset of the thirteen-factor product: the exclusive through lane `s_th_excl = s_o·f_w·f_HVg·f_a·f_bb·f_LU` and the curb (parking-adjacent) lane `s_th_curb = s_o·f_w·f_HVg·f_a·f_bb·f_p`. The turn factors f_LT/f_RT and the pedestrian–bicycle factors f_Lpb/f_Rpb are applied only to the turn-lane-group saturation flows. Scope notes (deliberate omissions, not book disagreements): f_wz exists as a standalone, currently unused free function (`exhibits.rs::work_zone_factor`, Eqs. 31-89..31-91, verified against the book), and f_ms/f_sp are not implemented anywhere — every product that the book writes with `f_ms·f_sp` is implemented with those two factors at their 1.0 defaults. Likewise Eq. 31-84 (the one-way-street pedestrian factor for left turns) is not separately implemented; only the two-way-street procedure (Eqs. 31-85..31-88) exists.
+
+The static factors, as transcribed into `src/hcm/signalized/exhibits.rs` (structure and code constants; the formulas below are the code's own arithmetic, verified against the book):
+
+```
+Exhibit 19-20 (lane width):  f_w = 0.96 (width < 10.0 ft), 1.00 (10.0–12.9 ft), 1.04 (> 12.9 ft)
+Implemented in: src/hcm/signalized/exhibits.rs::lane_width_factor
+```
+
+```
+Equations 19-9/19-10 (heavy vehicles and grade):
+  downhill (P_g < 0):        f_HVg = (100 − 0.79·P_HV − 2.07·P_g) ÷ 100
+  level or uphill (P_g ≥ 0): f_HVg = (100 − 0.78·P_HV − 0.31·P_g²) ÷ 100
+  P_HV = percentage heavy vehicles                                      [%]
+  P_g  = approach grade                                                 [%]
+Implemented in: src/hcm/signalized/exhibits.rs::heavy_vehicle_grade_factor
+```
+
+```
+Equation 19-11 (parking):  f_p = (N − 0.1 − 18·N_m/3,600) ÷ N, floored at 0.050     [unitless]
+  N   = lanes in the lane group                                         [ln]
+  N_m = parking maneuver rate adjacent to the group, capped at 180      [maneuvers/h]
+Implemented in: src/hcm/signalized/exhibits.rs::parking_factor
+```
+
+```
+Equation 19-12 (bus blockage):  f_bb = (N − 14.4·N_b/3,600) ÷ N, floored at 0.050     [unitless]
+  N_b = bus stopping rate on the approach, capped at 250                [buses/h]
+Implemented in: src/hcm/signalized/exhibits.rs::bus_blockage_factor
+```
+
+```
+Area type:  f_a = 0.90 (CBD), 1.00 (otherwise)
+Implemented in: src/hcm/signalized/exhibits.rs::area_type_factor
+```
+
+```
+Equation 19-7 (lane utilization, measured):  f_LU = v_g ÷ (N_e × v_g1)     [unitless]
+  v_g  = demand flow rate for the movement group                        [veh/h]
+  N_e  = number of exclusive lanes in the movement group                [ln]
+  v_g1 = demand flow rate in the highest-flow exclusive lane            [veh/h/ln]
+Implemented in: src/hcm/signalized/exhibits.rs::lane_utilization_factor
+(defaults per Exhibit 19-15 via exhibits.rs::default_lane_utilization_factor — through 1/2/3+ lanes: 1.000/0.952/0.908; left 1/2+: 1.000/0.971; right 1/2+: 1.000/0.885; lane counts beyond the table take the smallest tabulated factor per Exhibit 19-15 note a)
+```
+
+```
+Equations 19-13/19-14 (protected turn factors):  f_RT = 1/E_R,  f_LT = 1/E_L     [unitless]
+  E_R = equivalent through-car count, protected right turn: 1.18 (E_R_PROTECTED_RIGHT)
+  E_L = equivalent through-car count, protected left turn: 1.05 (E_L_PROTECTED_LEFT)
+Implemented in: src/hcm/signalized/exhibits.rs::protected_right_turn_factor, ::protected_left_turn_factor
+```
+
+The permitted-left procedure (Ch. 31 §3) builds the permitted saturation flow from gap acceptance against the opposing stream:
+
+```
+Equation 31-100:  s_p = v_o·e^(−v_o·t_cg/3,600) ÷ (1 − e^(−v_o·t_fh/3,600))     [veh/h/ln]
+  s_p  = saturation flow rate of a permitted left-turn movement
+  v_o  = opposing demand flow rate (0.1 veh/h substituted when 0)       [veh/h]
+  t_cg = critical headway: 4.5 s (CRITICAL_HEADWAY_PERMITTED_LEFT)
+  t_fh = follow-up headway: 2.5 s (FOLLOW_UP_HEADWAY_PERMITTED_LEFT)
+Implemented in: src/hcm/signalized/signalized.rs::permitted_left_saturation_flow
+```
+
+```
+Equation 31-101:  E_L1 = s_o ÷ s_p     [unitless]
+  E_L1 = equivalent through-car count for a permitted left-turning vehicle (filtering case)
+Implemented in: src/hcm/signalized/signalized.rs::el1_permitted_left
+```
+
+```
+Equation 31-102:  E_L2 = max((1 − (1 − P_lto)^n_q) ÷ P_lto, E_L)     [unitless]
+Equation 31-103:  n_q = max(0.278 × (g_p − g_u − g_f), 0)             [veh]
+  E_L2  = equivalent through-car count, permitted left opposed by a single-lane queue
+  P_lto = proportion of left-turning vehicles in the opposing stream   [decimal]
+  n_q   = maximum opposing vehicles that could arrive between g_f and g_u
+  E_L   = 1.05 (the floor)
+Implemented in: src/hcm/signalized/signalized.rs::el2_permitted_left
+```
+
+The permitted green windows come from Exhibit 31-12, whose rows specialize Eqs. 31-94/31-95 by phase sequence:
+
+```
+Equation 31-94:  g_p = max(G_p − l₁,p + e_p, 0)     [s]
+Equation 31-95:  g_u = min(G_u + e_p, g_p)          [s]
+  g_p  = effective green time for permitted left-turn operation         [s]
+  G_p  = displayed green interval corresponding to g_p                  [s]
+  l₁,p = permitted start-up lost time (per Exhibit 31-12 row; base 2.0 s)
+  e_p  = permitted extension of effective green (per Exhibit 31-12 row; base 2.0 s)
+  g_u  = permitted green not blocked by the opposing queue; G_u = its displayed interval   [s]
+Implemented in: src/hcm/signalized/signalized.rs::permitted_green_times
+```
+
+The fully worked representative row is the permitted-permitted sequence (`PermPerm`, the validated Example Problem 1 case), whose displayed unblocked interval is `G_U = D_p,opp − Y_own − R_c,own − G_q`, i.e. the opposing approach's through-phase duration less the subject's own change period less the worst-case opposing-queue clearance G_q (computed as g_s + l₁, or the shared-lane equivalent per Exhibit 31-12 note a). A subscript caution when reading the exhibit against the code: Exhibit 31-12's "D_p2/Y_2/R_c2" notation refers to the *opposing* approach's through phase and "D_p6/Y_6/R_c6" to the *subject's own* through phase (confirmed by the HCM's own footnote text), which is counter-intuitive from the phase numbering alone. All seven rows (`LeadLead`, `LeadLag`, `LagLead`, `LagLag`, `PermLead`, `PermLag`, `PermPerm`), including the note-b/note-c l₁,p and e_p corrections for `LeadLead` and `LagLag`, were verified term-by-term against the book and match; the remaining six rows follow the same pattern — see `permitted_green_times` in `src/hcm/signalized/signalized.rs`.
+
+```
+Equation 31-99:  LTC = v_lt × C ÷ 3,600     [veh/cycle]
+Equation 31-97 (one-lane approach):   g_f = min(max(G_p·e^(−0.860·LTC^0.629) − l₁,p, 0), g_f,max)     [s]
+Equation 31-98 (multilane approach):  g_f = min(max(G_p·e^(−0.882·LTC^0.717) − l₁,p, 0), g_f,max)     [s]
+Equation 31-96:  g_f,max = max([(1−P_L)/(0.5·P_L)] × (1 − (1−P_L)^(0.5·g_p)) − l₁,p, 0)     [s]
+  g_f  = time before the first left-turning vehicle arrives and blocks the shared lane     [s]
+  LTC  = left-turn flow rate per cycle                                  [veh/cycle]
+  v_lt = left-turn demand flow rate                                     [veh/h]
+  P_L  = proportion of left-turning vehicles in the shared lane         [decimal]
+Implemented in: src/hcm/signalized/signalized.rs::time_before_first_left_blocks
+```
+
+```
+Equation 31-122:  s_sl = (s_th/g_p) × [ g_f + g_diff/(1 + P_L·(E_L2/f_Lpb − 1)) + min(g_p − g_f, g_u)/(1 + P_L·(E_L1/f_Lpb − 1)) ]     [veh/h/ln]
+  with Equation 31-107:  g_diff = max(g_p − g_u − g_f, 0)     [s]
+  s_sl  = saturation flow rate of the shared left-turn/through lane     [veh/h/ln]
+  s_th  = through saturation flow rate (curb lane)                      [veh/h/ln]
+  f_Lpb = pedestrian adjustment factor for left turns (Eqs. 31-85..31-88)
+Implemented in: src/hcm/signalized/signalized.rs::shared_left_lane_saturation_flow
+```
+
+```
+Equation 31-59:  s_sl = (s_th/g_p) × [ g_f + g_diff/(1 + P_L·(E_L2,m − 1)) + min(g_p − g_f, g_u)/(1 + P_L·(E_L1,m − 1)) + 3,600·n_s*·f_ms·f_sp/s_th ]     [veh/h/ln]
+Equation 31-60:  n_s* = P_L/(1 − P_L) × (1 − P_L^n_s)  if P_L < 0.999;  n_s* = n_s·P_L  if P_L ≥ 0.999     [veh]
+  n_s* = expected sneakers per cycle in the shared left-turn lane
+  n_s  = sneakers per cycle: 2.0 (SNEAKERS_PER_CYCLE)                   [veh]
+  E_L1,m, E_L2,m = modified through-car equivalents (Eqs. 31-48/31-49)
+  f_ms, f_sp = 1.0 (not implemented; see the Eq. 19-8 note)
+Implemented in: src/hcm/signalized/signalized.rs::shared_left_lane_saturation_flow_modified
+```
+
+The pedestrian–bicycle adjustment factors (Ch. 31 §2 Steps E–G):
+
+```
+Equation 31-74:  v_pedg = min(v_ped × C ÷ g_ped, 5,000)     [p/h]
+Equation 31-75 (v_pedg ≤ 1,000):  OCC_pedg = v_pedg ÷ 2,000
+Equation 31-76 (v_pedg > 1,000):  OCC_pedg = min(0.4 + v_pedg ÷ 10,000, 0.90)
+Equation 31-77:  v_bicg = min(v_bic × C ÷ g, 1,900)          [bicycles/h]
+Equation 31-78:  OCC_bicg = 0.02 + v_bicg ÷ 2,700
+Equation 31-79 (no bicycles):    OCC_r = (g_ped/g) × OCC_pedg
+Equation 31-80 (with bicycles):  OCC_r = (g_ped/g)·OCC_pedg + OCC_bicg − (g_ped/g)·OCC_pedg·OCC_bicg
+Equation 31-81 (receiving lanes = turn lanes):  A_pbT = 1 − OCC_r
+Equation 31-82 (receiving lanes > turn lanes):  A_pbT = 1 − 0.6 × OCC_r
+Equation 31-83:  f_Rpb = A_pbT
+  v_ped, v_bic = pedestrian / bicycle flow rates                        [p/h, bicycles/h]
+  g_ped = pedestrian service time                                       [s]
+  OCC_pedg, OCC_bicg, OCC_r = pedestrian / bicycle / relevant-conflict-zone occupancies   [decimal]
+Implemented in: src/hcm/signalized/signalized.rs::ped_bike_factor_right
+```
+
+```
+Equation 31-85 (g_q < g_ped):  OCC_pedu = OCC_pedg × (1 − 0.5·g_q/g_ped)
+Equation 31-86 (g_q ≥ g_ped):  OCC_pedu = 0.0
+Equation 31-87:  OCC_r = [(g_ped − g_q) ÷ (g_p − g_q)] × OCC_pedu × e^(−5.00·v_o/3,600)
+Equation 31-88:  f_Lpb = A_pbT   (via Eqs. 31-81/31-82 with g_p in place of g)
+  g_q = opposing-queue service time = g_p − g_u                         [s]
+  v_o = opposing demand flow rate                                       [veh/h]
+Implemented in: src/hcm/signalized/signalized.rs::ped_factor_left_two_way
+```
+
+The opposing-queue clearance used to derive g_u is computed by `queue_service_time` (`g_s = q_r·r/(s/3,600 − q_g)`, with red/green arrival rates q_r = (1−P)·q·C/r and q_g = P·q·C/g); this is the same equation as Chapter 31's Eq. 31-9 — see `chapter19-actuated.md` Part 1 for the full block (and note that the milestone-1 `queue_service_time` here carries the correct book form).
+
+### Step 5 — Proportion arriving during green
+
+```
+Equation 19-15:  P = min(R_p × g ÷ C, 1.0)     [decimal]
+  P   = proportion of vehicles arriving during the green indication
+  R_p = platoon ratio (Exhibit 19-13, by arrival type): 0.33 (AT1) / 0.67 (AT2) / 1.00 (AT3, random) / 1.33 (AT4) / 1.67 (AT5) / 2.00 (AT6)
+  g   = lane-group effective green time                                 [s]
+  C   = cycle length                                                    [s]
+Implemented in: src/hcm/signalized/signalized.rs::step_5_proportion_arriving_on_green, using src/hcm/signalized/exhibits.rs::platoon_ratio_for_arrival_type
+```
+
+The cap at 1.0 is a physical clamp added by the code (the book states the bare product).
+
+### Step 6 — Signal phase duration (input) and the timing primitives
+
+```
+Equation 19-1:  l_t = l₁ + l₂ = l₁ + Y + R_c − e     [s]
+  l_t = phase lost time                                                 [s]
+  l₁  = start-up lost time: 2.0 s (START_UP_LOST_TIME)
+  l₂  = clearance lost time = Y + R_c − e                               [s]
+  Y   = yellow change interval                                          [s]
+  R_c = red clearance interval                                          [s]
+  e   = extension of effective green: 2.0 s (EXTENSION_OF_EFFECTIVE_GREEN)
+Implemented in: src/hcm/signalized/signalized.rs::PhaseTiming::lost_time_s (constants in src/hcm/signalized/exhibits.rs)
+```
+
+```
+Equation 19-3:  g = D_p − l₁ − l₂     [s]
+  g   = effective green time (floored at 0 in code)                     [s]
+  D_p = phase duration = G + Y + R_c                                    [s]
+Implemented in: src/hcm/signalized/signalized.rs::PhaseTiming::effective_green_s
+```
+
+The change period CP = Y + R_c is not a separately numbered equation (it is the Exhibit 19-6 term definition) and is exposed as `PhaseTiming::change_period_s`.
+
+```
+Equation 19-25:  g_a = G_max + Y + R_c − l₁ − l₂  (= G_max − l₁ + e)     [s]
+  g_a   = available effective green time for an actuated lane group     [s]
+  G_max = maximum green setting                                         [s]
+Implemented in: src/hcm/signalized/signalized.rs::PhaseTiming::available_effective_green_s (falls back to effective_green_s when no max_green_s is set)
+```
+
+The pretimed-design free functions implement the Chapter 31, Section 2 timing-plan equations (Eq. 31-67 is the identical formula to Eq. 19-30, quoted under the critical-v/c heading below):
+
+```
+Equation 31-68:  C = L × X_c ÷ (X_c − Σᵢ y_c,i)     [s]
+  C     = cycle length for a target critical v/c ratio                  [s]
+  L     = cycle lost time (Eq. 19-31)                                   [s]
+  X_c   = target critical intersection volume-to-capacity ratio
+  y_c,i = critical flow ratio for critical phase i = v_i/(N_i·s_i)
+Implemented in: src/hcm/signalized/signalized.rs::cycle_length_for_target_xc (returns None when X_c ≤ Σy_c,i, the undefined-denominator domain)
+```
+
+```
+Equation 31-69:  g_i = y_c,i × (C ÷ X_i)     [s]
+  g_i = effective green allocated to critical phase i                   [s]
+  X_i = target volume-to-capacity ratio for lane group i
+Implemented in: src/hcm/signalized/signalized.rs::pretimed_effective_green
+```
+
+### Step 7 — Capacity and v/c ratio
+
+```
+Equation 19-16:  c = N × s × g ÷ C     [veh/h]
+  c = lane-group capacity                                               [veh/h]
+  N = number of lanes in the lane group                                 [ln]
+  s = adjusted saturation flow rate                                     [veh/h/ln]
+  g = effective green time                                              [s]
+  C = cycle length                                                      [s]
+Implemented in: src/hcm/signalized/signalized.rs::step_7_capacity_and_vc (generic match arm; available capacity c_a = N·s·g_a/C with g_a from Eq. 19-25, the Eq. 19-24 family)
+```
+
+```
+Equation 19-17:  X = v ÷ c     [unitless]
+  X = volume-to-capacity ratio (∞ when c = 0 in code)
+  v = demand flow rate                                                  [veh/h]
+Implemented in: src/hcm/signalized/signalized.rs::step_7_capacity_and_vc
+```
+
+The book bars Eq. 19-16 for shared-lane and permitted-operation lane groups; the code routes those to the Chapter 31 forms (f_ms = f_sp = 1.0 throughout, per the Step 4 scope note):
+
+```
+Equation 31-119:  c_l,e = (g_u·s_l + 3,600·n_s·f_ms·f_sp) ÷ C × N_l     [veh/h]
+Equation 31-120:  c_a,l,e = c_l,e + max(G_max − g_p, 0) × s_l ÷ C × N_l     [veh/h]
+  c_l,e   = capacity, exclusive-lane lane group with permitted left-turn operation
+  c_a,l,e = available capacity of that lane group
+  g_u   = unblocked permitted green                                     [s]
+  s_l   = permitted left-turn saturation flow (s_left_perm)             [veh/h/ln]
+  n_s   = sneakers per cycle: 2.0 (SNEAKERS_PER_CYCLE)                  [veh]
+  N_l   = lanes in the exclusive left-turn group                        [ln]
+  G_max = maximum green of the phase serving the permitted period       [s]
+  g_p   = effective permitted green (the code's resolution of the book's un-subscripted g)   [s]
+Implemented in: src/hcm/signalized/signalized.rs::step_7_capacity_and_vc ((ExclusiveLeft, Permitted) arm)
+```
+
+```
+Equation 31-124:  c_l,e,pp = (g_l·s_lt + g_u·s_l + 3,600·n_s·f_ms·f_sp) ÷ C × N_l     [veh/h]
+Equation 31-125:  c_a,l,e,pp = (G_max·s_lt + g_u·s_l + 3,600·n_s·f_ms·f_sp) ÷ C × N_l     [veh/h]
+  c_l,e,pp = capacity, exclusive-lane lane group with protected-permitted left-turn operation
+  g_l   = effective green of the protected left-turn phase              [s]
+  s_lt  = protected left-turn saturation flow (s_left_prot)             [veh/h/ln]
+  G_max = maximum green of the left-turn phase (falls back to g_l when unset)   [s]
+Implemented in: src/hcm/signalized/signalized.rs::step_7_capacity_and_vc ((ExclusiveLeft, ProtectedPermitted) arm; c_a floored at c)
+```
+
+```
+Equation 31-121:  c_sl = (g_p·s_sl + 3,600·(1 + P_L)·f_ms·f_sp) ÷ C     [veh/h]
+Equation 31-126:  c_sl,pp = g_l·s_sl4 ÷ C + (g_p·s_sl + 3,600·(1 + P_L)·f_ms·f_sp) ÷ C     [veh/h]
+  c_sl    = capacity, shared-lane lane group with permitted left-turn operation
+  c_sl,pp = capacity, shared-lane lane group with protected-permitted operation
+  s_sl    = shared-lane saturation flow (Eq. 31-122)                    [veh/h/ln]
+  s_sl4   = shared-lane saturation flow during the protected period (Eq. 31-113) = s_th ÷ (1 + P_L·(E_L − 1))   [veh/h/ln]
+  P_L     = proportion of left turns in the shared lane                 [decimal]
+Implemented in: src/hcm/signalized/signalized.rs::step_7_capacity_and_vc ((SharedLeftThrough, Permitted|ProtectedPermitted) arm)
+```
+
+**DISCREPANCY:** the shared-lane available capacity of Equations 31-123 and 31-127 is not implemented. The book defines, for a shared-lane lane group with permitted operation, `c_a,sl = c_sl + (G_max − g_p)·s_sl3/C` (Eq. 31-123), and for protected-permitted operation `c_a,sl,pp = c_sl,pp + (G_max − g_p)·s_sl3/C` (Eq. 31-127, with s_sl4 replacing s_sl3 for a lagging left-turn phase). The `SharedLeftThrough` arm of `step_7_capacity_and_vc` computes the capacity correctly per Eqs. 31-121/31-126 but then returns available capacity equal to capacity, omitting the `(G_max − g_p)·s_sl3/C` extension term entirely — even though the exclusive-lane arms directly above it do implement the analogous Eq. 31-120/31-125 extension, and s_sl3 is already computed elsewhere in the code for the QAP intervals. The omission biases the actuated incremental-delay factor k (which consumes `available_capacity` in `step_8_delay`) toward its 0.50 ceiling for shared left-turn lane groups under actuated control; it has no effect on pretimed analysis, where k = 0.50 regardless. The code is left unchanged; recorded here as a new finding from this documentation pass.
+
+### Step 8 — Delay
+
+```
+Equation 19-18:  d = d₁ + d₂ + d₃     [s/veh]
+  d  = control delay
+  d₁ = uniform delay (Eq. 19-19, PF included)                           [s/veh]
+  d₂ = incremental delay (Eq. 19-26)                                    [s/veh]
+  d₃ = initial queue delay (Eqs. 19-44..19-49)                          [s/veh]
+Implemented in: src/hcm/common/delay.rs::control_delay_signalized
+```
+
+```
+Equation 19-19:  d₁ = PF × [0.5·C·(1 − g/C)²] ÷ [1 − min(1, X)·g/C]     [s/veh]
+  PF = progression adjustment factor (Eq. 19-20); 1.0 for random arrivals
+  C  = cycle length                                                     [s]
+  g  = effective green time                                             [s]
+  X  = lane-group volume-to-capacity ratio
+Implemented in: src/hcm/common/delay.rs::uniform_delay (returns 0 when g/C ≥ 1, the guarded analytic limit)
+```
+
+```
+Equation 19-21:  y = min(1, X) × g/C     [unitless]
+Equation 19-20:  PF = [(1 − P)/(1 − g/C)] × [(1 − y)/(1 − min(1,X)·P)] × [1 + y·(1 − P·C/g)/(1 − g/C)]     [unitless]
+  P = proportion of vehicles arriving during green (Eq. 19-15)          [decimal]
+  y = flow ratio (Eq. 19-21)
+Implemented in: src/hcm/common/delay.rs::progression_factor (Eq. 19-21 as delay.rs::flow_ratio; returns 1.0 when g/C ≥ 1, a guard against the 0/0 singularity)
+```
+
+```
+Equation 19-23:  k_min = −0.375 + 0.354·PT − 0.0910·PT² + 0.00889·PT³, floored at 0.04     [unitless]
+Equation 19-22:  k = (1 − 2·k_min) × (v/c_a − 0.5) + k_min, clamped to [k_min, 0.50]     [unitless]
+  k     = incremental delay factor; K_PRETIMED = 0.50 for pretimed/coordinated/recall-to-max phases
+  PT    = passage time setting                                          [s]
+  v/c_a = demand over available capacity (Eq. 19-24 family)
+Implemented in: src/hcm/common/delay.rs::incremental_delay_factor_min, ::incremental_delay_factor_actuated
+```
+
+```
+Equation 19-26:  d₂ = 900 × T × [(X_A − 1) + √((X_A − 1)² + 8·k·I·X_A ÷ (c_A·T))]     [s/veh]
+  T   = analysis period duration: 0.25 default (analysis_period_h)      [h]
+  X_A = average volume-to-capacity ratio v/c_A (Eq. 19-27; milestone 1 uses c_A = c)
+  c_A = average lane-group capacity                                     [veh/h]
+  I   = upstream filtering factor: 1.0 isolated (I_ISOLATED), floor 0.090 (I_MIN)
+Implemented in: src/hcm/common/delay.rs::incremental_delay_signalized
+```
+
+```
+Equations 19-44..19-49 (initial queue delay d₃):
+  Equation 19-45:  Q_e = Q_b + t_A × (v − c_A)     [veh]
+  if v ≥ c_A:  Equation 19-46: Q_eo = T × (v − c_A);  Equation 19-47: t_A = T
+  if v < c_A:  Equation 19-48: Q_eo = 0.0;            Equation 19-49: t_A = min(Q_b/(c_A − v), T)
+  Equation 19-44:  d₃ = 3,600/(v·T) × [ t_A·(Q_b + Q_e − Q_eo)/2 + (Q_e² − Q_eo²)/(2·c_A) − Q_b²/(2·c_A) ]     [s/veh]
+  Q_b  = initial queue at the start of the period (via initial_queue_for_group)   [veh]
+  Q_e  = queue at the end of the period                                 [veh]
+  Q_eo = queue at the end of the period, zero-initial-queue baseline    [veh]
+  t_A  = duration of unmet demand within the period                     [h]
+  (d₃ = 0 whenever Q_b ≤ 0, v ≤ 0, or T ≤ 0, matching the book's no-initial-queue case)
+Implemented in: src/hcm/common/delay.rs::initial_queue_delay (Eq. 19-45's Q_e also exposed as delay.rs::queue_end_of_period for multi-period hand-off)
+```
+
+For permitted and protected-permitted left-turn lane groups, d₁ comes from the incremental queue accumulation polygon instead of the closed form. `build_left_turn_qap` constructs the interval sequence per the Exhibit 31-13..31-17 shapes (red, blocked permitted, unblocked permitted at s_l, protected period at s_lt or s_sl4, sneaker removals at period ends) and `qap_evaluate` integrates it:
+
+```
+Equations 19-32..19-36 (QAP evaluation, general form):
+  per interval i with net slope w = arrival − discharge (veh/s):
+  Equation 19-36:  t_t,i = min(t_d,i, Q_(i−1) ÷ |w|)  when the queue is draining (w < 0), else t_d,i     [s]
+  Equation 19-35:  d₁ = [0.5 × Σᵢ (Q_(i−1) + Q_i) × t_t,i] ÷ (q_avg × C)     [s/veh]
+  Q_i   = queue at the end of interval i                                [veh]
+  t_d,i = interval duration                                             [s]
+  q_avg = average arrival rate over the cycle                           [veh/s]
+Implemented in: src/hcm/signalized/signalized.rs::qap_evaluate (steady-state polygon iterated to a fixed starting queue, trapezoid areas truncated at queue-zero crossings); intervals from src/hcm/signalized/signalized.rs::build_left_turn_qap
+```
+
+### Step 9 — LOS
+
+```
+Equation 19-28:  d_A = Σᵢ(dᵢ × vᵢ) ÷ Σᵢ vᵢ, over the lane groups i of the approach     [s/veh]
+Equation 19-29:  d_I = Σᵢ(dᵢ × vᵢ) ÷ Σᵢ vᵢ, over all lane groups of the intersection    [s/veh]
+  dᵢ, vᵢ = lane-group control delay (s/veh) and demand flow rate (veh/h)
+Implemented in: src/hcm/common/delay.rs::aggregate_control_delay, called from src/hcm/signalized/signalized.rs::step_9_los at both levels
+```
+
+```
+Exhibit 19-8 (LOS thresholds, s/veh control delay):
+  A ≤ 10;  B ≤ 20;  C ≤ 35;  D ≤ 55;  E ≤ 80;  F > 80
+  Forced F when v/c > 1.0 — applied at the lane-group level only; approach and intersection LOS are defined solely by control delay per the exhibit's own footnote
+Implemented in: src/hcm/common/los_tables.rs::los_signalized_intersection (step_9_los passes vc_gt_1 = false for approach/intersection calls)
+```
+
+### Step 10 — Back of queue and queue storage ratio (Ch. 31 §4)
+
+```
+Equation 31-132:  S_a = 0.90 × (25.6 + 0.47 × S_pl)     [mi/h]
+Equation 31-131:  d_a = [1.47 × (S_a − S_s)]² ÷ (2 × 1.47 × S_a) × (1/r_a + 1/r_d)     [s]
+  d_a  = acceleration–deceleration delay per full stop                  [s]
+  S_a  = average approach speed                                         [mi/h]
+  S_pl = posted speed limit                                             [mi/h]
+  S_s  = stop-threshold speed: 5.0 mi/h (STOP_THRESHOLD_SPEED_MPH)
+  r_a  = acceleration rate: 3.5 ft/s² (QUEUE_ACCELERATION_RATE)
+  r_d  = deceleration rate: 4.0 ft/s² (QUEUE_DECELERATION_RATE)
+Implemented in: src/hcm/signalized/signalized.rs::accel_decel_delay
+```
+
+```
+Equations 31-133..31-141 (first-term back of queue Q1, basic Exhibit 31-25 polygon):
+  q_r = (1 − P) × q × C ÷ r;  q_g = P × q × C ÷ g;  q = v_ln/3,600;  r = C − g
+  if d_a ≤ (1 − P)·g·X:
+    Equation 31-137:  t_f = q·C·(1 − P − P·d_a/g) ÷ (s·(1 − min(1, X)·P))     [s]
+    Equation 31-139:  N_f = q_r·r + q_g·(t_f − d_a)     [veh/ln]
+  else:
+    Equation 31-138:  t_f = q·C·(1 − P)·(r − d_a) ÷ (s·(r − min(1, X)·(1 − P)·g))     [s]
+    Equation 31-140:  N_f = q_r·(r − d_a + t_f)     [veh/ln]
+  Equation 31-141:  Q1 = N_f, floored at 0     [veh/ln]
+  t_f = service time for fully stopped vehicles                         [s]
+  q_r, q_g = arrival rates during effective red / green                 [veh/s]
+  s   = adjusted saturation flow rate (per lane, veh/s in the formula)
+Implemented in: src/hcm/signalized/signalized.rs::first_term_back_of_queue (through movements, protected turns, shared through+right); permitted/protected-permitted left-turn lane groups instead reuse the Step 8 QAP maximum queue in milestone 1 (see Deviations) and the ADP full-stop count in milestone 2 (chapter19-actuated.md Part 2)
+```
+
+```
+Equation 31-142:  Q2 = c_A ÷ (3,600 × N) × d₂     [veh/ln]
+  Q2  = second-term (incremental) back of queue
+  c_A = average lane-group capacity                                     [veh/h]
+  N   = lanes in the group                                              [ln]
+  d₂  = incremental delay (Eq. 19-26)                                   [s/veh]
+Implemented in: src/hcm/signalized/signalized.rs::second_term_back_of_queue
+```
+
+```
+Equations 31-143..31-148 (third-term back of queue Q3, initial-queue contribution):
+  Equation 31-144:  Q_e = Q_b + t_A × (v − c_A)     [veh]
+  if v ≥ c_A:  Equation 31-145: Q_eo = T × (v − c_A);  Equation 31-146: t_A = T
+  if v < c_A:  Equation 31-147: Q_eo = 0.0;            Equation 31-148: t_A = min(Q_b/(c_A − v), T)
+  Equation 31-143:  Q3 = 1/(N·T) × t_A × (Q_b + Q_e − Q_eo)/2     [veh/ln]
+  (same branch structure as d₃ but without the /(2·c_A) quadratic terms — Q3 is the linear queue-count analog, matching the book)
+Implemented in: src/hcm/signalized/signalized.rs::third_term_back_of_queue
+```
+
+```
+Equations 31-150..31-153 (percentile back of queue):
+  Equation 31-150:  Q% = (Q1 + Q2) × f_B% + Q3     [veh/ln]
+  if v ≥ c_A (Eqs. 31-151/31-152):  f_B% = min(1.8, 1 + z·√(I/(Q1+Q2)) + 0.60·z^0.24·(g/C)^0.33·(1 − e^(2 − 2·X_A)))
+  if v < c_A (Eq. 31-153):          f_B% = min(1.8, 1 + z·√(I/(Q1+Q2)))
+  z = percentile parameter: 1.04 (85th), 1.28 (90th), 1.64 (95th)
+  I = upstream filtering adjustment factor
+Implemented in: src/hcm/signalized/signalized.rs::percentile_back_of_queue
+```
+
+```
+Equation 31-155:  L_h = L_pc × (1 − 0.01·P_HV) + 0.01 × L_HV × P_HV     [ft/veh]
+  L_h  = average queue spacing
+  L_pc = stored passenger-car length: 25.0 ft (STORED_PASSENGER_CAR_LENGTH_FT)
+  L_HV = stored heavy-vehicle length: 45.0 ft (STORED_HEAVY_VEHICLE_LENGTH_FT)
+  P_HV = percent heavy vehicles                                         [%]
+Implemented in: src/hcm/signalized/signalized.rs::average_vehicle_spacing
+```
+
+```
+Equations 31-154/31-156:  R_Q = L_h × Q ÷ L_a     [unitless]
+  R_Q = queue storage ratio (Eq. 31-154 with the 50th-percentile Q; Eq. 31-156 with Q%)
+  Q   = back-of-queue estimate                                          [veh/ln]
+  L_a = available queue storage distance (storage_left_ft/storage_through_ft)   [ft/ln]
+Implemented in: src/hcm/signalized/signalized.rs::queue_storage_ratio_eq
+```
+
+### Critical v/c ratio
+
+```
+Equation 19-31:  L = Σᵢ l_t,i, over the critical phases i     [s]
+Equation 19-30 (= Equation 31-67):  X_c = C ÷ (C − L) × Σᵢ y_c,i     [unitless]
+  X_c   = critical intersection volume-to-capacity ratio (∞ when C ≤ L in code)
+  L     = cycle lost time                                               [s]
+  y_c,i = critical flow ratio for phase i = v_i ÷ (N_i·s_i)
+Implemented in: src/hcm/signalized/signalized.rs::critical_vc_ratio_eq (the shared formula); src/hcm/signalized/signalized.rs::compute_critical_vc (critical-path selection and the L / Σy_c,i accumulation)
+```
+
+The critical-path selection in `compute_critical_vc` treats the two direction pairs [NB, SB] and [EB, WB] as opposing barriers. For each pair it computes per approach a through flow ratio (the maximum over that approach's non-exclusive-left lane groups) and, for `Protected`/`ProtectedPermitted` lefts, splits the left-turn volume into a protected part (up to the protected phase's capacity N_l·s_lt·g_l/C) and a permitted remainder, each with its own flow ratio; a `Permitted` left contributes only a permitted flow ratio. With both approaches present it evaluates three candidate paths — Ring 1 (this approach's protected-left ratio plus the opposing through ratio), Ring 2 (the mirror), and each approach's own protected-plus-permitted left combination (one lost-time increment, the max of the two phases') — keeping the largest flow-ratio sum with its associated lost time; with one approach the path is simply that approach's through plus protected-left ratios. The winning sums and lost times from both barriers accumulate into Σy_c,i and L for Eq. 19-30.
+
 ## Deviations (cross-referenced to `docs/hcm/VERIFICATION.md`)
 
-`docs/hcm/VERIFICATION.md` is introduced by a later branch (`feat/hcm-ch19-actuated`, commit that adds the file consolidates the project's `VERIFY-HCM` items); it is not present in the working tree at this branch's tip. Its "Chapter 19 (feat/hcm-ch19-signalized)" section, read from that later commit's history, records no `VERIFY-HCM` items for this branch's code, but does flag two interpretation notes worth the reviewer's attention: (1) the Exhibit 31-12 lag-row sub-variants (`LagLead`, `LagLag`, `PermLead`, `PermLag`) were transcribed into `permitted_green_times` but only the `PermPerm` and `LeadLead` rows were validated against a published g_u value (the `case1.json`/Example Problem 1 fixture uses `PermPerm`; `test_permitted_green_times_lead_lead` in `tests.rs` covers `LeadLead`) — the other four rows are un-exercised by any fixture in this repository as of this branch. (2) The opposing-queue clearance Gq for an opposing shared through+right lane group is computed as `g_s + l_1` inside `opposing_queue_data`, matching Exhibit 31-12 note (a); this was validated numerically against Example Problem 1 rather than against an independently published Gq value. The same VERIFICATION.md entry also records two *known engine deviations* documented directly in `tests.rs`/`chapter19_integration.rs` rather than as `VERIFY-HCM` code comments: the protected-permitted left-turn d1 (uniform delay, via the QAP path) carries roughly ±1.2 s/veh of residual error against the published Exhibit 31-81 values in the tighter cases (the `chapter19_integration.rs` `d_tol` column widens to 1.5 s/veh for every permitted/protected-permitted left-turn lane group and for the oversaturated NB lane groups, versus 0.5 s/veh for the closed-form cases); and the SB-left back-of-queue estimate uses the QAP polygon's maximum queue (`lg.q1_veh` set inside `step_8_delay`'s QAP branch, reused directly by `step_10_queue_storage` for `is_perm_left` groups) as a stand-in for the full left-turn arrival–departure-polygon (ADP) family of Exhibits 31-26 through 31-31, which is explicitly deferred to milestone 2 (`chapter19-actuated.md`). This Q1 substitution is documented inline in `step_10_queue_storage`'s doc comment as "a milestone-2 item."
+`docs/hcm/VERIFICATION.md` is introduced by a later branch (`feat/hcm-ch19-actuated`, commit that adds the file consolidates the project's `VERIFY-HCM` items); it is not present in the working tree at this branch's tip. Its "Chapter 19 (feat/hcm-ch19-signalized)" section, read from that later commit's history, records no `VERIFY-HCM` items for this branch's code, but does flag two interpretation notes worth the reviewer's attention: (1) the Exhibit 31-12 lag-row sub-variants (`LagLead`, `LagLag`, `PermLead`, `PermLag`) were transcribed into `permitted_green_times` but only the `PermPerm` and `LeadLead` rows were validated against a published g_u value (the `case1.json`/Example Problem 1 fixture uses `PermPerm`; `test_permitted_green_times_lead_lead` in `tests.rs` covers `LeadLead`) — the other four rows are un-exercised by any fixture in this repository as of this branch. (2) The opposing-queue clearance Gq for an opposing shared through+right lane group is computed as `g_s + l_1` inside `opposing_queue_data`, matching Exhibit 31-12 note (a); this was validated numerically against Example Problem 1 rather than against an independently published Gq value. The same VERIFICATION.md entry also records two *known engine deviations* documented directly in `tests.rs`/`chapter19_integration.rs` rather than as `VERIFY-HCM` code comments: the protected-permitted left-turn d1 (uniform delay, via the QAP path) carries roughly ±1.2 s/veh of residual error against the published Exhibit 31-81 values in the tighter cases (the `chapter19_integration.rs` `d_tol` column widens to 1.5 s/veh for every permitted/protected-permitted left-turn lane group and for the oversaturated NB lane groups, versus 0.5 s/veh for the closed-form cases); and the SB-left back-of-queue estimate uses the QAP polygon's maximum queue (`lg.q1_veh` set inside `step_8_delay`'s QAP branch, reused directly by `step_10_queue_storage` for `is_perm_left` groups) as a stand-in for the full left-turn arrival–departure-polygon (ADP) family of Exhibits 31-26 through 31-31, which is explicitly deferred to milestone 2 (`chapter19-actuated.md`). This Q1 substitution is documented inline in `step_10_queue_storage`'s doc comment as "a milestone-2 item." Additional to these previously recorded items, the **DISCREPANCY** block under Step 7 above (the un-implemented shared-lane available-capacity Eqs. 31-123/31-127) is a new finding from this documentation pass, as are the Step 4 scope notes on f_wz/f_ms/f_sp and Eq. 31-84 (deliberate omissions defaulting to 1.0 or absent, called out there for completeness).
 
 ## Validation
 
-The fixtures live under `tests/ExampleCases/hcm/Signalized/` as `case1.json` and `case2.json`, both loaded via `serde_json` into `SignalizedIntersection`. `case1.json` encodes HCM Chapter 31, Section 10, Example Problem 1 (Exhibits 31-69 through 31-82) with the Exhibit 31-79 converged phase durations supplied as fixed pretimed/coordinated timing (this fixture therefore validates Steps 1–5 and 7–10 without exercising the actuated convergence loop). `case2.json` encodes the Chapter 31, Section 2 pretimed phase-duration example (Exhibit 31-7) as a full pretimed timing plan, with delay/LOS expectations hand-computed from Eq. 19-19 (PF = 1 for random arrivals) and Eq. 19-26 (pretimed k = 0.50) rather than taken directly from a published delay exhibit. Three test layers exercise these fixtures and the underlying functions: unit tests in `src/hcm/chapter19/tests.rs` (per-step spot checks, e.g. `test_permitted_left_saturation_flow_eq_31_100`, `test_unblocked_permitted_green_exhibit_31_79`, `test_ped_bike_factors_exhibit_31_77`, `test_pretimed_phase_duration_exhibit_31_7`, `test_permitted_green_times_perm_perm`/`_lead_lead`, `test_qap_matches_closed_form_uniform_delay`); coefficient-table unit tests in `src/hcm/chapter19/exhibits.rs` (e.g. `test_lane_width_factor_exhibit_19_20`, `test_heavy_vehicle_grade_factor`, `test_default_lane_utilization_exhibit_19_15`, `test_default_system_cycle_length_exhibit_19_17`); and the full-pipeline integration tests in `tests/chapter19_integration.rs` (`test_case1_example_problem_1_full_pipeline`, `test_case2_pretimed_exhibit_31_7_timing_plan`, `test_fixture_serde_roundtrip`), mirrored for the Python bindings in `tests/test_chapter19_integration.py`. The integration test's documented tolerances, stated verbatim in its module doc comment, are: LOS exact; intersection/approach control delay ±0.5 s/veh; lane-group control delay ±0.5 s/veh for lane groups on the Eq. 19-19 closed-form path, widened to ±1.5 s/veh for permitted/protected-permitted left-turn lane groups (QAP path) and for the oversaturated NB lane groups in `case1.json` (sensitivity of d2 to small lane-flow differences); adjusted saturation flow ±10 veh/h/ln; capacity ±6 veh/h; v/c ratio ±0.02. `case2.json`'s critical v/c ratio X_c is checked to ±0.001 against the published 0.923, and its per-approach capacity/v-c/d1/d2/delay values to ±1.0 veh/h / ±0.005 / ±0.5 s/veh (each).
+The fixtures live under `tests/ExampleCases/hcm/Signalized/` as `case1.json` and `case2.json`, both loaded via `serde_json` into `SignalizedIntersection`. `case1.json` encodes HCM Chapter 31, Section 10, Example Problem 1 (Exhibits 31-69 through 31-82) with the Exhibit 31-79 converged phase durations supplied as fixed pretimed/coordinated timing (this fixture therefore validates Steps 1–5 and 7–10 without exercising the actuated convergence loop). `case2.json` encodes the Chapter 31, Section 2 pretimed phase-duration example (Exhibit 31-7) as a full pretimed timing plan, with delay/LOS expectations hand-computed from Eq. 19-19 (PF = 1 for random arrivals) and Eq. 19-26 (pretimed k = 0.50) rather than taken directly from a published delay exhibit. Three test layers exercise these fixtures and the underlying functions: unit tests in `src/hcm/signalized/tests.rs` (per-step spot checks, e.g. `test_permitted_left_saturation_flow_eq_31_100`, `test_unblocked_permitted_green_exhibit_31_79`, `test_ped_bike_factors_exhibit_31_77`, `test_pretimed_phase_duration_exhibit_31_7`, `test_permitted_green_times_perm_perm`/`_lead_lead`, `test_qap_matches_closed_form_uniform_delay`); coefficient-table unit tests in `src/hcm/signalized/exhibits.rs` (e.g. `test_lane_width_factor_exhibit_19_20`, `test_heavy_vehicle_grade_factor`, `test_default_lane_utilization_exhibit_19_15`, `test_default_system_cycle_length_exhibit_19_17`); and the full-pipeline integration tests in `tests/chapter19_integration.rs` (`test_case1_example_problem_1_full_pipeline`, `test_case2_pretimed_exhibit_31_7_timing_plan`, `test_fixture_serde_roundtrip`), mirrored for the Python bindings in `tests/test_chapter19_integration.py`. The integration test's documented tolerances, stated verbatim in its module doc comment, are: LOS exact; intersection/approach control delay ±0.5 s/veh; lane-group control delay ±0.5 s/veh for lane groups on the Eq. 19-19 closed-form path, widened to ±1.5 s/veh for permitted/protected-permitted left-turn lane groups (QAP path) and for the oversaturated NB lane groups in `case1.json` (sensitivity of d2 to small lane-flow differences); adjusted saturation flow ±10 veh/h/ln; capacity ±6 veh/h; v/c ratio ±0.02. `case2.json`'s critical v/c ratio X_c is checked to ±0.001 against the published 0.923, and its per-approach capacity/v-c/d1/d2/delay values to ±1.0 veh/h / ±0.005 / ±0.5 s/veh (each).
 
 ## Deferred
 

--- a/docs/hcm/procedures/chapter20.md
+++ b/docs/hcm/procedures/chapter20.md
@@ -1,6 +1,6 @@
 # HCM Chapter 20 — Two-Way STOP-Controlled Intersections
 
-This document walks the HCM 7th Edition Chapter 20 motorized-vehicle methodology for two-way STOP-controlled (TWSC) intersections as implemented on branch `feat/hcm-ch20-22-unsignalized`. The code follows Chapter 20, Section 3 ("Motorized Vehicle Core Methodology," the thirteen-step procedure of the module's own header comment, itself a transcription of HCM Exhibit 20-6) together with Section 4's pedestrian-impedance extension (Equations 20-67 through 20-75). The two source files are `src/hcm/chapter20/twsc.rs` (movement model, the `Twsc` facility struct, and the full Steps 1-13 pipeline) and `src/hcm/chapter20/tests.rs` (per-step unit tests against HCM Chapter 32 TWSC Example Problems 1 and 3). Gap-acceptance building blocks shared with Chapters 21-23 (potential capacity, queue-free probability, pedestrian blockage/impedance, movement capacity) live in `src/hcm/common/gap_acceptance.rs`; unsignalized control-delay and LOS-threshold primitives live in `src/hcm/common/delay.rs` and `src/hcm/common/los_tables.rs`. These three `common` modules are documented in depth separately in `common-infrastructure.md` and are only referenced here by function name. `docs/hcm/VERIFICATION.md` does not exist as a file in this branch's working tree (it is not introduced until a later branch, following the same pattern chapter10.md documents for its own branch), so every deviation below is cross-referenced to the `// VERIFY-HCM` code comments in `twsc.rs` directly rather than to a consolidated verification file.
+This document walks the HCM 7th Edition Chapter 20 motorized-vehicle methodology for two-way STOP-controlled (TWSC) intersections as implemented on branch `feat/hcm-ch20-22-unsignalized`. The code follows Chapter 20, Section 3 ("Motorized Vehicle Core Methodology," the thirteen-step procedure of the module's own header comment, itself a transcription of HCM Exhibit 20-6) together with Section 4's pedestrian-impedance extension (Equations 20-67 through 20-75). The two source files are `src/hcm/twsc/twsc.rs` (movement model, the `Twsc` facility struct, and the full Steps 1-13 pipeline) and `src/hcm/twsc/tests.rs` (per-step unit tests against HCM Chapter 32 TWSC Example Problems 1 and 3). Gap-acceptance building blocks shared with Chapters 21-23 (potential capacity, queue-free probability, pedestrian blockage/impedance, movement capacity) live in `src/hcm/common/gap_acceptance.rs`; unsignalized control-delay and LOS-threshold primitives live in `src/hcm/common/delay.rs` and `src/hcm/common/los_tables.rs`. These three `common` modules are documented in depth separately in `common-infrastructure.md` and are only referenced here by function name. `docs/hcm/VERIFICATION.md` does not exist as a file in this branch's working tree (it is not introduced until a later branch, following the same pattern chapter10.md documents for its own branch), so every deviation below is cross-referenced to the `// VERIFY-HCM` code comments in `twsc.rs` directly rather than to a consolidated verification file. This pass adds a complete equation-by-equation reference, cross-checked against both the Rust code and the HCM 7th Edition EPUB (Chapter 20 body, Chapter 30 Section 3, and Chapter 32 worked examples), for every equation the crate implements.
 
 The public entry point is `Twsc::analyze(&mut self)`, which runs Steps 1-2, 3, 4, 5, 6-9, 10, 11, and 12 in sequence (Step 13, 95th-percentile queue, is folded into Step 11's per-movement and per-lane computation rather than broken out as a separate pass). Movement numbering follows HCM Exhibit 20-1 (module header table): major-street EB movements 1/2/3 (+ U-turn 1U), major-street WB movements 4/5/6 (+ 4U), minor-street NB (south leg) movements 7/8/9, minor-street SB (north leg) movements 10/11/12, and pedestrian movements 13-16 crossing the west, east, south, and north legs respectively. A three-leg (T) intersection is modeled by `TwscGeometry::is_three_leg`, which restricts the minor stem to movements 7 and 9 (the NB approach) per the T-intersection panel of Exhibit 20-1.
 
@@ -20,47 +20,346 @@ The public entry point is `Twsc::analyze(&mut self)`, which runs Steps 1-2, 3, 4
 
 Note that Exhibit 20-2 defines no overall LOS letter for a TWSC intersection (only for individual movements/lanes), which the code respects: `intersection_delay` is a plain seconds-per-vehicle number with no accompanying `los` field.
 
+### Steps 1-2: demand flow rates
+
+```
+Equation 20-1:  v_i = V_i ÷ PHF                                              [veh/h]
+  V_i = demand volume for movement i                                        [veh/h]
+  PHF = peak hour factor for the intersection (defaults to 1.0 when `phf` is None or <= 0, treating volumes as already-adjusted flow rates)  [unitless]
+Implemented in: twsc/twsc.rs::Twsc::step1_2_demand_flow_rates
+```
+
+The same PHF divides every one of the fourteen vehicular movements plus the four pedestrian movements 13-16 (the pedestrian counts are also demand-volume inputs on `TwscDemand`, divided by the same intersection-wide PHF as the vehicular movements per the HCM's single-PHF convention for Step 2).
+
 ### Step 3: conflicting flow rates and the `VERIFY-HCM` deviation
 
-`step3_conflicting_flows` computes ten conflicting-flow expressions (Equations 20-2 through 20-15) directly from movement flow rates and the major-street right-turn/lane-count configuration, using small private "conflicting-flow factor" helpers rather than inlined literals, e.g. `f_minor_rt_vs_major_through` returns 1.0 for a one-lane major street and 0.5 for two or three lanes (Exhibit 20-10), and `f_uturn_vs_major_through` returns 0.73 for a three-lane major (Exhibit 20-12). A documented `VERIFY-HCM` block precedes the function: the HCM Chapter 32 TWSC Example Problem 3 worked values for movements 7, 8, 10, and 11's Stage II/Stage I conflicting flows use HCM 6th Edition equation forms (a factor of 1.0 rather than the 7th Edition's 0.5 on the relevant major-street right-turn term for movement 8's Stage II and movement 11's Stage I, and a different opposing-minor-through treatment for movements 7/10's Stage II). The implementation follows the 7th Edition exhibits as its default behavior; a `ConflictingFlowOverride` mechanism (movement label + stage + literal value) lets a caller substitute the published 6th-Edition-style numbers to reproduce Example Problem 3 exactly. `chapter20/tests.rs::test_ep3_step3_default_exhibit_factors` explicitly checks the 7th-Edition default values against the overridden ones so both code paths are exercised.
+`step3_conflicting_flows` computes ten conflicting-flow expressions (Equations 20-2 through 20-15) directly from movement flow rates and the major-street right-turn/lane-count configuration, using small private "conflicting-flow factor" helpers rather than inlined literals, e.g. `f_minor_rt_vs_major_through` returns 1.0 for a one-lane major street and 0.5 for two or three lanes (Exhibit 20-10), and `f_uturn_vs_major_through` returns 0.73 for a three-lane major (Exhibit 20-12). A documented `VERIFY-HCM` block precedes the function: the HCM Chapter 32 TWSC Example Problem 3 worked values for movements 7, 8, 10, and 11's Stage II/Stage I conflicting flows use HCM 6th Edition equation forms (a factor of 1.0 rather than the 7th Edition's 0.5 on the relevant major-street right-turn term for movement 8's Stage II and movement 11's Stage I, and a different opposing-minor-through treatment for movements 7/10's Stage II). The implementation follows the 7th Edition exhibits as its default behavior; a `ConflictingFlowOverride` mechanism (movement label + stage + literal value) lets a caller substitute the published 6th-Edition-style numbers to reproduce Example Problem 3 exactly. `twsc/tests.rs::test_ep3_step3_default_exhibit_factors` explicitly checks the 7th-Edition default values against the overridden ones so both code paths are exercised.
+
+All ten expressions share the general shape `v_c,x = Σ (f · v_conflicting) + v_ped`, a weighted sum of the vehicular movements that conflict with x plus the pedestrian movement(s) crossing x's path, where each weight f is a conflicting-flow factor of 0, 0.5, 0.73, 1, or 2 read off Exhibits 20-8/20-10/20-12/20-14/20-16 depending on lane configuration. One-stage movements (1, 4, 1U, 4U, 9, 12) use a single expression; the two-stage-eligible minor movements (7, 8, 10, 11) get separate Stage I and Stage II expressions whose sum is the one-stage total. The one-stage EB left turn is representative of the simplest family member:
+
+```
+Equation 20-2:  v_c,1 = v_5 + f(1,6)·v_6 + v_16                              [veh/h]
+  v_5    = major-street WB through flow rate                                [veh/h]
+  v_6    = major-street WB right-turn flow rate                             [veh/h]
+  f(1,6) = 0 if movement 6 uses a STOP/YIELD-controlled channelized right-turn lane (Exhibit 20-8), else 1  [unitless]
+  v_16   = pedestrian flow rate crossing the north minor leg                [p/h]
+Implemented in: twsc/twsc.rs::Twsc::step3_conflicting_flows (f(1,6) via Twsc::f_channelized_zero); Equation 20-3 (v_c,4) mirrors this with the EB quantities and v_15
+```
+
+The minor-street right turns (9, 12) and major-street U-turns (1U, 4U) follow the same pattern with different factor sets (Equations 20-4/20-5, Exhibit 20-10; Equations 20-6/20-7, Exhibit 20-12), implemented by the same function via `f_minor_rt_vs_major_through`, `f_shared_half`, `f_uturn_vs_major_through`, and `f_uturn_vs_major_right`. The two-stage minor-through movement 8 is representative of the Stage I/II family (Exhibit 20-14):
+
+```
+Equation 20-8 (Stage I):   v_c,I,8  = 2·v_1 + 2·v_1U + v_2 + f(8,3)·v_3 + v_15   [veh/h]
+Equation 20-10 (Stage II): v_c,II,8 = 2·v_4 + 2·v_4U + v_5 + f(8,6)·v_6 + v_16   [veh/h]
+  v_1, v_1U = major-street EB left-turn / U-turn flow rate                       [veh/h]
+  v_2       = major-street EB through flow rate                                 [veh/h]
+  f(8,3)    = 0.5 if movement 3 shares a lane with the EB through movement (Exhibit 20-14), 0 if exclusive/channelized  [unitless]
+  v_15, v_16 = pedestrian flow rate crossing the south / north minor leg         [p/h]
+  v_c,8 (one-stage total) = v_c,I,8 + v_c,II,8
+Implemented in: twsc/twsc.rs::Twsc::step3_conflicting_flows (f(8,3)/f(8,6) via Twsc::f_shared_half). The remaining Stage I/II pairs — Equations 20-9/20-11 (movement 11), 20-12/20-14 (movement 7), 20-13/20-15 (movement 10) — are the same weighted-sum pattern against Exhibit 20-16's factors and are implemented in the same function.
+```
 
 ### Step 4: critical and follow-up headways
 
 `base_critical_headway` and `base_followup_headway` transcribe Exhibits 20-17/20-18 as per-movement, per-lane-count match arms (e.g. major-street left turn 4.1 s for one/two major lanes, 5.3 s for three; minor-street through 6.5 s one-stage vs. 5.5 s per stage). `critical_headway` then applies Equation 20-16's `t_c = t_c,base + t_c,HV * P_HV + t_c,G * G - t_3,LT` with `t_c,HV` = 1.0 s for a one-lane major and 2.0 s for two/three lanes, `t_c,G` = 0.1 s for movements 9/12 and 0.2 s for movements 7/8/10/11, and the three-leg minor-left correction `t_3,LT` = 0.7 s. Two `VERIFY-HCM` comments flag places where Exhibit 20-17/20-18 lists "NA": U-turn critical/follow-up headway on a two-lane major street (the four-lane wide-median value 6.4 s / 2.5 s is used as a fallback if a caller codes a U-turn there anyway).
 
+```
+Equation 20-16:  t_c,x = t_c,base + t_c,HV·P_HV + t_c,G·G − t_3,LT           [s]
+  t_c,base = base critical headway (Exhibit 20-17 match arm on movement × major-street through-lane count)  [s]
+  t_c,HV   = heavy-vehicle adjustment: 1.0 for a one-lane major street, 2.0 for two/three lanes             [s]
+  P_HV     = proportion heavy vehicles = heavy_vehicle_pct ÷ 100                                            [unitless]
+  t_c,G    = grade adjustment: 0.1 for movements 9/12, 0.2 for movements 7/8/10/11, 0 otherwise             [s]
+  G        = signed approach grade for the minor leg the movement is on (negative = downhill)               [%]
+  t_3,LT   = three-leg minor-left correction: 0.7 for movements 7/10 at a T intersection, 0 otherwise        [s]
+Implemented in: twsc/twsc.rs::Twsc::critical_headway (base value via Twsc::base_critical_headway, grade via Twsc::grade_for)
+```
+
+```
+Equation 20-17:  t_f,x = t_f,base + t_f,HV·P_HV                              [s]
+  t_f,base = base follow-up headway (Exhibit 20-18 match arm)                [s]
+  t_f,HV   = heavy-vehicle adjustment: 0.9 for a one-lane major street, 1.0 for two/three lanes  [s]
+  P_HV     = proportion heavy vehicles                                       [unitless]
+Implemented in: twsc/twsc.rs::Twsc::followup_headway (base value via Twsc::base_followup_headway)
+```
+
+### Step 5a: potential capacity (gap-acceptance base case)
+
+```
+Equation 20-18:  c_p,x = v_c,x · exp(−v_c,x·t_c,x ÷ 3,600) ÷ (1 − exp(−v_c,x·t_f,x ÷ 3,600))   [veh/h]
+  v_c,x = conflicting flow rate for movement x (Step 3)                      [veh/h]
+  t_c,x = critical headway for movement x (Equation 20-16)                   [s]
+  t_f,x = follow-up headway for movement x (Equation 20-17)                  [s]
+  Limit v_c,x -> 0: c_p,x -> 3,600 ÷ t_f,x, returned explicitly for v_c,x <= 0 rather than evaluated as a 0/0 limit  [veh/h]
+Implemented in: common/gap_acceptance.rs::potential_capacity, called from twsc/twsc.rs::Twsc::step5_potential_capacities for every Rank 2-4 movement (and, for two-stage movements, separately for each stage's own conflicting flow and critical headway)
+```
+
 ### Step 5b: upstream-signal platoon blockage
 
 When the TWSC intersection sits between coordinated upstream signals, arrivals on the major street are platooned and the conflicting stream alternates between blocked and unblocked periods (HCM Step 5b). `step5_potential_capacities` selects this path per movement whenever the optional `platoon_blockage: Option<PlatoonBlockage>` input is present with a nonzero proportion for that movement, otherwise it uses the plain Equation 20-18 gap-acceptance capacity. The switch is per movement and per stage, so a partially-populated `PlatoonBlockage` mixes platooned and non-platooned movements, and an all-zero (or `None`) input reduces the whole step to Equation 20-18 bit-for-bit — `test_platoon_off_equivalence` asserts that `None` and `Some(PlatoonBlockage::default())` yield identical pipeline output for Example Problem 3.
 
-`PlatoonBlockage` carries eight analyst-supplied proportions (p_b,1, p_b,4, p_b,7, p_b,8, p_b,9, p_b,10, p_b,11, p_b,12). `PlatoonBlockage::total` and `PlatoonBlockage::stages` encode the Exhibit 20-19 mapping: movements 1U/4U reuse p_b,1/p_b,4; the one-stage total for each movement is its own p_b; and the two-stage movements draw their Stage I/Stage II proportions from the opposing major-street left-turn direction (movements 7 and 8 use Stage I = p_b,4, Stage II = p_b,1; movements 10 and 11 mirror to Stage I = p_b,1, Stage II = p_b,4). `potential_capacity_upstream_signal` then applies Equation 20-19 (unblocked-period conflicting flow v_c,u,x, with v_c,min = 1,000 N and the `v_c,x <= 1.5 v_c,min p_b,x` -> v_c,u,x = 0 branch), Equation 20-21 (random-flow capacity c_r,x, with the v_c,u,x = 0 -> 3,600/t_f branch), and Equation 20-20 (c_p,x = (1 - p_b,x) c_r,x). The proportions can be supplied directly (e.g. from the Chapter 30 movement-based access-point output, Exhibit 32-12) or computed from upstream-signal descriptors as described next.
+`PlatoonBlockage` carries eight analyst-supplied proportions (p_b,1, p_b,4, p_b,7, p_b,8, p_b,9, p_b,10, p_b,11, p_b,12). `PlatoonBlockage::total` and `PlatoonBlockage::stages` encode the Exhibit 20-19 mapping (confirmed against the EPUB table, whose column headers are "One-Stage Movements" / "Two-Stage Movements: Stage I" / "Two-Stage Movements: Stage II" and whose rows are "1, 1U" / "4, 4U" / "7" / "8" / "9" / "10" / "11" / "12"; only the mapping structure is reproduced here, not the exhibit's data cells): movements 1U/4U reuse p_b,1/p_b,4; the one-stage total for each movement is its own p_b; and the two-stage movements draw their Stage I/Stage II proportions from the opposing major-street left-turn direction (movements 7 and 8 use Stage I = p_b,4, Stage II = p_b,1; movements 10 and 11 mirror to Stage I = p_b,1, Stage II = p_b,4).
+
+```
+Equation 20-19:  v_c,u,x = (v_c,x − 1.5·v_c,min·p_b,x) ÷ (1 − p_b,x)   if v_c,x > 1.5·v_c,min·p_b,x, else v_c,u,x = 0   [veh/h]
+  v_c,x   = total conflicting flow rate for movement x (Step 3)              [veh/h]
+  v_c,min = minimum platooned conflicting flow rate ≈ 1,000·N                [veh/h]
+  N       = major-street through lanes per direction (major_lanes_per_direction)  [lanes]
+  p_b,x   = proportion of the analysis period movement x is blocked by the platoon (Exhibit 20-19)  [unitless]
+Implemented in: twsc/twsc.rs::Twsc::potential_capacity_upstream_signal
+```
+
+```
+Equation 20-21:  c_r,x = v_c,u,x · exp(−v_c,u,x·t_c,x ÷ 3,600) ÷ (1 − exp(−v_c,u,x·t_f,x ÷ 3,600))   if v_c,u,x > 0, else c_r,x = 3,600 ÷ t_f,x   [veh/h]
+  v_c,u,x = unblocked-period conflicting flow (Equation 20-19)               [veh/h]
+  t_c,x, t_f,x = critical / follow-up headway for movement x                 [s]
+Implemented in: twsc/twsc.rs::Twsc::potential_capacity_upstream_signal (the v_c,u,x > 0 branch reuses common/gap_acceptance.rs::potential_capacity)
+```
+
+```
+Equation 20-20:  c_p,x = (1 − p_b,x) · c_r,x                                  [veh/h]
+  p_b,x = proportion of time blocked (as above)                              [unitless]
+  c_r,x = random-flow capacity of the unblocked period (Equation 20-21)      [veh/h]
+Implemented in: twsc/twsc.rs::Twsc::potential_capacity_upstream_signal
+```
+
+The proportions can be supplied directly (e.g. from the Chapter 30 movement-based access-point output, Exhibit 32-12, which reports p_b and delay-to-through-vehicles for a specific worked example rather than serving as a generic definitional table — Exhibit 20-19 is the generic p_b mapping) or computed from upstream-signal descriptors as described next.
 
 ### Step 5b input: computed proportion of time blocked (HCM Chapter 30, Section 3)
 
-When the analyst supplies coordinated upstream-signal descriptors instead of the p_b values themselves, `Twsc::analyze` derives them via the HCM Chapter 30, Section 3 "Proportion of Time Blocked" procedure (EPUB `235_Ch30_03.xhtml`, Equation 30-13), implemented in `src/hcm/chapter20/computed_pb.rs`. The new input is `upstream_signals: Option<UpstreamSignals>`, holding the system cycle length C and up to two `UpstreamSignal` descriptors (`eastbound`, feeding the movement-2 through-lane group; `westbound`, feeding movement 5). Each descriptor gives the segment length (`distance_ft`), progression speed (`progression_speed_mph`, which fixes the running time t_R that drives dispersion), an optional uniform midblock volume, and the upstream `discharges` (a list of `MovementDischarge` profiles reused from `chapter18::platoon_dispersion`). `analyze` calls `UpstreamSignals::compute_platoon_blockage` at the top of the pipeline (critical headways depend only on geometry and heavy-vehicle percentage, so this precedes Step 4), which:
+When the analyst supplies coordinated upstream-signal descriptors instead of the p_b values themselves, `Twsc::analyze` derives them via the HCM Chapter 30, Section 3 "Proportion of Time Blocked" procedure (EPUB `235_Ch30_03.xhtml` — Equation 30-13 and neighboring Equations 30-9 through 30-12 appear in this same file), implemented in `src/hcm/twsc/computed_pb.rs`. The new input is `upstream_signals: Option<UpstreamSignals>`, holding the system cycle length C and up to two `UpstreamSignal` descriptors (`eastbound`, feeding the movement-2 through-lane group; `westbound`, feeding movement 5). Each descriptor gives the segment length (`distance_ft`), progression speed (`progression_speed_mph`, which fixes the running time t_R that drives dispersion), an optional uniform midblock volume, and the upstream `discharges` (a list of `MovementDischarge` profiles reused from `chapter18::platoon_dispersion`). `analyze` calls `UpstreamSignals::compute_platoon_blockage` at the top of the pipeline (critical headways depend only on geometry and heavy-vehicle percentage, so this precedes Step 4), which:
 
-1. Builds each direction's combined arrival flow profile at the TWSC intersection by dispersing the upstream discharge profiles over the segment (`combined_arrival_profile`, Equations 30-9 through 30-12).
-2. For each Rank 2–4 movement, forms the critical platoon flow rate q_c = 3,600 / t_c from the Chapter 20 critical headway (`Twsc::critical_headway`) and counts the cycle steps whose arrival flow rate exceeds q_c — the blocked period duration t'_p (`blocked_period_steps`).
+1. Builds each direction's combined arrival flow profile at the TWSC intersection by dispersing the upstream discharge profiles over the segment (`combined_arrival_profile`, Equations 30-9 through 30-12 — the Robertson-style platoon-dispersion recursion `q'_a|u,j = F·q'_u,i + (1-F)·q'_a|u,j-1` with smoothing factor `F = 1/(1 + 0.138 t'_R + 0.315/d_t)` and platoon arrival time `t' = t'_R - 1/F + 1.25`, where `t'_R` is the segment running time in time steps; this dispersion machinery lives in `urban_segments::platoon_dispersion` and is only referenced here by function name, per this document's read-only scope on that module).
+2. For each Rank 2-4 movement, forms the critical platoon flow rate q_c = 3,600 / t_c from the Chapter 20 critical headway (`Twsc::critical_headway`) and counts the cycle steps whose arrival flow rate exceeds q_c — the blocked period duration t'_p (`blocked_period_steps`).
 3. Applies Equation 30-13, p_b = t'_p d_t / C (`proportion_time_blocked_from_profile`).
+
+```
+Equation 30-13:  p_b = t'_p · d_t ÷ C                                        [unitless, clamped to [0,1]]
+  t'_p = blocked-period duration: count of cycle time steps whose arrival flow rate exceeds the critical platoon flow rate q_c = 3,600 ÷ t_c  [steps]
+  d_t  = flow-profile time step (Chapter 30 recommends 1.0)                  [s/step]
+  C    = system cycle length shared by the coordinated signals               [s]
+  q_c  = critical platoon flow rate = 3,600 ÷ t_c (t_c = the movement's Chapter 20 critical headway); above q_c, platoon headways are too short to enter or cross  [veh/h]
+Implemented in: twsc/computed_pb.rs::proportion_time_blocked_from_profile (single through-lane group), twsc/computed_pb.rs::union_proportion_time_blocked (minor-street left/through movements, union of both directions' blocked steps); q_c via twsc/computed_pb.rs::q_c
+```
 
 The through-lane group evaluated per movement follows the Chapter 20 conflict equations: movement 1 (EB left) and movement 12 (SB right) read the westbound profile (their v_c involves v_5); movement 4 (WB left) and movement 9 (NB right) read the eastbound profile (v_2); the minor-street left and through movements 7, 8, 10, 11 are blocked when a platoon is present from either direction, so their p_b is the union of the two directions' blocked steps. Only the one-stage totals (`pb1`, `pb4`, `pb7`, `pb8`, `pb9`, `pb10`, `pb11`, `pb12`) are populated; the two-stage Stage I/II proportions are still derived from `pb1`/`pb4` by `PlatoonBlockage::stages` per Exhibit 20-19. Section 3 does not use v_c,min in the blocked-period computation (that threshold belongs to the downstream Step 5b Equation 20-19); the blocked period is governed solely by q_c. An explicit `platoon_blockage` always takes precedence over `upstream_signals`, and absent/empty descriptors yield all-zero p_b, so the analyst-input and no-platooning pipelines are bit-identical.
 
 ### Steps 6-9: the impedance chain
 
-This is the heart of the Rank 2/3/4 dependency structure. Rank 2 movements (major-street left turns 1/4, U-turns 1U/4U, minor-street right turns 9/12) either have unimpeded potential capacity (major left turns, `assign(self, Mv::M1, pp16)` applies only the pedestrian factor) or are impeded by the queue-free probability of another Rank 2 movement (U-turn 1U is impeded by `p0_12 = prob_queue_free(flow(M12), capacity(M12))`, i.e. Equations 20-24/20-26). `p0_major_left` computes the Equation 20-28 queue-free probability `p_0 = 1 - v/c_m` for the combined major left + U-turn flow using the shared-lane capacity form (Equation 20-27) when the U-turn shares a lane with the left turn. Rank 3 movements (minor-street through, 8/11, at a four-leg intersection; minor-street left, 7, at a T) multiply their potential capacity by the product of the impeding Rank 2 queue-free probabilities and pedestrian impedance factors (`f_r3 = p0_1 * p0_4 * pp15 * pp16`, Equation 20-35/20-36 — `vehicular_impedance_factor` in `gap_acceptance.rs` is the literal `Π p_0,j` product but the Rank 3/4 call sites in `twsc.rs` inline the multiplication rather than calling that helper directly). Rank 4 movements (minor-street left, 7/10, at a four-leg intersection) use the more elaborate "dependent" combinatorial form of Equations 20-41/20-42 (extended with the Exhibit 20-23/20-24 pedestrian terms to 20-74/20-75): `dependent(p_majors, p_cross) = 1 / (1/p_majors + 1/p_cross - 1)`, then multiplied by the queue-free probability of the opposing minor-street right turn and both relevant pedestrian factors.
+This is the heart of the Rank 2/3/4 dependency structure. Rank 2 movements (major-street left turns 1/4, U-turns 1U/4U, minor-street right turns 9/12) either have unimpeded potential capacity (major left turns, `assign(self, Mv::M1, pp16)` applies only the pedestrian factor) or are impeded by the queue-free probability of another Rank 2 movement (U-turn 1U is impeded by `p0_12 = prob_queue_free(flow(M12), capacity(M12))`, i.e. Equations 20-24/20-26).
 
-Two-stage movements (7, 8, 10, 11 when `median_storage_nb`/`sb` is `Some(n) > 0` and the intersection is not three-leg) get Stage I and Stage II movement capacities from the same impedance chain applied to each stage's own potential capacity, then combine them via `two_stage_total_capacity`, which transcribes Equations 20-38/20-39/20-40 (Rank 3) and 20-46/20-47/20-48 (Rank 4) including the `y == 1` branch (Equation 20-40/20-48) as a numerically distinct case from the general `y != 1` closed form (Equation 20-39/20-47). The adjustment factor `a = 1 - 0.32 e^(-1.3 sqrt(n_m))` (`two_stage_adjustment_a`, Equations 20-37/20-45) is verified in `tests.rs::test_two_stage_total_capacity_equation` against the Chapter 32 Example Problem 3 value `a = 0.949` at `n_m = 2`.
+```
+Equation 20-22:  c_m,j = c_p,j                                                [veh/h]  (Rank 2 major-street left turn, unimpeded by vehicular movements)
+  c_p,j = potential capacity from Step 5 (Equation 20-18)                    [veh/h]
+  In code the vehicular factor of 1.0 is combined with the pedestrian factor of Equation 20-69: c_m,1 = c_p,1 × p_p,16, c_m,4 = c_p,4 × p_p,15 (Exhibit 20-22 mapping)
+Implemented in: twsc/twsc.rs::Twsc::step6_9_movement_capacities (assign(M1, pp16), assign(M4, pp15))
+```
 
-### Step 10: shared and flared minor-lane capacity
+```
+Equation 20-23 / 20-70 / 20-71 / 20-72:  c_m,j = c_p,j × f_j,  f_9 = p_p,15 × p_p,14,  f_12 = p_p,16 × p_p,13   [veh/h]
+  p_p,x = pedestrian impedance factor of the conflicting pedestrian movement x (Equation 20-68)  [unitless]
+Implemented in: twsc/twsc.rs::Twsc::step6_9_movement_capacities (assign(M9, pp15*pp14), assign(M12, pp16*pp13))
+```
 
-`minor_lanes` dispatches on `MinorLaneConfig` (single shared lane, shared-left-through + exclusive-right, exclusive-left + shared-through-right, or fully separate lanes) and, for a single shared lane with `flare_storage > 0`, calls `flared_lane_capacity` (Equation 20-50), whose `n_R = 0` case is verified in `test_flared_lane_capacity_equation` to reduce exactly to `shared_lane_capacity` (Equation 20-49, the harmonic-mean-like form `c_SH = Σv_y / Σ(v_y/c_m,y)`). The shared/short major-street left-turn queue-free probability `prob_queue_free_shared_major` (Equations 20-29 through 20-34) is now wired into the impedance chain through Step 7d (see below). The remaining shared-major-lane helper `shared_major_lane_capacity` (Step 10c, Equations 20-51 through 20-60, the reduced through-lane capacity c_SS when left turns share or short-pocket into the through lane) is implemented and unit-tested (`test_shared_major_lane_capacity`) but is not called from `step10_lane_capacities` or `analyze`: it models the capacity of the shared major-street through lane itself, which neither reported fixture output depends on (in Example Problem 4 it evaluates to the s_2+3 saturation-flow bound and does not feed the minor-street results), so it exists as a standalone, independently-verified building block a caller can invoke directly.
+```
+Equation 20-24 / 20-25:  f_1U = p_0,12 = 1 − v_12/c_m,12,   f_4U = p_0,9 = 1 − v_9/c_m,9   [unitless]
+  v_12, v_9     = flow rate of the companion minor-street right turn                [veh/h]
+  c_m,12, c_m,9 = movement capacity of the companion minor-street right turn        [veh/h]
+Equation 20-26:  c_m,jU = c_p,jU × f_jU                                              [veh/h]
+Implemented in: twsc/twsc.rs::Twsc::step6_9_movement_capacities (p0_12, p0_9, assign(M1U, p0_12), assign(M4U, p0_9)); common/gap_acceptance.rs::prob_queue_free
+```
+
+`p0_major_left` computes the Equation 20-28 queue-free probability `p_0 = 1 - v/c_m` for the combined major left + U-turn flow using the shared-lane capacity form (Equation 20-27) when the U-turn shares a lane with the left turn:
+
+```
+Equation 20-27:  c_SH = Σ v_y ÷ Σ (v_y ÷ c_m,y)                                    [veh/h]
+  v_y, c_m,y = flow rate / movement capacity of each movement y sharing the lane  [veh/h]
+  (algebraically the same harmonic-mean form as the general shared-lane Equation 20-49; the HCM restates it here specifically for the major-street left-turn + U-turn pair sharing one lane, immediately ahead of Equation 20-28)
+Equation 20-28:  p_0,j = 1 − v_j ÷ c_m,j                                           [unitless, clamped to [0,1]]
+  j = 1+1U (EB) or 4+4U (WB), using the shared-lane v_j/c_m,j of Equation 20-27 when the U-turn shares the left-turn lane, else the plain left-turn v/c
+Implemented in: twsc/twsc.rs::Twsc::p0_major_left (Eq 20-27 via Twsc::shared_lane_capacity); common/gap_acceptance.rs::prob_queue_free (Eq 20-28)
+```
+
+Rank 3 movements (minor-street through, 8/11, at a four-leg intersection; minor-street left, 7, at a T) multiply their potential capacity by the product of the impeding Rank 2 queue-free probabilities and pedestrian impedance factors:
+
+```
+Equation 20-35:  f_k = Π p_0,j                                                     [unitless]
+  p_0,j = queue-free probability of each impeding Rank 2 movement j (Equation 20-28, or p*_0,j of Equations 20-29..20-34 when the major left shares/short-pockets)
+Equation 20-36 (extended with pedestrian terms to Equation 20-73):  c_m,k = c_p,k × f_k × p_p,x   [veh/h]
+Implemented in: common/gap_acceptance.rs::vehicular_impedance_factor, movement_capacity (the literal Π p_0,j form); inlined directly at the Rank 3/4 call sites in twsc/twsc.rs::Twsc::step6_9_movement_capacities as f_r3 = p0_1*p0_4*pp15*pp16 (movements 8/11, four-leg) and f7 = p0_4*pp15*pp13 (movement 7 at a T)
+```
+
+Two-stage movements (7, 8, 10, 11 when `median_storage_nb`/`sb` is `Some(n) > 0` and the intersection is not three-leg) get Stage I and Stage II movement capacities from the same impedance chain applied to each stage's own potential capacity, then combine them via `two_stage_total_capacity`, which transcribes Equations 20-38/20-39/20-40 (Rank 3) and 20-46/20-47/20-48 (Rank 4):
+
+```
+Equation 20-37 / 20-45:  a = 1 − 0.32 · exp(−1.3·√n_m)                              [unitless]
+  n_m = median storage, vehicles (median_storage_nb / median_storage_sb)          [veh]
+Implemented in: twsc/twsc.rs::Twsc::two_stage_adjustment_a — verified in twsc/tests.rs::test_two_stage_total_capacity_equation against the Chapter 32 Example Problem 3 value a = 0.949 at n_m = 2
+```
+
+```
+Equation 20-38 / 20-46:  y = (c_I − c_m,x) ÷ (c_II − v_L − c_m,x)                   [unitless]
+  c_I    = Stage I movement capacity                                              [veh/h]
+  c_II   = Stage II movement capacity                                             [veh/h]
+  c_m,x  = one-stage movement capacity of the subject movement (Equation 20-36 for Rank 3, Equation 20-43/20-44 for Rank 4)  [veh/h]
+  v_L    = major-street left-turn + U-turn conflicting flow (v_1+v_1U for movements 8/7, v_4+v_4U for movements 11/10)      [veh/h]
+Implemented in: twsc/twsc.rs::Twsc::two_stage_total_capacity
+```
+
+```
+Equation 20-39 / 20-47 (y ≠ 1):  c_T = a ÷ (y^(n_m+1) − 1) · [y·(y^n_m − 1)·(c_II − v_L) + (y − 1)·c_m,x]   [veh/h]
+Equation 20-40 / 20-48 (y = 1):  c_T = a ÷ (n_m + 1) · [n_m·(c_II − v_L) + c_m,x]                            [veh/h]
+Implemented in: twsc/twsc.rs::Twsc::two_stage_total_capacity, which selects the y = 1 branch when `(y - 1.0).abs() < 1e-9` as a numerically distinct case from the general y != 1 closed form
+```
+
+Rank 4 movements (minor-street left, 7/10, at a four-leg intersection) use the more elaborate "dependent" combinatorial form of Equations 20-41/20-42 (extended with the Exhibit 20-23/20-24 pedestrian terms to 20-74/20-75):
+
+```
+Equation 20-41 / 20-74:  f_p,7  = [1 ÷ (1÷(p_0,1+1U·p_0,4+4U) + 1÷p_0,11 − 1)] · p_0,12 · p_p,15 · p_p,13   [unitless]
+Equation 20-42 / 20-75:  f_p,10 = [1 ÷ (1÷(p_0,1+1U·p_0,4+4U) + 1÷p_0,8  − 1)] · p_0,9  · p_p,16 · p_p,14   [unitless]
+  p_0,1+1U, p_0,4+4U = queue-free probability of the major-street left+U-turn movements (p*_0,j when the lane is shared/short-pocket)  [unitless]
+  p_0,11 / p_0,8     = queue-free probability of the opposing crossing minor-street through movement       [unitless]
+  p_0,12 / p_0,9     = queue-free probability of the conflicting minor-street right turn                    [unitless]
+  p_p,x              = pedestrian impedance factor of the relevant crossing pedestrian movements (Equation 20-68)  [unitless]
+Equation 20-43 / 20-44:  c_m,7 = c_p,7 × f_p,7,   c_m,10 = c_p,10 × f_p,10                                    [veh/h]
+Implemented in: twsc/twsc.rs::Twsc::step6_9_movement_capacities (closure `dependent(p_majors, p_cross) = 1/(1/p_majors + 1/p_cross - 1)`, then fp7, fp10)
+```
+
+`dependent(p_majors, p_cross) = 1 / (1/p_majors + 1/p_cross - 1)`, then multiplied by the queue-free probability of the opposing minor-street right turn and both relevant pedestrian factors, as above. For the two-stage Rank 4 movements the code extends this with a Stage II impedance term `p_ii` that additionally incorporates the opposing crossing movement's own Stage I queue-free probability (`p0_i_cross`), mirroring the worked procedure of HCM Chapter 32 Example Problem 3 rather than a single boxed equation number; this is implemented in the same function (`step6_9_movement_capacities`, the "Step 9b" block) and is exercised by the Example Problem 3 fixture.
 
 ### Step 7d: shared/short major-street left-turn queue-free probability
 
-When a major-street left turn shares the adjacent through lane or uses a short storage pocket, a left-turning vehicle waiting for a gap can block the Rank 1 through/right traffic behind it, so the queue-free probability the impedance chain sees is p\*_0,j (Equations 20-29 through 20-34), not the exclusive-lane p_0,j (Equation 20-28). `MajorLeftLaneConfig` (`major_left_eb`/`major_left_wb`, default `Exclusive`) marks each major approach as `Exclusive`, `Shared` (n_L = 0), or `SharedShortPocket{storage_veh}` (n_L > 0). `step6_9_movement_capacities` computes the exclusive-lane p_0,1+1U and p_0,4+4U as before, then `p0_star_major_left` substitutes p\*_0,j = `prob_queue_free_shared_major(p_0, x, n_L)` whenever the config is not `Exclusive`. The combined degree of saturation x_2+3 / x_5+6 (Equations 20-30/20-32) uses `f_ll_major` (1.0/0.5/0.33 for one/two/three through lanes) and the default saturation flow rates s = 1,800 (through) / 1,500 (right) veh/h. The substituted p\*_0,j then propagates into every Rank 3 and Rank 4 impedance product (movements 7/8/10/11) exactly where p_0,1/p_0,4 appear. HCM Chapter 32 Example Problem 4 (case3.json, shared major lefts) exercises this path: x_2+3 = 0.304, p\*_0 = 0.856, giving c_m,7 = c_m,10 = 47 veh/h (`test_p0_star_shared_major_ep4_value`, `test_major_left_shared_wiring`). For `Exclusive` (the default) no substitution occurs and behavior is bit-identical to before.
+When a major-street left turn shares the adjacent through lane or uses a short storage pocket, a left-turning vehicle waiting for a gap can block the Rank 1 through/right traffic behind it, so the queue-free probability the impedance chain sees is p\*_0,j (Equations 20-29 through 20-34), not the exclusive-lane p_0,j (Equation 20-28). `MajorLeftLaneConfig` (`major_left_eb`/`major_left_wb`, default `Exclusive`) marks each major approach as `Exclusive`, `Shared` (n_L = 0), or `SharedShortPocket{storage_veh}` (n_L > 0). `step6_9_movement_capacities` computes the exclusive-lane p_0,1+1U and p_0,4+4U as before, then `p0_star_major_left` substitutes p\*_0,j = `prob_queue_free_shared_major(p_0, x, n_L)` whenever the config is not `Exclusive`.
+
+```
+Equation 20-30 / 20-32:  x_2+3 = f_LL,2+3 · (v_2/s_2 + v_3/s_3),   x_5+6 = f_LL,5+6 · (v_5/s_5 + v_6/s_6)   [unitless]
+  f_LL,2+3, f_LL,5+6 = portion of through/right traffic using the left lane: 1.0 (N=1), 0.5 default (N=2), 0.33 default (N=3)  [unitless]
+  v_2, v_5 = major-street through flow rate                                        [veh/h]
+  v_3, v_6 = major-street right-turn flow rate (0 with an exclusive right-turn lane)  [veh/h]
+  s_2, s_5 = major-street through saturation flow rate, default 1,800               [veh/h]
+  s_3, s_6 = major-street right-turn saturation flow rate, default 1,500            [veh/h]
+Implemented in: twsc/twsc.rs::Twsc::major_through_saturation (f_LL via Twsc::f_ll_major; constants MAJOR_THROUGH_SAT_FLOW = 1,800.0, MAJOR_RIGHT_SAT_FLOW = 1,500.0)
+```
+
+```
+Equation 20-29 / 20-31 (n_L > 0, short pocket, general root form):
+  p*_0,1+1U = 1 − (1 − p_0,1+1U) · [1 + x_2+3^(n_L+1) ÷ (1 − x_2+3)]^(1/(n_L+1))
+  p*_0,4+4U = 1 − (1 − p_0,4+4U) · [1 + x_5+6^(n_L+1) ÷ (1 − x_5+6)]^(1/(n_L+1))
+Equation 20-33 / 20-34 (n_L = 0, shared lane, reduced form):
+  p*_0,1+1U = 1 − (1 − p_0,1+1U) ÷ (1 − x_2+3)
+  p*_0,4+4U = 1 − (1 − p_0,4+4U) ÷ (1 − x_5+6)
+  p_0,j = exclusive-lane queue-free probability (Equation 20-28)                    [unitless]
+  n_L   = vehicles storable in the left-turn pocket (0 = shared lane, Exhibit 20-20)  [veh]
+  x_2+3 / x_5+6 = combined degree of saturation (Equation 20-30 / 20-32)             [unitless]
+  Result clamped to [0,1].
+Implemented in: twsc/twsc.rs::Twsc::prob_queue_free_shared_major, a single root-form expression that reduces exactly to the n_L = 0 case (the bracket becomes 1/(1-x)); called from Twsc::p0_star_major_left
+```
+
+The combined degree of saturation x_2+3 / x_5+6 (Equations 20-30/20-32) uses `f_ll_major` (1.0/0.5/0.33 for one/two/three through lanes) and the default saturation flow rates s = 1,800 (through) / 1,500 (right) veh/h. The substituted p\*_0,j then propagates into every Rank 3 and Rank 4 impedance product (movements 7/8/10/11) exactly where p_0,1/p_0,4 appear. HCM Chapter 32 Example Problem 4 (case3.json, shared major lefts) exercises this path: x_2+3 = 0.304, p\*_0 = 0.856, giving c_m,7 = c_m,10 = 47 veh/h (`test_p0_star_shared_major_ep4_value`, `test_major_left_shared_wiring`). For `Exclusive` (the default) no substitution occurs and behavior is bit-identical to before.
+
+### Step 10: shared and flared minor-lane capacity
+
+`minor_lanes` dispatches on `MinorLaneConfig` (single shared lane, shared-left-through + exclusive-right, exclusive-left + shared-through-right, or fully separate lanes) and, for a single shared lane with `flare_storage > 0`, calls `flared_lane_capacity` (Equation 20-50), whose `n_R = 0` case is verified in `test_flared_lane_capacity_equation` to reduce exactly to `shared_lane_capacity` (Equation 20-49, the harmonic-mean-like form `c_SH = Σv_y / Σ(v_y/c_m,y)`).
+
+```
+Equation 20-49:  c_SH = Σ v_y ÷ Σ (v_y ÷ c_m,y)                                       [veh/h]
+  v_y, c_m,y = flow rate / movement capacity of each movement y sharing the lane      [veh/h]
+  (empty-shared-lane fallback in code: if total demand is 0, returns the minimum of the individual movement capacities rather than dividing 0/0)
+Implemented in: twsc/twsc.rs::Twsc::shared_lane_capacity
+```
+
+```
+Equation 20-50:  c_F = (v_R + v_L+TH) ÷ [(v_R/c_R)^(n_R+1) + (v_L+TH/c_L+TH)^(n_R+1)]^(1/(n_R+1))   [veh/h]
+  v_R, c_R       = flow rate / capacity of the right-turn movement                     [veh/h]
+  v_L+TH, c_L+TH = combined flow rate / shared-lane capacity of the left+through movements  [veh/h]
+  n_R            = storage spaces in the flared portion of the approach (Exhibit 20-21)  [veh]
+  For n_R = 0 this reduces exactly to Equation 20-49
+Implemented in: twsc/twsc.rs::Twsc::flared_lane_capacity
+```
+
+The shared/short major-street left-turn queue-free probability `prob_queue_free_shared_major` (Equations 20-29 through 20-34) is now wired into the impedance chain through Step 7d (see above). The remaining shared-major-lane helper `shared_major_lane_capacity` (Step 10c, Equations 20-51 through 20-60, the reduced through-lane capacity c_SS when left turns share or short-pocket into the through lane) is implemented and unit-tested (`test_shared_major_lane_capacity`) but is not called from `step10_lane_capacities` or `analyze`: it models the capacity of the shared major-street through lane itself, which neither reported fixture output depends on (in Example Problem 4 it evaluates to the s_2+3 saturation-flow bound and does not feed the minor-street results), so it exists as a standalone, independently-verified building block a caller can invoke directly.
+
+```
+Equation 20-53 / 20-58:  x_1+1U = v_1+1U ÷ c_m,1+1U,   x_4+4U = v_4+4U ÷ c_m,4+4U     [unitless]
+Equation 20-54 / 20-59:  x_2+3 = f_LL,2+3·(v_2/s_2+v_3/s_3),  x_5+6 = f_LL,5+6·(v_5/s_5+v_6/s_6)   [unitless]  (identical form to Equation 20-30/20-32)
+Equation 20-52 / 20-57:  x_1+1U+2+3 = x_1+1U · [1 + x_2+3^(n_L+1)/(1−x_2+3)]^(1/(n_L+1))            [unitless]
+Equation 20-55 / 20-60:  s_2+3 = (v_2+v_3) ÷ (v_2/(N·s_2) + v_3/s_3)                                [veh/h]
+Equation 20-51 / 20-56:  c_SS = min[(v_1+1U+v_2+v_3) ÷ x_1+1U+2+3, s_2+3]                            [veh/h]
+  N = major-street through lanes per direction                                                      [lanes]
+  n_L = vehicles storable in the left-turn pocket                                                   [veh]
+  The WB side (Equations 20-56 through 20-60) mirrors this chain with 4+4U/5+6 in place of 1+1U/2+3.
+Implemented in: twsc/twsc.rs::Twsc::shared_major_lane_capacity (standalone; not called from step10_lane_capacities or analyze — see Deferred)
+```
+
+### Step 11a: control delay, LOS, and queue
+
+Movement/lane control delay uses `common::delay::control_delay_unsignalized` (Equation 20-61, the standard `d = 3,600/c + 900T[...] + 5` form) uniformly for major-street left/U-turn movements and for the shared/flared minor lanes.
+
+```
+Equation 20-61:  d_x = 3,600÷c_m,x + 900·T·[(v_x/c_m,x − 1) + √((v_x/c_m,x − 1)² + (3,600/c_m,x)(v_x/c_m,x)/(450·T))] + 5   [s/veh]
+  c_m,x = movement (or lane) capacity                                              [veh/h]
+  v_x   = movement (or lane) demand flow rate                                      [veh/h]
+  T     = analysis period (analysis_period_h, default 0.25)                        [h]
+  +5    = deceleration-to and acceleration-from-the-stop term                      [s]
+Implemented in: common/delay.rs::control_delay_unsignalized, called from twsc/twsc.rs::Twsc::step11_movement_delay for both exclusive-lane movement delay and per-lane (shared/flared) delay; the same algebraic form serves AWSC (Equation 21-30) and roundabouts (Equation 22-17) via the same shared function
+```
+
+LOS follows Exhibit 20-2 ("LOS Criteria: Motorized Vehicle Mode"), applied per movement/lane on the minor street and to the major-street left/U-turn movements, with v/c > 1.0 forcing LOS F regardless of the delay thresholds:
+
+```
+common/los_tables.rs::los_unsignalized(control_delay_s, vc_gt_1): thresholds A <= 10, B <= 15, C <= 25, D <= 35, E <= 50, F > 50 s/veh (Exhibit 20-2), overridden to F whenever vc_gt_1 is true
+```
+
+```
+Equation 20-66:  Q_95 ≈ 900·T·[(v_x/c_m,x − 1) + √((v_x/c_m,x − 1)² + (3,600/c_m,x)(v_x/c_m,x)/(150·T))] · (c_m,x ÷ 3,600)   [veh]
+  Same v_x, c_m,x, T as Equation 20-61; the radicand denominator is 150·T here versus 450·T in Equation 20-61 — confirmed against the EPUB as a genuine difference between the two formulas, not a transcription artifact
+Implemented in: twsc/twsc.rs::Twsc::queue_95
+```
 
 ### Step 11b: Rank 1 delay from shared/short major-left lanes
 
-Movement/lane control delay uses `common::delay::control_delay_unsignalized` (Equation 20-61, the standard `d = 3,600/c + 900T[...] + 5` form) uniformly for major-street left/U-turn movements and for the shared/flared minor lanes. When a major approach has a shared or short left-turn lane, `step11_movement_delay` also computes the Step 11b Rank 1 delay via `compute_rank1_major_delay`, which calls `Twsc::rank1_delay` (Equations 20-62/20-63) for each of the EB (d_2+3) and WB (d_5+6) approaches and stores `[d_2+3, d_5+6]` in `Twsc.rank1_major_delay` (`None` when both major lefts are exclusive). `step12_approach_intersection_delay` then charges the Rank 1 major-street through/right movements (2/3, 5/6) this shared-lane delay in Equation 20-64 instead of zero. This matches the HCM Step 12 rule that Rank 1 delay is zero *with an exclusive left-turn lane* while a shared/short pocket produces the nonzero d_2+3/d_5+6 the worked Example Problem 4 uses (published d_2+3 = d_5+6 = 1.3 s; `test_rank1_delay_ep4_value`, and the integration test's d_A,EB = d_A,WB = 1.9 s and d_I = 34.1 s). For exclusive major lefts (the default) `rank1_major_delay` is `None` and the EB/WB Rank 1 movements keep zero delay, bit-identical to before.
+When a major approach has a shared or short left-turn lane, `step11_movement_delay` also computes the Step 11b Rank 1 delay via `compute_rank1_major_delay`, which calls `Twsc::rank1_delay` (Equations 20-62/20-63) for each of the EB (d_2+3) and WB (d_5+6) approaches and stores `[d_2+3, d_5+6]` in `Twsc.rank1_major_delay` (`None` when both major lefts are exclusive).
+
+```
+Equation 20-62 (N > 1):  d_2+3 = [(1 − p*_0,1+1U)·f_LL,2+3·(v_2+v_3)] ÷ [v_1+1U + f_LL,2+3·(v_2+v_3)] · d_1+1U   [s/veh]
+Equation 20-62 (N = 1):  d_2+3 = (1 − p*_0,1+1U) · d_1+1U                                                        [s/veh]
+Equation 20-63:  d_5+6 mirrors d_2+3 with the WB quantities (4+4U/5+6 in place of 1+1U/2+3)                       [s/veh]
+  p*_0,1+1U / p*_0,4+4U = shared/short-pocket queue-free probability (Equations 20-29..20-34)  [unitless]
+  v_1+1U / v_4+4U       = major-street left-turn + U-turn flow rate in the shared lane          [veh/h]
+  v_2,v_3 / v_5,v_6     = major-street through / right-turn flow rate                            [veh/h]
+  d_1+1U / d_4+4U       = control delay to the major-street left+U-turn movement (Equation 20-61)  [s/veh]
+  f_LL,2+3 / f_LL,5+6   = portion of through/right traffic in the left lane                       [unitless]
+  N                     = major-street through lanes per direction                                [lanes]
+Implemented in: twsc/twsc.rs::Twsc::rank1_delay, orchestrated per approach by Twsc::compute_rank1_major_delay
+```
+
+`step12_approach_intersection_delay` then charges the Rank 1 major-street through/right movements (2/3, 5/6) this shared-lane delay in Equation 20-64 instead of zero. This matches the HCM Step 12 rule that Rank 1 delay is zero *with an exclusive left-turn lane* while a shared/short pocket produces the nonzero d_2+3/d_5+6 the worked Example Problem 4 uses (published d_2+3 = d_5+6 = 1.3 s; `test_rank1_delay_ep4_value`, and the integration test's d_A,EB = d_A,WB = 1.9 s and d_I = 34.1 s). For exclusive major lefts (the default) `rank1_major_delay` is `None` and the EB/WB Rank 1 movements keep zero delay, bit-identical to before.
+
+### Step 12: approach and intersection control delay
+
+```
+Equation 20-64:  d_A,x = Σ (d_i,x · v_i,x) ÷ Σ v_i,x                                [s/veh]
+  d_i,x = control delay of movement/lane i on approach x                            [s/veh]
+  v_i,x = flow rate of movement/lane i on approach x                                [veh/h]
+  Rank 1 major-street through/right movements carry 0 s/veh with an exclusive left-turn lane, or the Step 11b d_2+3/d_5+6 (Equations 20-62/20-63) with a shared/short-pocket left-turn lane
+Equation 20-65:  d_I = Σ (d_A,x · v_A,x) ÷ Σ v_A,x, over the four approaches (EB, WB, NB, SB)   [s/veh]
+  d_A,x, v_A,x = approach delay / approach flow rate from Equation 20-64             [s/veh, veh/h]
+Implemented in: common/delay.rs::aggregate_control_delay (flow-rate-weighted average, `Σ(d·v)/Σv`, zero-volume guard returns 0.0), called from twsc/twsc.rs::Twsc::step12_approach_intersection_delay for both the per-approach (Eq 20-64) and intersection-level (Eq 20-65) aggregation
+```
+
+Exhibit 20-2 defines no overall LOS letter for the intersection as a whole, so `intersection_delay` is stored without an accompanying LOS field (see the note after the step table above).
+
+### Section 4: pedestrian impedance
+
+```
+Equation 20-67:  f_pb = (v_x · w ÷ S_p) ÷ 3,600                                     [unitless]
+  v_x = pedestrian flow rate for the conflicting pedestrian movement (13-16)         [p/h]
+  w   = width of the lane the minor movement negotiates into (lane_width_ft, default 12)  [ft]
+  S_p = pedestrian walking speed, assumed 3.5 (PEDESTRIAN_WALKING_SPEED_FT_S)        [ft/s]
+Equation 20-68:  p_p,x = 1 − f_pb                                                    [unitless, clamped to [0,1]]
+Implemented in: common/gap_acceptance.rs::pedestrian_blockage_factor (Eq 20-67), pedestrian_impedance_factor (Eq 20-68); called from twsc/twsc.rs::Twsc::ped_impedance for each of pp13, pp14, pp15, pp16
+```
+
+Equations 20-69 through 20-75 apply this pedestrian impedance factor p_p,x on top of the corresponding vehicle-only capacity equation, mapping each vehicular movement to its conflicting pedestrian movement(s) per Exhibits 20-22 (Rank 2 major left, movements 1/4), 20-23 (Rank 2 minor right, movements 9/12, a product of two pedestrian factors), and 20-24 (Rank 3/4 minor left/through, movements 7/8/10/11, likewise a product of two). Concretely: Equation 20-69 (`c_m,j = c_p,j × p_p,i`) is Equation 20-22 with the pedestrian factor attached, implemented at the same `assign(M1, pp16)` / `assign(M4, pp15)` call sites documented above; Equations 20-70/20-71 (`f_9 = p_p,15 × p_p,14`, `f_12 = p_p,16 × p_p,13`) and 20-72 (`c_m,j = c_p,j × f_j`) are the minor-right-turn factors documented above under Equation 20-23; Equation 20-73 (`f_k = Π p_0,j × p_p,x`) is Equation 20-35/20-36 with the pedestrian factor folded in, implemented as `f_r3 = p0_1 * p0_4 * pp15 * pp16` (movements 8/11) and `f7 = p0_4 * pp15 * pp13` (movement 7 at a T), documented above under Steps 6-9; and Equations 20-74/20-75 are Equations 20-41/20-42 with the pedestrian factor folded in, documented above under Steps 6-9's Rank 4 discussion. No separate implementation exists for the pedestrian-only equations — the crate always evaluates the combined vehicular-times-pedestrian form directly, since `pp13`..`pp16` default to 1.0 (no impedance) whenever the corresponding pedestrian demand is zero.
 
 ## Deviations
 
@@ -69,15 +368,17 @@ No `docs/hcm/VERIFICATION.md` exists on this branch; all known deviations are do
 2. U-turn base critical headway (6.4 s) and follow-up headway (2.5 s) fall back to the four-lane "wide median" row when a U-turn is coded on a two-lane major street, since Exhibit 20-17/20-18 lists "NA" for that cell.
 3. Chapter 32 TWSC Example Problem 4 (case3.json) drops the major-street right-turn term in the minor-street left-turn Stage II conflicting flow (0.5 v_6 for movement 7, 0.5 v_3 for movement 10): its published v_c,7 = 1,827 and v_c,10 = 1,832 veh/h, whereas the 7th Edition Exhibit 20-16 factors used here give 1,874 and 1,879. The fixture uses `conflicting_flow_overrides` to reproduce the published totals, mirroring the Example Problem 3 pattern above. This is recorded as a `// VERIFY-HCM` note alongside the existing Step 3 comment.
 
+No new discrepancies between the code and the HCM 7th Edition EPUB were found while cross-checking every equation above (Equations 20-1 through 20-75, plus Equation 30-13 and the surrounding Chapter 30 Section 3 procedure); every formula, branch condition, and constant in `twsc.rs`, `computed_pb.rs`, and `gap_acceptance.rs` was verified to match the EPUB text exactly, including subtle points that could plausibly have been transcription errors but were confirmed correct: the distinct 450T (Equation 20-61) vs 150T (Equation 20-66) radicand denominators, the dual role of Equation 20-27 as both the specific major-left-plus-U-turn shared-lane form and an exact restatement of the general Equation 20-49 form, and the N=1 vs N>1 branch structure of Equations 20-62/20-63.
+
 ## Validation
 
-Fixtures live at `tests/ExampleCases/hcm/Twsc/case1.json` (HCM Chapter 32 TWSC Example Problem 1: three-leg intersection, one major lane per direction, 10% heavy vehicles), `case2.json` (TWSC Example Problem 3: four-leg, two major lanes per direction, two-stage gap acceptance with `n_m = 2`, flared single-lane minor approaches with `n_R = 1`, 10% heavy vehicles, using the `conflicting_flow_overrides` mechanism to match the published 6th-Edition-style Step 3 values), and `case3.json` (TWSC Example Problem 4: four-leg TWSC between two coordinated upstream signals, four-lane major street with shared major-street left turns, no minor-street through movements, one stage, exercising the Step 5b platoon-blockage path with p_b = 0.170 for movements 1/4/9/12 and 0.260 for movements 7/10). `test_twsc_example_problem_4_upstream_signals` reproduces the published conflicting flows (1,086 / 1,076 / 538 / 543 / 1,827 / 1,832 veh/h), the platooned potential capacities c_p,1 = 750, c_p,4 = 758, c_p,9 = 859, c_p,12 = 852, c_p,7 = 73, c_p,10 = 72 veh/h, LOS B/B/A/A/F/F, and — now that Step 7d and Step 11b are wired — the shared-major-left results exactly: c_m,7 = c_m,10 = 47 veh/h (via p\*_0 = 0.856, Equations 20-33/34), the Step 11b Rank 1 delay d_2+3 = d_5+6 = 1.3 s (Equations 20-62/63), d_A,EB = d_A,WB = 1.9 s, and d_I = 34.1 s (asserted at +-0.5 s). The two oversaturated minor-street left delays d_7 = d_10 = 529 s and the minor-approach delays d_A,NB = d_A,SB = 241 s use a wider documented tolerance (+-12 s and +-5 s): Equation 20-61 has slope ~18.6 s per veh/h near v/c = 1.7, and the book rounds c_m to the integer 47 while this library carries 46.6-47.1, so the two per-movement delays split symmetrically around 529 s (their over/under-shoots cancel in d_I). The Rust integration test is `tests/chapter20_integration.rs` (`test_twsc_example_problem_1_full_pipeline`, `test_twsc_example_problem_3_full_pipeline`, `test_twsc_fixture_roundtrip`); a PyO3-bound Python equivalent is `tests/test_chapter20_integration.py`. Declared tolerances (module doc comment of `chapter20_integration.rs`): LOS exact; control delay within +-0.5 s/veh; capacity within +-5 veh/h (the integration test file additionally widens queue tolerance to +-0.2 veh at individual assertion sites). Example Problem 1 reproduces c_m,4 = 1,238, c_m,9 = 760, c_m,7 = 268, c_SH,NB = 521 veh/h; d_4 = 8.3 s/veh (LOS A), d_SH,NB = 14.9 s/veh (LOS B); approach delays d_EB = 0.0, d_WB = 2.9, d_NB = 14.9 s/veh; intersection delay 4.1 s/veh; Q95,4 = 0.4, Q95,NB = 1.3 veh. Example Problem 3 reproduces the two-stage total capacities c_T,8 = 390, c_T,11 = 405, c_T,7 = 365, c_T,10 = 342 veh/h; flared-lane capacities c_F,NB = 498, c_F,SB = 487 veh/h; d_1 = 8.4, d_4 = 8.2 s/veh (both LOS A); d_NB = 18.3, d_SB = 15.6 s/veh (both LOS C); intersection delay 6.3 s/veh; queues 0.1/0.2/2.4/1.3 veh. Additional per-step unit tests in `src/hcm/chapter20/tests.rs` (37 tests total, including the Exhibit 20-19 mapping, both Equation 20-19 branches, the Equation 20-21 zero-flow branch, platoon-off equivalence, the shared-major-left p\*_0 = 0.856 value and short-pocket variant, the EP4 Rank 1 delay value, and the end-to-end `Exclusive`-vs-`Shared` wiring check) spot-check every step against the example problems' intermediate values (conflicting flows, headways, potential capacities, stage capacities, lane capacities) at tighter tolerances (typically 1.0-2.0 veh/h or 1e-9 s for closed-form arithmetic). The computed proportion-of-time-blocked path (`computed_pb.rs`) adds eight mechanism tests: `test_proportion_time_blocked_square_wave` (Equation 30-13 on a hand-constructed 20-of-100-step platoon, p_b = 0.20 exactly), `test_computed_pb_direction_mapping` (only-eastbound signal blocks movements 4/9 not 1/12), `test_computed_pb_decreases_with_distance` (dispersion-flattening monotonicity of p_b vs segment length), `test_computed_pb_union_of_both_directions` (minor-street p_b as the union of both directions' blocked steps), `test_analyst_pb_takes_precedence_over_upstream`, `test_computed_pb_matches_manual_platoon_blockage` (computed path is bit-identical to manually setting the derived `PlatoonBlockage`), `test_computed_pb_empty_signals_equivalent_to_off`, and `test_upstream_signals_serde_roundtrip`. There is no published-target regression for the end-to-end p_b values (Chapter 30 Example Problem 1 reports them as engine output — 0.170/0.260 in Exhibit 32-12 — requiring the full Chapter 19 coordinated engine and Section 2 O-D distribution, the same dependency that blocks reproducing EP1's P = 0.493). The standalone `shared_major_lane_capacity` (Step 10c) helper remains covered by `test_shared_major_lane_capacity` only, since neither example problem's reported output depends on the shared through-lane capacity c_SS.
+Fixtures live at `tests/ExampleCases/hcm/Twsc/case1.json` (HCM Chapter 32 TWSC Example Problem 1: three-leg intersection, one major lane per direction, 10% heavy vehicles), `case2.json` (TWSC Example Problem 3: four-leg, two major lanes per direction, two-stage gap acceptance with `n_m = 2`, flared single-lane minor approaches with `n_R = 1`, 10% heavy vehicles, using the `conflicting_flow_overrides` mechanism to match the published 6th-Edition-style Step 3 values), and `case3.json` (TWSC Example Problem 4: four-leg TWSC between two coordinated upstream signals, four-lane major street with shared major-street left turns, no minor-street through movements, one stage, exercising the Step 5b platoon-blockage path with p_b = 0.170 for movements 1/4/9/12 and 0.260 for movements 7/10). `test_twsc_example_problem_4_upstream_signals` reproduces the published conflicting flows (1,086 / 1,076 / 538 / 543 / 1,827 / 1,832 veh/h), the platooned potential capacities c_p,1 = 750, c_p,4 = 758, c_p,9 = 859, c_p,12 = 852, c_p,7 = 73, c_p,10 = 72 veh/h, LOS B/B/A/A/F/F, and — now that Step 7d and Step 11b are wired — the shared-major-left results exactly: c_m,7 = c_m,10 = 47 veh/h (via p\*_0 = 0.856, Equations 20-33/34), the Step 11b Rank 1 delay d_2+3 = d_5+6 = 1.3 s (Equations 20-62/63), d_A,EB = d_A,WB = 1.9 s, and d_I = 34.1 s (asserted at +-0.5 s). The two oversaturated minor-street left delays d_7 = d_10 = 529 s and the minor-approach delays d_A,NB = d_A,SB = 241 s use a wider documented tolerance (+-12 s and +-5 s): Equation 20-61 has slope ~18.6 s per veh/h near v/c = 1.7, and the book rounds c_m to the integer 47 while this library carries 46.6-47.1, so the two per-movement delays split symmetrically around 529 s (their over/under-shoots cancel in d_I). The Rust integration test is `tests/chapter20_integration.rs` (`test_twsc_example_problem_1_full_pipeline`, `test_twsc_example_problem_3_full_pipeline`, `test_twsc_fixture_roundtrip`); a PyO3-bound Python equivalent is `tests/test_chapter20_integration.py`. Declared tolerances (module doc comment of `chapter20_integration.rs`): LOS exact; control delay within +-0.5 s/veh; capacity within +-5 veh/h (the integration test file additionally widens queue tolerance to +-0.2 veh at individual assertion sites). Example Problem 1 reproduces c_m,4 = 1,238, c_m,9 = 760, c_m,7 = 268, c_SH,NB = 521 veh/h; d_4 = 8.3 s/veh (LOS A), d_SH,NB = 14.9 s/veh (LOS B); approach delays d_EB = 0.0, d_WB = 2.9, d_NB = 14.9 s/veh; intersection delay 4.1 s/veh; Q95,4 = 0.4, Q95,NB = 1.3 veh. Example Problem 3 reproduces the two-stage total capacities c_T,8 = 390, c_T,11 = 405, c_T,7 = 365, c_T,10 = 342 veh/h; flared-lane capacities c_F,NB = 498, c_F,SB = 487 veh/h; d_1 = 8.4, d_4 = 8.2 s/veh (both LOS A); d_NB = 18.3, d_SB = 15.6 s/veh (both LOS C); intersection delay 6.3 s/veh; queues 0.1/0.2/2.4/1.3 veh. Additional per-step unit tests in `src/hcm/twsc/tests.rs` (37 tests total, including the Exhibit 20-19 mapping, both Equation 20-19 branches, the Equation 20-21 zero-flow branch, platoon-off equivalence, the shared-major-left p\*_0 = 0.856 value and short-pocket variant, the EP4 Rank 1 delay value, and the end-to-end `Exclusive`-vs-`Shared` wiring check) spot-check every step against the example problems' intermediate values (conflicting flows, headways, potential capacities, stage capacities, lane capacities) at tighter tolerances (typically 1.0-2.0 veh/h or 1e-9 s for closed-form arithmetic). The computed proportion-of-time-blocked path (`computed_pb.rs`) adds eight mechanism tests: `test_proportion_time_blocked_square_wave` (Equation 30-13 on a hand-constructed 20-of-100-step platoon, p_b = 0.20 exactly), `test_computed_pb_direction_mapping` (only-eastbound signal blocks movements 4/9 not 1/12), `test_computed_pb_decreases_with_distance` (dispersion-flattening monotonicity of p_b vs segment length), `test_computed_pb_union_of_both_directions` (minor-street p_b as the union of both directions' blocked steps), `test_analyst_pb_takes_precedence_over_upstream`, `test_computed_pb_matches_manual_platoon_blockage` (computed path is bit-identical to manually setting the derived `PlatoonBlockage`), `test_computed_pb_empty_signals_equivalent_to_off`, and `test_upstream_signals_serde_roundtrip`. There is no published-target regression for the end-to-end p_b values (Chapter 30 Example Problem 1 reports them as engine output — 0.170/0.260 in Exhibit 32-12 — requiring the full Chapter 19 coordinated engine and Section 2 O-D distribution, the same dependency that blocks reproducing EP1's P = 0.493). The standalone `shared_major_lane_capacity` (Step 10c) helper remains covered by `test_shared_major_lane_capacity` only, since neither example problem's reported output depends on the shared through-lane capacity c_SS.
 
 ## Deferred
 
 The upstream-signal potential-capacity adjustment (Equations 20-19 through 20-21, Exhibit 20-19) is now wired into `analyze` through the `platoon_blockage` input and validated end-to-end by Example Problem 4 (case3.json). What remains deferred:
 
-- **Chapter 30 derivation of p_b,x.** *Wired (this branch).* The Chapter 30, Section 3 "Proportion of Time Blocked" computation (Equation 30-13) now derives p_b,x from `upstream_signals` (system cycle, per-direction segment length / progression speed / discharge profiles) via `src/hcm/chapter20/computed_pb.rs`, using the `chapter18::platoon_dispersion` machinery to build the arrival flow profiles and the blocked-period-vs-q_c logic to count blocked steps (see "Step 5b input: computed proportion of time blocked" above). The mechanism is unit-tested (square-wave hand check, dispersion-flattening monotonicity, directional mapping, both-direction union, analyst precedence, and equivalence to manually supplying the computed `PlatoonBlockage`). What remains genuinely deferred: the HCM does not publish a hand-computable derivation chain from raw upstream timing to the Chapter 30 Example Problem 1 / Exhibit 32-12 p_b values (0.170 / 0.260) — those are engine outputs that require the full Chapter 19 coordinated-actuated discharge profiles and the Section 2 origin–destination distribution (the same dependency that blocks reproducing Example Problem 1's P = 0.493, per `chapter18-computed.md`), so there is no published-target regression for the end-to-end p_b, only the mechanism tests.
+- **Chapter 30 derivation of p_b,x.** *Wired (this branch).* The Chapter 30, Section 3 "Proportion of Time Blocked" computation (Equation 30-13) now derives p_b,x from `upstream_signals` (system cycle, per-direction segment length / progression speed / discharge profiles) via `src/hcm/twsc/computed_pb.rs`, using the `chapter18::platoon_dispersion` machinery to build the arrival flow profiles and the blocked-period-vs-q_c logic to count blocked steps (see "Step 5b input: computed proportion of time blocked" above). The mechanism is unit-tested (square-wave hand check, dispersion-flattening monotonicity, directional mapping, both-direction union, analyst precedence, and equivalence to manually supplying the computed `PlatoonBlockage`). What remains genuinely deferred: the HCM does not publish a hand-computable derivation chain from raw upstream timing to the Chapter 30 Example Problem 1 / Exhibit 32-12 p_b values (0.170 / 0.260) — those are engine outputs that require the full Chapter 19 coordinated-actuated discharge profiles and the Section 2 origin–destination distribution (the same dependency that blocks reproducing Example Problem 1's P = 0.493, per `chapter18-computed.md`), so there is no published-target regression for the end-to-end p_b, only the mechanism tests.
 - **Shared / short major-street left-turn pocket.** *Impedance and delay wired (this branch).* The `MajorLeftLaneConfig` input (`major_left_eb`/`major_left_wb` = `Exclusive`/`Shared`/`SharedShortPocket{storage_veh}`) now drives the Step 7d p\*_0,j substitution (Equations 20-29 through 20-34, `prob_queue_free_shared_major`) into the Rank 3/4 impedance chain and the Step 11b Rank 1 delay (Equations 20-62/63, `rank1_delay`) into Step 12, so Example Problem 4 reproduces c_m,7 = c_m,10 = 47 veh/h, d_2+3 = d_5+6 = 1.3 s, and d_I = 34.1 s exactly. What remains: the Step 10c shared through-lane capacity `shared_major_lane_capacity` (Equations 20-51 through 20-60, the reduced c_SS of the major through lane) is still standalone and unwired — it does not affect the minor-street or intersection-delay outputs in Example Problem 4 (it evaluates to the s_2+3 bound), but a caller wanting the reported major-street through-lane capacity under a short pocket must invoke it directly. `f_LL` and the s = 1,800/1,500 saturation flow rates are fixed at the HCM defaults rather than exposed as per-approach field-measured inputs.
 
 None of these are stubbed with `todo!()`.

--- a/docs/hcm/procedures/chapter21.md
+++ b/docs/hcm/procedures/chapter21.md
@@ -1,6 +1,6 @@
 # HCM Chapter 21 — All-Way STOP-Controlled Intersections
 
-This document walks the HCM 7th Edition Chapter 21 motorized-vehicle methodology for all-way STOP-controlled (AWSC) intersections as implemented on branch `feat/hcm-ch20-22-unsignalized`. The code follows Chapter 21, Section 3 (the core two-lane-approach methodology) and Section 4 (the three-lane-approach extension), transcribed as the sixteen-step procedure in the module header of `src/hcm/chapter21/awsc.rs`, which is also the sole source file (`src/hcm/chapter21/tests.rs` holds the per-step unit tests against HCM Chapter 32 AWSC Example Problems 1 and 2). As with Chapter 20, the shared delay/LOS primitives (`control_delay_awsc`, `aggregate_control_delay` in `src/hcm/common/delay.rs`; `los_unsignalized` in `src/hcm/common/los_tables.rs`) are documented separately in `common-infrastructure.md`. `docs/hcm/VERIFICATION.md` does not exist in this branch's working tree; deviations are called out inline below with reference to the relevant test or code comment.
+This document walks the HCM 7th Edition Chapter 21 motorized-vehicle methodology for all-way STOP-controlled (AWSC) intersections as implemented on branch `feat/hcm-ch20-22-unsignalized`. The code follows Chapter 21, Section 3 (the core two-lane-approach methodology) and Section 4 (the three-lane-approach extension), transcribed as the sixteen-step procedure in the module header of `src/hcm/awsc/awsc.rs`, which is also the sole source file (`src/hcm/awsc/tests.rs` holds the per-step unit tests against HCM Chapter 32 AWSC Example Problems 1 and 2). As with Chapter 20, the shared delay/LOS primitives (`control_delay_awsc`, `aggregate_control_delay` in `src/hcm/common/delay.rs`; `los_unsignalized` in `src/hcm/common/los_tables.rs`) are documented separately in `common-infrastructure.md`. `docs/hcm/VERIFICATION.md` does not exist in this branch's working tree; deviations are called out inline below with reference to the relevant test or code comment. Every equation transcribed below was cross-checked against both the Rust function body and the HCM 7th Edition Chapter 21 EPUB text (Sections 3 and 4); no mathematical discrepancies were found between the code, this document, and the published equations — every case is either an exact match or a documented, already-flagged simplification (see Deviations).
 
 The public entry point is `Awsc::analyze(&mut self)`, which runs Steps 1-2, 3, 4, 5-11 (the departure-headway iteration), 13-14 and 16 (lane delay/LOS/queue), and 15 (approach/intersection aggregation) — deliberately *excluding* Step 12 (capacity), which the module doc comment flags as "expensive" since it requires a fresh bisection search (each trial itself re-running the full departure-headway iteration) per lane; callers who need lane capacity call `Awsc::step12_capacities()` separately.
 
@@ -18,35 +18,196 @@ The public entry point is `Awsc::analyze(&mut self)`, which runs Steps 1-2, 3, 4
 | Step 15 — Approach/intersection delay and LOS | Equations 21-31, 21-32 | `Awsc::step15_aggregate_delay`, `common::delay::aggregate_control_delay` | Per-lane control delay and flow rate | `AwscApproach.control_delay`/`los`; `Awsc.intersection_delay`/`intersection_los` |
 | Step 16 — 95th percentile queue | Equation 21-33 | `Awsc::queue_95` | Degree of utilization x, departure headway h_d (s), analysis period T (h) | `AwscLane.queue_95` (veh) |
 
+### Steps 1-2: demand flow rates
+
+```
+Equation 21-12:  v_i = V_i / PHF                                              [veh/h]
+  v_i = demand flow rate for movement i                                       [veh/h]
+  V_i = demand volume for movement i                                          [veh/h]
+  PHF = peak hour factor
+Implemented in: awsc/awsc.rs::Awsc::step1_2_flow_rates
+```
+
+The code applies Equation 21-12 to each lane's total assigned demand (`AwscLane::total_volume`, the sum of the left/through/right volumes already assigned to that lane by the caller — Step 2's lane assignment is left to the caller rather than automated) rather than to a single intersection-wide movement, since AWSC lane flow rates are already the per-lane unit of analysis. `Awsc.phf` is `Option<f64>`; a `None` or non-positive value is treated as PHF = 1.0, i.e. the input volumes are already 15-min flow rates (matching Example Problem 2's fixture, which supplies flow rates directly with no PHF).
+
 ### Step 3: geometry groups (Exhibit 21-11)
 
-`geometry_group(four_leg, subject_lanes, opposing_lanes, conflicting_lanes)` implements the full Exhibit 21-11 decision tree as a nested `match` on subject-approach lane count (1, 2, or 3+), then on `(opposing, conflicting)`. A single-lane subject approach with a single-lane opposing and conflicting approach is Group 1; two-lane opposing/single-lane conflicting is Group 3a at a T or Group 4a at a four-leg (and symmetrically 3b/4b for two-lane conflicting); anything with a three-lane opposing or conflicting approach, or a multilane subject approach paired with a three-lane cross street, falls to Group 5 (moderate multilane complexity) or Group 6 (full three-lane-everywhere complexity per Section 4). `chapter21/tests.rs::test_geometry_group_exhibit_21_11` exercises every named branch including the note-a "higher of the two conflicting approaches" rule implicit in the `conflicting_lanes.max(1)` call in `step3_geometry_groups`.
+`geometry_group(four_leg, subject_lanes, opposing_lanes, conflicting_lanes)` implements the full Exhibit 21-11 decision tree as a nested `match` on subject-approach lane count (1, 2, or 3+), then on `(opposing, conflicting)`. A single-lane subject approach with a single-lane opposing and conflicting approach is Group 1; two-lane opposing/single-lane conflicting is Group 3a at a T or Group 4a at a four-leg (and symmetrically 3b/4b for two-lane conflicting); anything with a three-lane opposing or conflicting approach, or a multilane subject approach paired with a three-lane cross street, falls to Group 5 (moderate multilane complexity) or Group 6 (full three-lane-everywhere complexity per Section 4). `awsc/tests.rs::test_geometry_group_exhibit_21_11` exercises every named branch.
+
+Exhibit 21-11 note (a) is a genuine equation-like rule rather than a table entry, and the code implements it as an explicit combinatorial step before the decision tree is even consulted:
+
+```
+Exhibit 21-11, note a:  n_conflicting = max(n_conflicting_left, n_conflicting_right)     [lanes]
+  n_conflicting_left  = lane count of the approach conflicting from the subject driver's left
+  n_conflicting_right = lane count of the approach conflicting from the subject driver's right
+  (if the two conflicting approaches have a different number of lanes, the higher of the two is used)
+Implemented in: awsc/awsc.rs::Awsc::step3_geometry_groups
+```
+
+Concretely, `step3_geometry_groups` computes `conflicting = conflicting_left.lanes.len().max(conflicting_right.lanes.len())` — this `.max()` call is note (a) itself. A second, unrelated `.max(1)` is then applied to that result before it is passed into `geometry_group(...)`; this second call is only a floor that substitutes 1 for the 0-lane conflicting approach at a T intersection's missing fourth leg (a T intersection still has real subject/opposing/conflicting-from-one-side geometry, so the decision tree needs a nonzero placeholder rather than a true "no conflicting approach" case), and is not itself part of note (a).
 
 ### Step 4: headway adjustment coefficients
+
+```
+Equation 21-13:  h_adj = h_LT,adj·P_LT + h_RT,adj·P_RT + h_HV,adj·P_HV        [s]
+  h_LT,adj = left-turn headway adjustment for the lane's geometry group        [s]
+  h_RT,adj = right-turn headway adjustment for the lane's geometry group       [s]
+  h_HV,adj = heavy-vehicle headway adjustment for the lane's geometry group    [s]
+  P_LT = proportion of left-turning vehicles in the lane                      [decimal]
+  P_RT = proportion of right-turning vehicles in the lane                     [decimal]
+  P_HV = proportion of heavy vehicles in the lane                             [decimal]
+Implemented in: awsc/awsc.rs::headway_adjustment (via Awsc::step4_headway_adjustments)
+```
 
 `H_LT_ADJ`, `H_RT_ADJ`, `H_HV_ADJ` are `[f64; 8]` arrays transcribing Exhibit 21-12's three adjustment rows across all eight geometry-group columns: left-turn adjustment is a uniform 0.2 s for Groups 1-4b and 0.5 s for Groups 5/6; right-turn adjustment is -0.6 s for Groups 1-4b and -0.7 s for Groups 5/6; heavy-vehicle adjustment is a uniform 1.7 s across every group. `headway_adjustment` then applies Equation 21-13 as a simple weighted sum, verified against the Chapter 32 AWSC Example Problem 1 (`h_adj,EB = 0.063`, `h_adj,WB = -0.116`, `h_adj,SB = -0.034` s — the last within a documented 0.002 s tolerance because the published value rounds intermediate flow rates to whole vehicles) and Example Problem 2 values.
 
 ### Steps 5-11: the departure-headway iteration and the 64-/512-state frameworks
 
-This is the procedure the task brief specifically calls out, and the code's actual state-space size is confirmed by direct inspection of `departure_headway_for`: `frame_lanes` is chosen once per intersection by `Awsc::iterate_departure_headways` as 2 if every approach has at most two lanes, or 3 if `max_lanes() >= 3` anywhere in the intersection (Section 4's three-lane-approach extension). Inside `departure_headway_for`, `n_states = 1u32 << (3 * frame_lanes)`, i.e. `2^(3*2) = 64` states for the two-lane framework and `2^(3*3) = 512` states for the three-lane framework — **both sizes appear in the code**, selected dynamically per-intersection rather than being two separate hard-coded tables, and the task brief's premise (that both 64 and 512 should appear, gated by lane count) is confirmed exactly as stated. Each "state" is one specific occupied/unoccupied combination across three approach groups relative to the subject lane — the opposing approach O, the conflicting-from-the-left approach CL, and the conflicting-from-the-right approach CR — with up to `frame_lanes` lanes tracked per group; the state is encoded as an integer whose bits, read `frame_lanes` at a time, give the occupancy pattern of each group's lanes (`(state >> (g * frame_lanes + lane)) & 1`). The probability of each state is the product of each bit's occupancy probability (`x_j` for an occupied lane, `1 - x_j` for an unoccupied one, per Exhibits 21-13/21-16), and the state's "degree-of-conflict case" (1 through 5) is a function of which of the three groups (O, CL, CR) have *any* occupied lane: case 1 is no conflicting vehicles present, case 2 is only the opposing approach occupied, case 3 is only one conflicting approach occupied, case 4 is two of the three groups occupied, and case 5 is all three occupied simultaneously (matching Exhibits 21-5/21-6/21-7's degree-of-conflict definitions). `base_saturation_headway(case, vehicles, group)` then looks up Exhibit 21-15's base saturation headway by case, geometry group, and (for Groups 5/6 only) the total vehicle count across the occupied lanes; Groups 1-4b use a single value per case regardless of vehicle count since those geometries cap conflicting lanes at one or two per group. The probability-adjustment terms `adj[0..5]` (Equations 21-21 through 21-25 for the two-lane framework, reused verbatim for 21-40 through 21-44 in the three-lane framework since the formulas have the same shape with different combinatorial divisors `n_c2`..`n_c5`) apply the `ALPHA = 0.01` serial-correlation coefficient. The converged departure headway is the probability-weighted sum `h_d = Σ P'(i) * h_si` over all `n_states` combinations (Equation 21-26 through 21-28), and the whole thing iterates (`iterate_departure_headways`) by feeding each lane's new `x = v*h_d/3,600` back into the next round's occupancy probabilities, capped at 100 iterations and declared converged at `CONVERGENCE_TOLERANCE_S` = 0.1 s change in any lane's headway — matching Exhibit 21-10 Step 11's literal convergence text quoted in the module header ("If the values change by more than 0.1 s ... repeat").
+This is the procedure the task brief specifically calls out, and the code's actual state-space size is confirmed by direct inspection of `departure_headway_for`: `frame_lanes` is chosen once per intersection by `Awsc::iterate_departure_headways` as 2 if every approach has at most two lanes, or 3 if `max_lanes() >= 3` anywhere in the intersection (Section 4's three-lane-approach extension). Inside `departure_headway_for`, `n_states = 1u32 << (3 * frame_lanes)`, i.e. `2^(3*2) = 64` states for the two-lane framework and `2^(3*3) = 512` states for the three-lane framework — **both sizes appear in the code**, selected dynamically per-intersection rather than being two separate hard-coded tables. Each "state" is one specific occupied/unoccupied combination across three approach groups relative to the subject lane — the opposing approach O, the conflicting-from-the-left approach CL, and the conflicting-from-the-right approach CR — with up to `frame_lanes` lanes tracked per group; the state is encoded as an integer whose bits, read `frame_lanes` at a time, give the occupancy pattern of each group's lanes (`(state >> (g * frame_lanes + lane)) & 1`).
 
-`chapter21/tests.rs::test_ep2_departure_headway_iteration` specifically exercises the 512-state (three-lane) framework against Example Problem 2's published `h_d,EB,1 ~= 8.19 s`, `x_EB,1 ~= 0.1274`, confirming the framework selection logic and the larger state space both function correctly; `test_ep1_departure_headway_iteration` exercises the 64-state framework against Example Problem 1.
+#### Probability of a state (Equations 21-14, 21-15, 21-34)
+
+```
+Equation 21-14:  x = v·h_d / 3,600                                            [unitless]
+  x   = degree of utilization for a framework lane
+  v   = lane flow rate                                                        [veh/h]
+  h_d = departure headway from the previous iteration (3.2 s at the first iteration)   [s]
+Implemented in: awsc/awsc.rs::Awsc::iterate_departure_headways (x recomputed once per iteration and capped at 1.0 mid-iteration per Step 6's guidance; `(v * h / 3_600.0).min(1.0)`)
+
+Equation 21-15 (two-lane framework):  P(i) = Π_j P(a_j)                       [unitless]
+  i   = one specific occupancy combination across the six framework lanes O1, O2, CL1, CL2, CR1, CR2 (64 combinations total, Exhibit 21-14)
+  a_j = 1 if a vehicle occupies framework lane j, else 0
+  P(a_j) = x_j if a_j=1 and V_j>0; 1−x_j if a_j=0 and V_j>0; 0 if a_j=1 and V_j=0; 1 if a_j=0 and V_j=0    (Exhibit 21-13)
+Equation 21-34 (three-lane framework): identical form over the nine framework lanes O1-3, CL1-3, CR1-3 (512 combinations, Exhibit 21-16 / Exhibit 32-15)
+Implemented in: awsc/awsc.rs::Awsc::departure_headway_for (the `probs` closure builds each P(a_j); the `state` loop enumerates all `n_states = 2^(3·frame_lanes)` combinations as bit patterns and multiplies each lane's occupied/unoccupied probability into `prob`, which is P(i))
+```
+
+The code's enumeration is a direct bit-pattern walk rather than a literal transcription of Exhibit 21-14/21-16's printed rows, but it is mathematically the identical partition: iterating `state` from 0 to `n_states - 1` and reading each group's occupancy off `state`'s bits produces exactly the same 64 (or 512) combinations the exhibits list by row number, in a different but equivalent order.
+
+#### Degree-of-conflict case probabilities (Equations 21-16 through 21-20, 21-35 through 21-39)
+
+```
+Equation 21-16 / 21-35:  P(C1) = P(1)                                          [unitless]
+Equation 21-17 / 21-36:  P(C2) = Σ P(i), for i = 2..4 (two-lane) or i = 2..8 (three-lane)
+Equation 21-18 / 21-37:  P(C3) = Σ P(i), for i = 5..10 (two-lane) or i = 9..22 (three-lane)
+Equation 21-19 / 21-38:  P(C4) = Σ P(i), for i = 11..37 (two-lane) or i = 23..169 (three-lane)
+Equation 21-20 / 21-39:  P(C5) = Σ P(i), for i = 38..64 (two-lane) or i = 170..512 (three-lane)
+Implemented in: awsc/awsc.rs::Awsc::departure_headway_for (`p_case[0..5]`)
+```
+
+Rather than summing a fixed printed index range, the code classifies each enumerated state directly by which of the three approach groups (O, CL, CR) have *any* occupied lane and accumulates its probability into the matching `p_case` bucket — mathematically the same partition of the 64/512 states into five degree-of-conflict cases, just computed from occupancy rather than looked up by row number:
+
+* **Case 1** — no conflicting vehicles present (none of O, CL, CR occupied).
+* **Case 2** — only the opposing approach O is occupied.
+* **Case 3** — only one conflicting approach (CL or CR, not both) is occupied.
+* **Case 4** — two of the three groups (O, CL, CR) are occupied.
+* **Case 5** — all three groups are occupied simultaneously.
+
+This matches Exhibits 21-5/21-6/21-7's degree-of-conflict definitions exactly.
+
+#### Probability adjustment (serial correlation) (Equations 21-21 through 21-26, 21-40 through 21-45)
+
+```
+Equation 21-21 / 21-40:  AdjP(1) = α·[P(C2) + 2·P(C3) + 3·P(C4) + 4·P(C5)] / 1              [unitless]
+Equation 21-22 / 21-41:  AdjP(case 2 states) = α·[P(C3) + 2·P(C4) + 3·P(C5) − P(C2)] / n_c2 [unitless]
+Equation 21-23 / 21-42:  AdjP(case 3 states) = α·[P(C4) + 2·P(C5) − 3·P(C3)] / n_c3         [unitless]
+Equation 21-24 / 21-43:  AdjP(case 4 states) = α·[P(C5) − 6·P(C4)] / n_c4                    [unitless]
+Equation 21-25 / 21-44:  AdjP(case 5 states) = −α·10·P(C5) / n_c5                            [unitless]
+  α = serial-correlation coefficient = 0.01 (0.00 disables the correlation adjustment)         (code: `ALPHA`)
+  n_c2, n_c3, n_c4, n_c5 = combinatorial divisors, the count of state indices spanned by each case:
+    two-lane framework:   n_c2=3, n_c3=6,  n_c4=27,  n_c5=27   (index ranges 2-4, 5-10, 11-37, 38-64)
+    three-lane framework: n_c2=7, n_c3=14, n_c4=147, n_c5=343  (index ranges 2-8, 9-22, 23-169, 170-512)
+Equation 21-26 / 21-45:  P'(i) = P(i) + AdjP(i)                                [unitless]
+Implemented in: awsc/awsc.rs::Awsc::departure_headway_for (`adj[0..5]`, and `p_adj = prob + adj[case-1]` applied per enumerated state)
+```
+
+The code derives the divisors from `m = 2^frame_lanes − 1` (the number of nonzero occupancy patterns per approach group) as `n_c2 = m`, `n_c3 = 2m`, `n_c4 = 3m²`, `n_c5 = m³`: for `frame_lanes = 2`, `m = 3` gives `(3, 6, 27, 27)`, and for `frame_lanes = 3`, `m = 7` gives `(7, 14, 147, 343)` — both derivations were checked against the HCM's literal divisors (3/6/27/27 in Equations 21-22 through 21-25; 7/14/147/343 in Equations 21-41 through 21-44) and match exactly. Because Equations 21-21 through 21-25 (and their three-lane counterparts) assign the *same* AdjP value to every state index within a case's range, the code's `p_adj = prob + adj[case-1]` — applying one adjustment value per case to every state in that case — is algebraically identical to looking up a distinct `AdjP(i)` for each `i` and adding it via Equation 21-26/21-45.
+
+#### Saturation headway and departure headway (Equations 21-27, 21-28)
+
+```
+Equation 21-27:  h_si = h_base + h_adj                                        [s]
+  h_base = base saturation headway for state i's degree-of-conflict case, geometry group, and (Groups 5/6 only) vehicle count (Exhibit 21-15)   [s]
+  h_adj  = headway adjustment from Equation 21-13 (Step 4)                    [s]
+Implemented in: awsc/awsc.rs::base_saturation_headway (h_base lookup) and Awsc::departure_headway_for (`h_si = base_saturation_headway(...) + h_adj`)
+
+Equation 21-28:  h_d = Σ P'(i)·h_si, for i = 1..64 (two-lane) or i = 1..512 (three-lane)    [s]
+Implemented in: awsc/awsc.rs::Awsc::departure_headway_for (`h_d += p_adj * h_si`, accumulated over every enumerated combination with nonzero probability)
+```
+
+`base_saturation_headway(case, vehicles, group)` looks up Exhibit 21-15's base saturation headway by case, geometry group, and (for Groups 5/6 only) the total vehicle count across the occupied lanes; Groups 1-4b use a single value per case regardless of vehicle count since those geometries cap conflicting lanes at one or two per group.
+
+#### Fully worked example: degree-of-conflict Case 1 (two-lane framework)
+
+Case 1 is the simplest of the five and corresponds to exactly one enumerated state: `state = 0`, i.e. every bit in the framework's six lanes (O1, O2, CL1, CL2, CR1, CR2) is unoccupied.
+
+1. **State probability (Equation 21-15).** With every `a_j = 0`, `P(a_j) = 1 − x_j` for any lane carrying demand (`V_j > 0`) and `P(a_j) = 1` for any lane with no demand (`V_j = 0`). So `P(1) = Π_j (1 − x_j)` over the six framework lanes — the probability that none of the opposing or conflicting lanes has a vehicle present.
+2. **Case probability (Equation 21-16).** Because state 1 is the only combination with zero occupied groups, `P(C1) = P(1)` directly (no summation needed).
+3. **Adjustment (Equation 21-21).** `AdjP(1) = α·[P(C2) + 2·P(C3) + 3·P(C4) + 4·P(C5)] / 1`; unlike the other four adjustments, the divisor is exactly 1 because Case 1 spans only the single state `i = 1`.
+4. **Adjusted probability (Equation 21-26).** `P'(1) = P(1) + AdjP(1)`.
+5. **Saturation headway (Equation 21-27).** `h_s1 = h_base(case=1, group) + h_adj`; Exhibit 21-15's Case 1 row is a single value per geometry group regardless of vehicle count (there are, by definition, no vehicles present in Case 1) — e.g. 3.9 s for Group 1, 4.5 s for Groups 5 and 6 (`BY_CASE[0]` / the `(1, _) => 4.5` arm in `base_saturation_headway`).
+6. **Contribution to Equation 21-28.** This state contributes the term `P'(1)·h_s1` to the sum that produces `h_d`.
+
+In code, this is `state = 0` on the first pass through the loop in `departure_headway_for`: `occupied = [0, 0, 0]` for all three groups, which the `match` on `(occupied[0] > 0, occupied[1] > 0, occupied[2] > 0)` classifies as `(false, false, false) => 1` (Case 1), `prob` accumulates as the product of `1.0 - p_occ` over every framework lane, and the same `prob` is pushed into both `p_case[0]` (`P(C1)`) and the `combos` vector for the later `h_d` accumulation. The remaining 63 (or 511) states for the two-lane (three-lane) framework follow the identical mechanics for Cases 2 through 5; see `awsc/awsc.rs::Awsc::departure_headway_for` for the full enumeration rather than retyping all 64/512 rows here.
+
+Finally, the whole procedure iterates (`Awsc::iterate_departure_headways`) by feeding each lane's new `x = v·h_d/3,600` back into the next round's occupancy probabilities, capped at 100 iterations and declared converged at `CONVERGENCE_TOLERANCE_S` = 0.1 s change in any lane's headway — matching Exhibit 21-10 Step 11's literal convergence text quoted in the module header ("If the values change by more than 0.1 s ... repeat").
+
+`awsc/tests.rs::test_ep2_departure_headway_iteration` specifically exercises the 512-state (three-lane) framework against Example Problem 2's published `h_d,EB,1 ~= 8.19 s`, `x_EB,1 ~= 0.1274`, confirming the framework selection logic and the larger state space both function correctly; `test_ep1_departure_headway_iteration` exercises the 64-state framework against Example Problem 1.
 
 ### Step 12: capacity via bisection
 
-`capacity_of_lane` clones the entire `Awsc` per trial, sets the subject lane's flow rate to a trial value, re-runs `iterate_departure_headways(0.01)` (a tighter, cheaper convergence tolerance than the main analysis's 0.1 s), and reads back the resulting degree of utilization. It first expands an upper bound in 200 veh/h steps until x >= 1.0 (capped at 3,600 veh/h), then bisects for 30 iterations or until the bracket narrows below 1 veh/h. `test_ep1_step12_capacity` documents a known, explained gap versus the literal published number: the HCM Chapter 32 text reports "approximately 720 veh/h" for the EB lane, but a naive `v/x` estimate gives 748 veh/h; a bisection on exact (unrounded) flow rates converges to about 704 veh/h, and the published 720 reflects the HCM's own coarser spreadsheet search rather than an exact closed form — the test therefore uses a +-20 veh/h tolerance and additionally asserts the qualitative fact that the computed capacity is below the naive 748 veh/h estimate (confirming the approach-interaction effect is present, even if its exact magnitude differs slightly from the published rounding).
+Step 12 is not itself a numbered HCM equation — the HCM text (Steps 12a-12e) describes it as a search procedure: pick a trial subject-lane flow, rerun Steps 5-11 to get the resulting degree of utilization, and adjust the trial flow up or down until `x = 1.0`. The code implements this search structure as follows.
+
+`capacity_of_lane` clones the entire `Awsc` per trial, sets the subject lane's flow rate to a trial value, re-runs `iterate_departure_headways(0.01)` (a tighter, cheaper convergence tolerance than the main analysis's 0.1 s), and reads back the resulting degree of utilization. The search has two phases:
+
+1. **Upper-bound expansion.** Starting from `hi = 400` veh/h, `lo = 0`, the trial flow `hi` is increased in 200 veh/h steps (each step re-running the full departure-headway iteration at that trial flow) until `x_at(hi) >= 1.0` or `hi` reaches the 3,600 veh/h cap; each expansion also advances `lo` to the previous `hi`, so `[lo, hi]` always brackets the point where `x` crosses 1.0.
+2. **Bisection.** For up to 30 iterations, the midpoint `mid = 0.5·(lo + hi)` is evaluated; if `x_at(mid) < 1.0` the bracket's lower bound moves up to `mid` (capacity is higher), otherwise the upper bound moves down to `mid`. The loop stops early once the bracket narrows to less than 1 veh/h. The final capacity estimate is the bracket's midpoint.
+
+`test_ep1_step12_capacity` documents a known, explained gap versus the literal published number: the HCM Chapter 32 text reports "approximately 720 veh/h" for the EB lane, but a naive `v/x` estimate gives 748 veh/h; a bisection on exact (unrounded) flow rates converges to about 704 veh/h, and the published 720 reflects the HCM's own coarser spreadsheet search rather than an exact closed form — the test therefore uses a +-20 veh/h tolerance and additionally asserts the qualitative fact that the computed capacity is below the naive 748 veh/h estimate (confirming the approach-interaction effect is present, even if its exact magnitude differs slightly from the published rounding). This is the same discrepancy already documented in Deviations below; it is not a new finding.
 
 ### Steps 13-16: service time, delay, LOS, queue, and aggregation
 
-Service time (Equation 21-29, `t_s = h_d - m`) uses `GeometryGroup::move_up_time`, which is 2.0 s for Groups 1-4b and 2.3 s for Groups 5/6 per the Equation 21-29 variable definitions. `control_delay_awsc` (Equation 21-30) takes `t_s`, `h_d`, `x`, and `T` directly rather than recomputing them, and its formula is algebraically the same overloaded-queueing shape used by `control_delay_unsignalized` (Chapter 20) and `control_delay_roundabout` (Chapter 22) — see `common-infrastructure.md`. LOS uses `los_unsignalized` per Exhibit 21-8, whose note (a) restricts LOS to a pure function of control delay for approaches and the intersection as a whole (the `false` literal passed as the `vc_gt_1` argument in `step15_aggregate_delay` reflects this — approach/intersection LOS never gets forced to F purely from an individual lane's v/c). Equation 21-33's 95th-percentile queue (`queue_95`) is algebraically identical in form to the Chapter 20 and Chapter 22 queue equations modulo the substitution of `h_d` for `3,600/c`.
+```
+Equation 21-29:  t_s = h_d − m                                                [s]
+  h_d = converged departure headway (Equation 21-28)                          [s]
+  m   = move-up time: 2.0 s (Geometry Groups 1-4b), 2.3 s (Groups 5-6)         [s]
+Implemented in: awsc/awsc.rs::Awsc::step13_14_16_lane_delay (`ts = h_d - m`) and GeometryGroup::move_up_time
+
+Equation 21-30:  d = t_s + 900·T·[(x−1) + √((x−1)² + h_d·x/(450·T))] + 5       [s/veh]
+  t_s = service time (Equation 21-29)                                         [s]
+  x   = degree of utilization = v·h_d/3,600                                   [unitless]
+  h_d = departure headway                                                     [s]
+  T   = analysis period, h (0.25 h for 15 min; code: `Awsc.analysis_period_h`) [h]
+  5   = deceleration/acceleration-to/from-stop constant                       [s]
+Implemented in: awsc/awsc.rs::Awsc::step13_14_16_lane_delay (via common::delay::control_delay_awsc)
+
+Equation 21-31:  d_a = Σ(d_i·v_i) / Σ(v_i)                                    [s/veh]
+  d_a = approach control delay
+  d_i = control delay for lane i                                              [s/veh]
+  v_i = flow rate for lane i                                                  [veh/h]
+Implemented in: awsc/awsc.rs::Awsc::step15_aggregate_delay (via common::delay::aggregate_control_delay)
+
+Equation 21-32:  d_intersection = Σ(d_a·v_a) / Σ(v_a)                         [s/veh]
+  d_a = approach control delay (Equation 21-31)                               [s/veh]
+  v_a = approach flow rate, the sum of the approach's lane flow rates         [veh/h]
+Implemented in: awsc/awsc.rs::Awsc::step15_aggregate_delay (via common::delay::aggregate_control_delay, invoked a second time over the approach-level (delay, flow) pairs)
+
+Equation 21-33:  Q_95 ≈ (900·T/h_d)·[(x−1) + √((x−1)² + h_d·x/(150·T))]        [veh]
+  x   = degree of utilization = v·h_d/3,600                                   [unitless]
+  h_d = departure headway                                                     [s]
+  T   = analysis period                                                       [h]
+Implemented in: awsc/awsc.rs::Awsc::queue_95
+```
+
+`control_delay_awsc` (Equation 21-30) takes `t_s`, `h_d`, `x`, and `T` directly rather than recomputing them, and its formula is algebraically the same overloaded-queueing shape used by `control_delay_unsignalized` (Chapter 20) and `control_delay_roundabout` (Chapter 22) — see `common-infrastructure.md`. LOS uses `los_unsignalized` per Exhibit 21-8, whose note (a) restricts LOS to a pure function of control delay for approaches and the intersection as a whole (the `false` literal passed as the `vc_gt_1` argument in `step15_aggregate_delay` reflects this — approach/intersection LOS never gets forced to F purely from an individual lane's v/c). Equation 21-33's 95th-percentile queue (`queue_95`) is algebraically identical in form to the Chapter 20 and Chapter 22 queue equations modulo the substitution of `h_d` for `3,600/c` (and the divisor 150·T rather than 450·T used in the delay equation — both were verified against the HCM 7th Edition Chapter 21 EPUB text and match exactly, including the divisor difference between Equations 21-30 and 21-33).
 
 ## Deviations
 
-No `docs/hcm/VERIFICATION.md` file exists at this branch's tip. The one documented, test-visible deviation is the Step 12 capacity discrepancy described above (`test_ep1_step12_capacity`'s doc comment): the published "approximately 720 veh/h" is a coarse HCM spreadsheet estimate, and an exact bisection on unrounded flow rates converges closer to 704 veh/h; the test asserts against the published value at a wide (+-20 veh/h) tolerance while separately asserting the qualitative approach-interaction effect (computed capacity below the naive v/x estimate) holds regardless of the exact number. No other `VERIFY-HCM`-style comments appear in `awsc.rs`.
+No `docs/hcm/VERIFICATION.md` file exists at this branch's tip. The one documented, test-visible deviation is the Step 12 capacity discrepancy described above (`test_ep1_step12_capacity`'s doc comment): the published "approximately 720 veh/h" is a coarse HCM spreadsheet estimate, and an exact bisection on unrounded flow rates converges closer to 704 veh/h; the test asserts against the published value at a wide (+-20 veh/h) tolerance while separately asserting the qualitative approach-interaction effect (computed capacity below the naive v/x estimate) holds regardless of the exact number. No other `VERIFY-HCM`-style comments appear in `awsc.rs`. No new discrepancies were found while cross-checking the code against the HCM 7th Edition Chapter 21 EPUB text (Sections 3 and 4) for this pass: Equations 21-12 through 21-33 (including the full probability/adjustment/case-classification machinery of Equations 21-14 through 21-28 and 21-34 through 21-45, the exact combinatorial divisors 3/6/27/27 and 7/14/147/343, and the Equation 21-30/21-33 delay and queue forms) all match the published equations exactly.
 
 ## Validation
 
-Fixtures live at `tests/ExampleCases/hcm/Awsc/case1.json` (HCM Chapter 32 AWSC Example Problem 1: single-lane, three-leg T intersection, 2% heavy vehicles, PHF = 0.95) and `case2.json` (AWSC Example Problem 2: four-leg multilane intersection with two-lane EB/WB approaches and three-lane NB/SB approaches, exercising the 512-state framework, 2% heavy vehicles, 15-min flow rates with no PHF). The Rust integration test is `tests/chapter21_integration.rs` (`test_awsc_example_problem_1_full_pipeline`, `test_awsc_example_problem_1_capacity`, `test_awsc_example_problem_2_full_pipeline`, `test_awsc_fixture_roundtrip`); the Python-bound equivalent is `tests/test_chapter21_integration.py`. Declared tolerances (module doc comment of `chapter21_integration.rs`): LOS exact, control delays within +-0.5 s/veh, departure headways within +-0.1 s (widened to +-0.15 s for the 512-state Example Problem 2 case at individual assertion sites, and capacity to +-20 veh/h per the Step 12 note above). Example Problem 1 reproduces h_d,EB = 4.97 s, h_d,WB = 4.74 s, h_d,SB = 5.70 s (Exhibit 32-21); t_s,EB = 2.97 s; d_EB = 13.0 s/veh (LOS B), d_WB = 13.5 s/veh, d_SB = 10.6 s/veh; intersection delay 12.8 s/veh (LOS B); Q95,EB = 2.9 veh; EB lane capacity ~720 veh/h. Example Problem 2 reproduces h_d,EB,1 = 8.19 s, x_EB,1 = 0.1274, t_s,EB,1 = 5.89 s, d_EB,1 = 12.1 s/veh (LOS B), d_EB,2 = 16.1 s/veh (LOS C); approach delays d_EB = 15.3 (LOS C), d_WB = 14.3, d_NB = 13.1, d_SB = 12.6 s/veh; intersection delay 14.0 s/veh (LOS B); Q95,EB,1 = 0.4 veh. Additional per-step unit tests in `src/hcm/chapter21/tests.rs` spot-check the geometry-group decision tree (all eight groups and their T-vs-four-leg variants), the Exhibit 21-12 headway-adjustment coefficients for both example problems, the Exhibit 21-15 base saturation headway table across representative case/group/vehicle-count combinations, the first-iteration degree-of-utilization values before any headway feedback, and the Equation 21-33 queue formula in isolation.
+Fixtures live at `tests/ExampleCases/hcm/Awsc/case1.json` (HCM Chapter 32 AWSC Example Problem 1: single-lane, three-leg T intersection, 2% heavy vehicles, PHF = 0.95) and `case2.json` (AWSC Example Problem 2: four-leg multilane intersection with two-lane EB/WB approaches and three-lane NB/SB approaches, exercising the 512-state framework, 2% heavy vehicles, 15-min flow rates with no PHF). The Rust integration test is `tests/chapter21_integration.rs` (`test_awsc_example_problem_1_full_pipeline`, `test_awsc_example_problem_1_capacity`, `test_awsc_example_problem_2_full_pipeline`, `test_awsc_fixture_roundtrip`); the Python-bound equivalent is `tests/test_chapter21_integration.py`. Declared tolerances (module doc comment of `chapter21_integration.rs`): LOS exact, control delays within +-0.5 s/veh, departure headways within +-0.1 s (widened to +-0.15 s for the 512-state Example Problem 2 case at individual assertion sites, and capacity to +-20 veh/h per the Step 12 note above). Example Problem 1 reproduces h_d,EB = 4.97 s, h_d,WB = 4.74 s, h_d,SB = 5.70 s (Exhibit 32-21); t_s,EB = 2.97 s; d_EB = 13.0 s/veh (LOS B), d_WB = 13.5 s/veh, d_SB = 10.6 s/veh; intersection delay 12.8 s/veh (LOS B); Q95,EB = 2.9 veh; EB lane capacity ~720 veh/h. Example Problem 2 reproduces h_d,EB,1 = 8.19 s, x_EB,1 = 0.1274, t_s,EB,1 = 5.89 s, d_EB,1 = 12.1 s/veh (LOS B), d_EB,2 = 16.1 s/veh (LOS C); approach delays d_EB = 15.3 (LOS C), d_WB = 14.3, d_NB = 13.1, d_SB = 12.6 s/veh; intersection delay 14.0 s/veh (LOS B); Q95,EB,1 = 0.4 veh. Additional per-step unit tests in `src/hcm/awsc/tests.rs` spot-check the geometry-group decision tree (all eight groups and their T-vs-four-leg variants), the Exhibit 21-12 headway-adjustment coefficients for both example problems, the Exhibit 21-15 base saturation headway table across representative case/group/vehicle-count combinations, the first-iteration degree-of-utilization values before any headway feedback, and the Equation 21-33 queue formula in isolation.
 
 ## Deferred
 

--- a/docs/hcm/procedures/chapter22.md
+++ b/docs/hcm/procedures/chapter22.md
@@ -1,6 +1,6 @@
 # HCM Chapter 22 — Roundabouts
 
-This document walks the HCM 7th Edition Chapter 22 motorized-vehicle methodology for roundabouts as implemented on branch `feat/hcm-ch20-22-unsignalized`. The code follows Chapter 22, Section 3 (core methodology) plus Section 4's capacity-model calibration extension (Equations 22-21 through 22-23), transcribed as the twelve-step procedure in the module header of `src/hcm/chapter22/roundabouts.rs` (the sole source file; `src/hcm/chapter22/tests.rs` holds the per-step unit tests against HCM Chapter 33 Example Problems 1 and 2). Delay/LOS primitives shared with Chapters 19-21 (`control_delay_roundabout`, `aggregate_control_delay` in `src/hcm/common/delay.rs`; `los_unsignalized` in `src/hcm/common/los_tables.rs`) are documented separately in `common-infrastructure.md`. `docs/hcm/VERIFICATION.md` does not exist in this branch's working tree; the deviations noted below come directly from code comments and test doc comments.
+This document walks the HCM 7th Edition Chapter 22 motorized-vehicle methodology for roundabouts as implemented on branch `feat/hcm-ch20-22-unsignalized`. The code follows Chapter 22, Section 3 (core methodology) plus Section 4's capacity-model calibration extension (Equations 22-21 through 22-23), transcribed as the twelve-step procedure in the module header of `src/hcm/roundabouts/roundabouts.rs` (the sole source file; `src/hcm/roundabouts/tests.rs` holds the per-step unit tests against HCM Chapter 33 Example Problems 1 and 2). Delay/LOS primitives shared with Chapters 19-21 (`control_delay_roundabout`, `aggregate_control_delay` in `src/hcm/common/delay.rs`; `los_unsignalized` in `src/hcm/common/los_tables.rs`) are documented separately in `common-infrastructure.md`. `docs/hcm/VERIFICATION.md` does not exist in this branch's working tree; the deviations noted below come directly from code comments and test doc comments. Every equation transcribed below was cross-checked against both the Rust function body and the HCM 7th Edition Chapter 22 EPUB text (Sections 3 and 4); no mathematical discrepancies were found — every case is either an exact match or a documented, already-flagged simplification (see Deviations).
 
 The geometry convention (stated in the module header) is a standard four-leg roundabout with the NB entry on the south leg, SB on the north leg, EB on the west leg, and WB on the east leg — i.e., `Leg` values name the direction of *travel through* the entry, not the compass position of the leg itself. The public entry point is `Roundabouts::analyze(&mut self)`, which runs Steps 1-2 (`step1_2_flow_rates_pce`), Step 3 (`step3_conflicting_flows`), Steps 4 through 10 and 12 combined per-approach (`step4_12_lane_performance`), and Step 11 (`step11_aggregate_delay`).
 
@@ -20,46 +20,230 @@ The geometry convention (stated in the module header) is a standard four-leg rou
 | Step 11 — Approach/intersection aggregation | Equations 22-18, 22-19 | `Roundabouts::step11_aggregate_delay`, `common::delay::aggregate_control_delay` | Per-lane (and bypass-lane) control delay and flow rate | `RoundaboutApproach.control_delay`/`los`; `Roundabouts.intersection_delay`/`intersection_los` |
 | Step 12 — 95th percentile queue | Equation 22-20 | `Roundabouts::queue_95` | v/c ratio, capacity (veh/h), analysis period T (h) | `RoundaboutLaneResult.queue_95` (veh) |
 
-### Entry-capacity regression equations (Step 5): exact coefficients
+### Steps 1-2: flow rates, PCE, and heavy-vehicle adjustment
 
-All six national entry/bypass capacity models reduce to the same generalized Siegloch exponential form, `capacity_exponential(a, b, v_c_pce) = a * (-b * v_c_pce).exp()` (HCM Equation 22-21's calibrated form, reused as the literal implementation of every "national" equation). The exact literal constants transcribed in `roundabouts.rs`, quoted verbatim from the source (no rounding applied here):
+```
+Equation 22-8:   v_i = V_i / PHF                                              [veh/h]
+  v_i  = demand flow rate for movement i                                      [veh/h]
+  V_i  = demand volume for movement i                                         [veh/h]
+  PHF  = peak hour factor
+Implemented in: roundabouts/roundabouts.rs::Roundabouts::step1_2_flow_rates_pce (`conv` closure, divide-by-phf leg)
 
-| Equation | Rust function | A (pc/h) | B (pc/h)^-1 | Case |
-|---|---|---|---|---|
-| 22-1 | `capacity_single_lane` | `1_380.0` | `1.02e-3` | One-lane entry, one circulating lane |
-| 22-2 | `capacity_two_lane_entry_one_circ` | `1_420.0` | `0.91e-3` | Each lane of a two-lane entry, one circulating lane |
-| 22-3 | `capacity_one_lane_entry_two_circ` | `1_420.0` | `0.85e-3` | One-lane entry, two circulating lanes (v_c is the two-lane total) |
-| 22-4 | `capacity_two_lane_entry_two_circ_right` | `1_420.0` | `0.85e-3` | Right lane of a two-lane entry, two circulating lanes |
-| 22-5 | `capacity_two_lane_entry_two_circ_left` | `1_350.0` | `0.92e-3` | Left lane of a two-lane entry, two circulating lanes |
-| 22-6 | `capacity_bypass_one_exit_lane` | `1_380.0` | `1.02e-3` | Yielding bypass, one opposing exit lane |
-| 22-7 | `capacity_bypass_two_exit_lanes` | `1_420.0` | `0.85e-3` | Yielding bypass, two opposing exit lanes |
+Equation 22-9:   v_i,pce = v_i / f_HV                                         [pc/h]
+  v_i,pce = demand flow rate for movement i, passenger-car equivalents        [pc/h]
+  v_i     = demand flow rate for movement i (Equation 22-8)                   [veh/h]
+  f_HV    = heavy-vehicle adjustment factor (Equation 22-10)
+Implemented in: roundabouts/roundabouts.rs::Roundabouts::step1_2_flow_rates_pce (`conv(v) = v / phf / f_hv`, Equations 22-8 and 22-9 fused into one closure)
 
-Two of these coefficient pairs are numerically identical to each other by construction rather than coincidence, and the code makes this explicit rather than duplicating the arithmetic: Equation 22-4 (two-lane entry, right lane, two circulating lanes) and Equation 22-3 (one-lane entry, two circulating lanes) share `(1_420.0, 0.85e-3)`, and `capacity_bypass_two_exit_lanes` (Equation 22-7) is implemented as a direct call to `capacity_two_lane_entry_two_circ_right` rather than a second literal — `test_bypass_capacity_equations` asserts this equivalence directly (`capacity_bypass_two_exit_lanes(500.0) == capacity_two_lane_entry_two_circ_right(500.0)` to `1e-9`). None of the seven coefficient pairs look physically implausible: intercepts A cluster around 1,350-1,420 pc/h (the theoretical maximum entry rate at zero conflicting flow, consistent with a follow-up headway of roughly 2.5-2.7 s), and slopes B are all small negative-exponent decay rates on the order of 0.85e-3 to 1.02e-3 per pc/h, consistent with the follow-up/critical-headway-derived Equations 22-22/22-23 (`calibrated_intercept_a(t_f) = 3,600/t_f`, `calibrated_slope_b(t_c, t_f) = (t_c - t_f/2)/3,600`) which `test_calibration_equations` verifies reproduce Equation 22-1's exact (1,380, 1.02e-3) pair when solved backward for `t_f = 3,600/1,380 ~= 2.609 s` and `t_c ~= 4.976 s`.
+Equation 22-10:  f_HV = 1 / [1 + P_T·(E_T − 1)]
+  f_HV = heavy-vehicle adjustment factor
+  P_T  = proportion of demand volume that is heavy vehicles                   [decimal] (code: `heavy_vehicle_pct / 100.0`)
+  E_T  = passenger car equivalent for heavy vehicles = 2.0 (Exhibit 22-11; code: `E_T_HEAVY_VEHICLE`)
+Implemented in: roundabouts/roundabouts.rs::Roundabouts::heavy_vehicle_factor
+```
 
-### PCE and heavy-vehicle treatment
+`E_T_HEAVY_VEHICLE = 2.0` (Exhibit 22-11's single passenger-car-equivalent for heavy vehicles; roundabouts do not distinguish truck sub-classes or grade the way Chapter 12 does). `heavy_vehicle_factor` (Equation 22-10) is applied twice in the pipeline: once in Step 1-2 to convert a veh/h demand volume into a pc/h flow rate (dividing by `f_hv` inflates veh/h into pc/h, Equations 22-8/22-9 combined), and again in Step 7 to convert a pc/h capacity back into veh/h (Equation 22-14, multiplying by `f_hv`) — the two uses are algebraically inverse operations on the same factor, correctly applied in opposite directions for flow (down-scale demand to pc/h by dividing) versus capacity (up-scale a pc/h capacity back to veh/h by multiplying), each additionally combined with the pedestrian factor only on the capacity side. The HCM's Equation 22-15 (a per-movement, flow-weighted average of `f_HV` across a shared lane's U/L/T/R movements, for cases where different movements have different heavy-vehicle percentages) is not implemented: the input model carries a single `heavy_vehicle_pct` per approach rather than per movement, so `f_HV` is computed once per approach and reused for every lane and movement on it. This is a simplification of input granularity, not a wrong equation — it was not in this task's enrichment scope and no fixture exercises per-movement heavy-vehicle percentages.
 
-`E_T_HEAVY_VEHICLE = 2.0` (Exhibit 22-11's single passenger-car-equivalent for heavy vehicles; roundabouts do not distinguish truck sub-classes or grade the way Chapter 12 does). `heavy_vehicle_factor(pct_heavy) = 1 / (1 + P_T*(E_T - 1))` (Equation 22-10) is applied twice in the pipeline: once in Step 1-2 to convert a veh/h demand volume into a pc/h flow rate (`conv(v) = v / phf / f_hv`, i.e. dividing by `f_hv` inflates veh/h into pc/h), and again in Step 7 to convert a pc/h capacity back into veh/h (`c_veh = c_pce * f_hv * f_ped`, multiplying by `f_hv` this time) — the two uses are algebraically inverse operations on the same factor, correctly applied in opposite directions for flow (down-scale demand to pc/h by dividing) versus capacity (up-scale a pc/h capacity back to veh/h by multiplying), each additionally combined with the pedestrian factor only on the capacity side.
+### Step 3: circulating and exiting flow (Equations 22-11, 22-12)
 
-### Lane-assignment logic (Step 4) and de facto lane checks
+```
+Equation 22-11 (example, northbound entry):
+  v_c,NB,pce = v_WB,U + v_SB,L + v_SB,U + v_EB,T + v_EB,L + v_EB,U             [pc/h]
+  v_c,NB,pce = conflicting circulating flow rate for the NB entry              [pc/h]
+  v_X,M,pce  = flow rate of movement M (U-turn/left/through) on leg X, pc/h
+Implemented in: roundabouts/roundabouts.rs::Roundabouts::circulating_flow_pce
 
-`entry_lane_flows_pce` first computes the full entry volume `ve = u + l + t + r_e` (right-turn flow `r_e` excluded when a bypass lane exists, since bypass traffic does not use the entry lanes at all), then, for a two-lane entry, applies Exhibit 22-14's "de facto lane" reclassification before assigning volumes per Exhibit 22-15: an `LT|TR` (`LeftThroughAndThroughRight`) entry becomes a de facto `L|TR` (`LeftAndThroughRight`) lane split if left-turn-plus-U-turn demand exceeds through-plus-right demand, or a de facto `LT|R` (`LeftThroughAndRight`) split if right-turn demand alone exceeds the combined left+through, mirroring the analogous checks for `L|LTR` (`LeftAndAllMovements`) and `LTR|R` (`AllMovementsAndRight`) configurations. For the three configurations that keep a genuinely shared movement in one lane (`LeftThroughAndThroughRight`, `LeftAndAllMovements`, `AllMovementsAndRight`), the Exhibit 22-9 default lane-utilization split (`pct_left_lane`) is 0.53 for `LeftAndAllMovements` and 0.47 for the other two, overridable per-approach. `test_de_facto_right_turn_lane` exercises the de facto right-turn-lane branch directly by giving an `LT|TR` approach overwhelming right-turn demand and confirming the left lane absorbs all left+through volume while the right lane gets only the right-turn flow.
+Equation 22-12 (example, southbound exit):
+  v_ex,SB,pce = v_NB,U + v_WB,L + v_SB,T + v_EB,R − v_EB,R,bypass,pce          [pc/h]
+  v_ex,SB,pce      = conflicting exiting flow for a bypass lane merging into the SB exit   [pc/h]
+  v_EB,R,bypass,pce = right-turn flow from the immediate upstream (EB) entry already diverted to its own bypass lane, excluded if that entry has no bypass   [pc/h]
+Implemented in: roundabouts/roundabouts.rs::Roundabouts::bypass_conflicting_exit_flow_pce
+```
 
-### Pedestrian impedance (Step 6)
+Both equations generalize across all four legs using the `Leg::opposite`/`left_of`/`right_of` topology rather than four separately hard-coded formulas. `circulating_flow_pce(leg)` computes, for the general entry `leg`: the U-turn flow of the entry to its right, plus the U-turn and left-turn flows of the opposite entry, plus the U-turn, left-turn, and through flows of the entry to its left — substituting `leg = NB` reproduces Equation 22-11 exactly (`right_of(NB) = WB`, `opposite(NB) = SB`, `left_of(NB) = EB`). `bypass_conflicting_exit_flow_pce(entry)` computes the exiting flow on the leg that `entry`'s right-turning traffic merges into (`exit_dir = entry.left_of()`) as the U-turn flow of the opposite leg, plus the left-turn flow of the leg to the exit's left, plus the exit leg's own through flow, plus the right-turn flow of the leg to the exit's right, minus that same right-turn flow if the entry generating it also has its own bypass lane (to avoid double-counting bypass traffic that never enters the circulatory roadway) — substituting `exit_dir = SB` reproduces Equation 22-12 exactly (`opposite(SB) = NB`, `left_of(SB) = WB`, `right_of(SB) = EB`).
 
-`ped_factor_one_lane` (Exhibit 22-18) is a three-branch function: full credit (factor 1.0) whenever conflicting circulating flow exceeds 881 pc/h (pedestrians are assumed to find adequate gaps regardless of their own volume at that point), a simple linear reduction `1 - 0.000137*n_ped` for light pedestrian volumes (n_ped <= 101 p/h), and a more complex bilinear regression `(1,119.5 - 0.715*v_c - 0.644*n_ped + 0.00073*v_c*n_ped) / (1,068.6 - 0.654*v_c)` clamped to [0, 1] for heavier pedestrian flows, verified continuous and monotonically decreasing at the boundary and beyond by `test_ped_factor_one_lane_exhibit_22_18`. `ped_factor_two_lane` (Exhibit 22-20) uses a similar structure but interpolates linearly between full credit and the n_ped = 100 regression value for light pedestrian flows (`1 - n_ped/100 * (1 - f_100)`), continuity across the n_ped = 100 breakpoint confirmed by `test_ped_factor_two_lane_exhibit_22_20`.
+### Step 4: entry-lane flows (Exhibits 22-14, 22-15, 22-9)
 
-### Calibration mechanism (Section 4)
+`entry_lane_flows_pce` first computes the full entry volume `v_e = v_U + v_L + v_T + v_R,e` (nonbypass right-turn flow `v_R,e` excluded when a bypass lane exists, since bypass traffic does not use the entry lanes at all — HCM Step 4, item 1), then, for a two-lane entry, applies Exhibit 22-14's de facto lane reclassification before assigning volumes per Exhibit 22-15. This reclassification is a precise conditional rule even though it is not a numbered equation, so it is written out here rather than only described:
 
-`Roundabouts.calibration: Option<(f64, f64)>` is an intersection-wide override: when set, `entry_capacity_pce` bypasses the geometry-based dispatch on `(entry_lanes, circulating_lanes)` entirely and calls `capacity_exponential(a, b, v_c)` with the caller-supplied (A, B) pair for every entry lane at the intersection (bypass lanes are unaffected — they always use the national `capacity_bypass_*` models). `calibrated_intercept_a`/`calibrated_slope_b` (Equations 22-22/22-23) are provided as free functions to derive (A, B) from field-measured follow-up headway t_f and critical headway t_c, but nothing in `analyze()` calls them automatically — a caller measuring local headways would compute (A, B) externally and set `Roundabouts.calibration` directly.
+```
+Exhibit 22-14, designated Left-Through | Through-Right entry:
+  if v_U + v_L > v_T + v_R,e:  reclassify as Left | Through-Right          (de facto left-turn lane)
+  else if v_R,e > v_U + v_L + v_T:  reclassify as Left-Through | Right     (de facto right-turn lane)
+  else:  keep Left-Through | Through-Right
+Implemented in: roundabouts/roundabouts.rs::Roundabouts::entry_lane_flows_pce (LaneAssignment::LeftThroughAndThroughRight match arm)
+
+Exhibit 22-14, designated Left | Left-Through-Right entry:
+  if v_T + v_R,e > v_U + v_L:  reclassify as Left | Through-Right          (de facto through-right lane)
+  else:  keep Left | Left-Through-Right
+Implemented in: roundabouts/roundabouts.rs::Roundabouts::entry_lane_flows_pce (LaneAssignment::LeftAndAllMovements match arm)
+
+Exhibit 22-14, designated Left-Through-Right | Right entry:
+  if v_U + v_L + v_T > v_R,e:  reclassify as Left-Through | Right         (de facto left-through lane)
+  else:  keep Left-Through-Right | Right
+Implemented in: roundabouts/roundabouts.rs::Roundabouts::entry_lane_flows_pce (LaneAssignment::AllMovementsAndRight match arm)
+```
+
+Once the (possibly reclassified) lane assignment is known, Exhibit 22-15 assigns volumes to the left and right lanes:
+
+```
+Exhibit 22-15, case Left | Through-Right:       left = v_U + v_L,            right = v_T + v_R,e
+Exhibit 22-15, case Left-Through | Right:       left = v_U + v_L + v_T,      right = v_R,e
+Exhibit 22-15, cases Left-Through | Through-Right, Left | Left-Through-Right, Left-Through-Right | Right (no de facto split applies):
+                                                 left = %LL·v_e,             right = %RL·v_e = (1 − %LL)·v_e
+  %LL = percentage of entry traffic using the left lane                     [decimal] (Exhibit 22-9 default: 0.53 for Left | Left-Through-Right, 0.47 for the other two; overridable per approach via `pct_left_lane`)
+Implemented in: roundabouts/roundabouts.rs::Roundabouts::entry_lane_flows_pce (final `match assignment` block)
+```
+
+`test_de_facto_right_turn_lane` exercises the de facto right-turn-lane branch directly by giving an `LT|TR` approach overwhelming right-turn demand and confirming the left lane absorbs all left+through volume while the right lane gets only the right-turn flow.
+
+### Step 5: entry-capacity regression equations — exact coefficients
+
+All six national entry/bypass capacity models reduce to the same generalized Siegloch exponential form (HCM Equation 22-21's calibrated form, reused as the literal implementation of every "national" equation):
+
+```
+Equation 22-21 (general Siegloch form):  c_pce = A·e^(−B·v_c)                 [pc/h]
+  c_pce = lane capacity, adjusted for heavy vehicles                          [pc/h]
+  v_c   = conflicting flow (circulating, or opposing-exit for a bypass lane)  [pc/h]
+  A, B  = calibration constants (intercept, decay rate); national values per Equations 22-1 through 22-7 below, or a caller-supplied override (Section 4)
+Implemented in: roundabouts/roundabouts.rs::capacity_exponential
+```
+
+The exact literal constants transcribed in `roundabouts.rs`, quoted verbatim from the source (no rounding applied here), each written out in the full Siegloch exponential form:
+
+```
+Equation 22-1:  c_e,pce = 1,380·e^(−1.02×10⁻³·v_c,pce)                        [pc/h]   one-lane entry, one circulating lane
+Equation 22-2:  c_e,pce = 1,420·e^(−0.91×10⁻³·v_c,pce)                        [pc/h]   each lane of a two-lane entry, one circulating lane
+Equation 22-3:  c_e,pce = 1,420·e^(−0.85×10⁻³·v_c,pce)                        [pc/h]   one-lane entry, two circulating lanes (v_c,pce is the two-lane total)
+Equation 22-4:  c_e,R,pce = 1,420·e^(−0.85×10⁻³·v_c,pce)                      [pc/h]   right lane of a two-lane entry, two circulating lanes
+Equation 22-5:  c_e,L,pce = 1,350·e^(−0.92×10⁻³·v_c,pce)                      [pc/h]   left lane of a two-lane entry, two circulating lanes
+Equation 22-6:  c_bypass,pce = 1,380·e^(−1.02×10⁻³·v_ex,pce)                  [pc/h]   yielding bypass, one opposing exit lane
+Equation 22-7:  c_bypass,pce = 1,420·e^(−0.85×10⁻³·v_ex,pce)                  [pc/h]   yielding bypass, two opposing exit lanes
+  v_c,pce  = conflicting circulating flow rate                                [pc/h]
+  v_ex,pce = conflicting exiting flow rate (bypass lanes only, Equation 22-12) [pc/h]
+Implemented in: roundabouts/roundabouts.rs::capacity_single_lane, capacity_two_lane_entry_one_circ, capacity_one_lane_entry_two_circ, capacity_two_lane_entry_two_circ_right, capacity_two_lane_entry_two_circ_left, capacity_bypass_one_exit_lane, capacity_bypass_two_exit_lanes (all via capacity_exponential)
+```
+
+Two of these coefficient pairs are numerically identical to each other by construction rather than coincidence, and the code makes this explicit rather than duplicating the arithmetic: Equation 22-4 (two-lane entry, right lane, two circulating lanes) and Equation 22-3 (one-lane entry, two circulating lanes) share `(1_420.0, 0.85e-3)`, and `capacity_bypass_two_exit_lanes` (Equation 22-7) is implemented as a direct call to `capacity_two_lane_entry_two_circ_right` rather than a second literal — `test_bypass_capacity_equations` asserts this equivalence directly (`capacity_bypass_two_exit_lanes(500.0) == capacity_two_lane_entry_two_circ_right(500.0)` to `1e-9`). None of the seven coefficient pairs look physically implausible: intercepts A cluster around 1,350-1,420 pc/h (the theoretical maximum entry rate at zero conflicting flow, consistent with a follow-up headway of roughly 2.5-2.7 s), and slopes B are all small negative-exponent decay rates on the order of 0.85e-3 to 1.02e-3 per pc/h.
+
+### Section 4: calibration (Equations 22-21 through 22-23)
+
+```
+Equation 22-22:  A = 3,600 / t_f                                              [pc/h]
+  A   = calibrated intercept (Equation 22-21)                                 [pc/h]
+  t_f = field-measured follow-up headway                                      [s]
+Implemented in: roundabouts/roundabouts.rs::calibrated_intercept_a
+
+Equation 22-23:  B = (t_c − t_f/2) / 3,600                                     [pc/h⁻¹]
+  B   = calibrated slope (Equation 22-21)                                     [pc/h⁻¹]
+  t_c = field-measured critical headway                                       [s]
+  t_f = field-measured follow-up headway                                      [s]
+Implemented in: roundabouts/roundabouts.rs::calibrated_slope_b
+```
+
+`Roundabouts.calibration: Option<(f64, f64)>` is an intersection-wide override: when set, `entry_capacity_pce` bypasses the geometry-based dispatch on `(entry_lanes, circulating_lanes)` entirely and calls `capacity_exponential(a, b, v_c)` with the caller-supplied (A, B) pair for every entry lane at the intersection (bypass lanes are unaffected — they always use the national `capacity_bypass_*` models). Nothing in `analyze()` calls `calibrated_intercept_a`/`calibrated_slope_b` automatically — a caller measuring local headways would compute (A, B) externally and set `Roundabouts.calibration` directly. `test_calibration_equations` verifies the round-trip: solving Equations 22-22/22-23 backward for `t_f = 3,600/1,380 ~= 2.609 s` and `t_c ~= 4.976 s` reproduces Equation 22-1's exact (1,380, 1.02e-3) pair.
+
+### Step 6: pedestrian impedance (Exhibits 22-18, 22-20)
+
+```
+Exhibit 22-18 (one-lane entry), piecewise in v_c,pce and n_ped:
+  if v_c,pce > 881:      f_ped = 1
+  else if n_ped <= 101:   f_ped = 1 − 0.000137·n_ped
+  else:                   f_ped = [1,119.5 − 0.715·v_c,pce − 0.644·n_ped + 0.00073·v_c,pce·n_ped] / [1,068.6 − 0.654·v_c,pce]
+  f_ped  = entry capacity adjustment factor for pedestrians                   [decimal]
+  n_ped  = number of conflicting pedestrians                                  [p/h]
+  v_c,pce = conflicting circulating flow rate                                 [pc/h]
+Implemented in: roundabouts/roundabouts.rs::ped_factor_one_lane
+
+Exhibit 22-20 (two-lane entry), piecewise in n_ped:
+  f_100 = [1,260.6 − 0.329·v_c,pce − 0.381×100] / [1,380 − 0.5·v_c,pce]
+  if n_ped < 100:  f_ped = min[1 − (n_ped/100)·(1 − f_100), 1]
+  else:            f_ped = min[(1,260.6 − 0.329·v_c,pce − 0.381·n_ped) / (1,380 − 0.5·v_c,pce), 1]
+Implemented in: roundabouts/roundabouts.rs::ped_factor_two_lane
+```
+
+`ped_factor_one_lane` (Exhibit 22-18) is a three-branch function: full credit (factor 1.0) whenever conflicting circulating flow exceeds 881 pc/h (pedestrians are assumed to find adequate gaps regardless of their own volume at that point), a simple linear reduction for light pedestrian volumes (n_ped <= 101 p/h), and the bilinear regression above for heavier pedestrian flows, clamped to [0, 1] and verified continuous and monotonically decreasing at the boundary and beyond by `test_ped_factor_one_lane_exhibit_22_18`. `ped_factor_two_lane` (Exhibit 22-20) interpolates linearly between full credit and the n_ped = 100 regression value for light pedestrian flows, continuity across the n_ped = 100 breakpoint confirmed by `test_ped_factor_two_lane_exhibit_22_20`. Every numeric coefficient above (881, 101, 0.000137, 1,119.5, 0.715, 0.644, 0.00073, 1,068.6, 0.654, 1,260.6, 0.329, 0.381, 1,380, 0.5) was checked against both the code and the HCM Chapter 22 EPUB text and matches exactly.
+
+### Step 7: pc/h to veh/h conversion (Equations 22-13, 22-14)
+
+```
+Equation 22-13:  v_i = v_i,PCE · f_HV,e                                       [veh/h]
+  v_i     = flow rate for lane i                                              [veh/h]
+  v_i,PCE = flow rate for lane i                                              [pc/h]
+  f_HV,e  = heavy-vehicle adjustment factor for the lane
+Implemented in: roundabouts/roundabouts.rs::Roundabouts::step4_12_lane_performance (`v_veh = v_pce * f_hv`)
+
+Equation 22-14:  c_i = c_i,PCE · f_HV,e · f_ped                                [veh/h]
+  c_i     = capacity for lane i                                               [veh/h]
+  c_i,PCE = capacity for lane i                                               [pc/h]
+  f_HV,e  = heavy-vehicle adjustment factor for the lane
+  f_ped   = pedestrian impedance factor (Step 6)
+Implemented in: roundabouts/roundabouts.rs::Roundabouts::step4_12_lane_performance (`c_veh = c_pce * f_hv * f_ped`)
+```
+
+### Step 8: volume-to-capacity ratio (Equation 22-16)
+
+```
+Equation 22-16:  x_i = v_i / c_i                                              [unitless]
+  x_i = volume-to-capacity ratio of subject lane i
+  v_i = demand flow rate of subject lane i                                    [veh/h]
+  c_i = capacity of subject lane i                                            [veh/h]
+Implemented in: roundabouts/roundabouts.rs::Roundabouts::step4_12_lane_performance (`x = if c_veh > 0.0 { v_veh / c_veh } else { 0.0 }`)
+```
+
+### Step 9: control delay (Equation 22-17)
+
+```
+Equation 22-17:  d = 3,600/c + 900·T·[x − 1 + √((x−1)² + (3,600/c)·x/(450·T))] + 5·min(x, 1)   [s/veh]
+  d = average control delay                                                   [s/veh]
+  x = volume-to-capacity ratio of the subject lane
+  c = capacity of the subject lane                                            [veh/h]
+  T = analysis period, h (0.25 h for a 15-min analysis)                       [h]
+Implemented in: roundabouts/roundabouts.rs (called via common::delay::control_delay_roundabout)
+```
+
+Equation 22-17 is verified to be the same shape as the Chapter 20/21 delay equation: it is identical to Equation 20-61/21-30 except the final "+5" term is scaled by `min(x, 1)` rather than applied unconditionally, reflecting YIELD control (an entering driver need not stop at all when there is no conflicting traffic; at higher v/c the likelihood of a full stop rises toward 1, matching STOP-control behavior). `control_delay_roundabout` implements exactly this: `3_600.0/capacity + 900.0*t_h*(...) + 5.0*x.min(1.0)`.
+
+### Steps 10-11: LOS and aggregation (Equations 22-18, 22-19)
+
+Step 10 (LOS) reuses `los_unsignalized` per Exhibit 22-8 with no chapter-specific logic; documented in `common-infrastructure.md`.
+
+```
+Equation 22-18:  d_approach = [d_LL·v_LL + d_RL·v_RL + d_bypass·v_bypass] / [v_LL + v_RL + v_bypass]   [s/veh]
+  d_approach = approach control delay
+  d_LL, d_RL, d_bypass = control delay of the left lane, right lane, and bypass lane (as present)   [s/veh]
+  v_LL, v_RL, v_bypass = flow rate of the left lane, right lane, and bypass lane (as present)         [veh/h]
+Implemented in: roundabouts/roundabouts.rs::Roundabouts::step11_aggregate_delay (via common::delay::aggregate_control_delay, over the approach's `lanes` plus its optional `bypass_lane`)
+
+Equation 22-19:  d_intersection = Σ(d_i·v_i) / Σ(v_i)                         [s/veh]
+  d_i = control delay for approach i                                         [s/veh]
+  v_i = flow rate for approach i                                             [veh/h]
+Implemented in: roundabouts/roundabouts.rs::Roundabouts::step11_aggregate_delay (via common::delay::aggregate_control_delay, invoked a second time over approach-level pairs)
+```
+
+`aggregate_control_delay` is the single flow-weighted-average implementation shared by both equations (and by the analogous Chapter 19/20/21 aggregation equations); the module-level function is generic over any list of `(delay, flow)` pairs rather than being called once per named lane, so Equation 22-18's three named terms (LL, RL, bypass) are simply whichever of `a.lanes` and `a.bypass_lane` are present for that approach, collected into one `pairs` vector before the weighted average is taken.
+
+### Step 12: 95th percentile queue (Equation 22-20)
+
+```
+Equation 22-20:  Q_95 = 900·T·[x − 1 + √((1−x)² + (3,600/c)·x/(150·T))]·(c/3,600)   [veh]
+  Q_95 = 95th percentile queue                                                [veh]
+  x    = volume-to-capacity ratio of the subject lane
+  c    = capacity of the subject lane                                        [veh/h]
+  T    = analysis period                                                     [h]
+Implemented in: roundabouts/roundabouts.rs::Roundabouts::queue_95
+```
+
+`queue_95` matches Equation 22-20 exactly, including the `(1−x)²` (equal to `(x−1)²`) form and the `150·T` divisor inside the radicand and the final `(c/3,600)` scaling factor outside the brackets. It is algebraically the same family as the AWSC/TWSC queue equations once the substitution `h_d = 3,600/c` is made: `900·T/h_d` (the AWSC prefactor) equals `900·T·c/3,600` (this equation's prefactor after distributing the trailing `c/3,600` term), confirmed by direct algebraic expansion during this review; no discrepancy.
 
 ## Deviations
 
-No `docs/hcm/VERIFICATION.md` exists in this branch's working tree. No `VERIFY-HCM` code comments appear in `roundabouts.rs`; the file's only documented modeling choice worth flagging as an interpretation (not a stated deviation) is the nonyielding (Type 2) bypass lane treatment: `step4_12_lane_performance`'s bypass-lane match arm assigns a nonyielding bypass zero capacity, zero v/c, zero delay, and LOS A unconditionally, citing "the HCM Chapter 33 Example Problem 1 treatment" in an inline comment rather than a numbered equation — the HCM textual guidance is that nonyielding (merge-style) bypass lanes experience negligible delay because they do not yield to circulating traffic, but the code's zero-capacity/zero-v-c representation is a simplification (a real nonyielding bypass has a finite, generally very high, capacity) rather than a literal transcription of an HCM equation. This is verified against Chapter 33 Example Problem 1's SB bypass (nonyielding), where the published answer is indeed 0 s/veh delay and LOS A, so the simplification reproduces the fixture correctly but would not distinguish a hypothetical highly-congested nonyielding bypass from an empty one.
+No `docs/hcm/VERIFICATION.md` exists in this branch's working tree. No `VERIFY-HCM` code comments appear in `roundabouts.rs`; the file's only documented modeling choice worth flagging as an interpretation (not a stated deviation) is the nonyielding (Type 2) bypass lane treatment: `step4_12_lane_performance`'s bypass-lane match arm assigns a nonyielding bypass zero capacity, zero v/c, zero delay, and LOS A unconditionally, citing "the HCM Chapter 33 Example Problem 1 treatment" in an inline comment rather than a numbered equation — the HCM textual guidance is that nonyielding (merge-style) bypass lanes experience negligible delay because they do not yield to circulating traffic, but the code's zero-capacity/zero-v-c representation is a simplification (a real nonyielding bypass has a finite, generally very high, capacity) rather than a literal transcription of an HCM equation. This is verified against Chapter 33 Example Problem 1's SB bypass (nonyielding), where the published answer is indeed 0 s/veh delay and LOS A, so the simplification reproduces the fixture correctly but would not distinguish a hypothetical highly-congested nonyielding bypass from an empty one. A second, newly-noted (but not a numerical error) simplification found during this pass: Equation 22-15's per-movement, flow-weighted heavy-vehicle adjustment factor is not implemented, because the input model has one `heavy_vehicle_pct` per approach rather than per movement (see Steps 1-2 above) — this is an input-granularity limitation, not a discrepancy against any equation the code does implement, and no fixture requires per-movement heavy-vehicle percentages. No other new discrepancies were found while cross-checking the code against the HCM 7th Edition Chapter 22 EPUB text (Sections 3 and 4) for this pass: Equations 22-1 through 22-23 (including the entry/bypass capacity regressions, the circulating/exiting flow topology, the de facto lane reclassification and volume-assignment rules, both pedestrian-impedance exhibits, the calibration equations, and the Equation 22-17/22-20 delay and queue forms) all match the published equations exactly.
 
 ## Validation
 
-Fixtures live at `tests/ExampleCases/hcm/Roundabouts/case1.json` (HCM Chapter 33 Example Problem 1: four-leg single-lane roundabout with a yielding WB bypass and a nonyielding SB bypass, 2% heavy vehicles, PHF = 0.94, 50 p/h crossing the NB entry) and `case2.json` (Example Problem 2: multilane roundabout — NB single-lane entry against two circulating lanes, SB two-lane `LT|R` entry against two circulating lanes, EB/WB two-lane `LT|TR` entries against one circulating lane, 5% heavy vehicles EB/WB and 2% NB/SB, PHF = 0.95). The Rust integration test is `tests/chapter22_integration.rs` (`test_roundabout_example_problem_1_full_pipeline`, `test_roundabout_example_problem_2_full_pipeline`, `test_roundabout_fixture_roundtrip`); the Python-bound equivalent is `tests/test_chapter22_integration.py`. Declared tolerances (module doc comment of `chapter22_integration.rs`): LOS exact, control delays within +-0.5 s/veh, capacities within +-5 veh/h. Example Problem 1 reproduces entry capacities c_NB = 597, c_SB = 618, c_EB = 824, c_WB = 694 veh/h and bypass capacity c_bypass,WB = 851 veh/h; v/c x_NB = 0.70; per-lane delays 22.6/14.0/0/22.0/26.8/20.2 s/veh with LOS C/B/A/C/D/C (Exhibit 33-8); approach delays d_WB = 23.3 s/veh (LOS C), d_SB = 4.7 s/veh (LOS A); intersection delay 17.5 s/veh (LOS C); Q95,NB = 5.7 veh. Example Problem 2 reproduces c_NB = 607, c_SB,L = 651, c_SB,R = 723, c_EB = 675 (both lanes), c_WB = 964 veh/h (both lanes); per-lane delays including d_NB = 11.8 s/veh (LOS B) and d_EB,R = 16.1 s/veh (LOS C, the only LOS-C lane in this fixture); approach delays d_SB = 13.9, d_EB = 15.1, d_WB = 8.3 s/veh; intersection delay 12.3 s/veh (LOS B); Q95,NB = 1.9 veh. Additional per-step unit tests in `src/hcm/chapter22/tests.rs` spot-check the seven capacity equations directly at the fixtures' own conflicting-flow values (e.g. `capacity_single_lane(796.0) ~= 613` pc/h, within 1.5 pc/h), the calibration-equation round-trip, both pedestrian-impedance exhibits, the Step 1-3 conflicting/exiting flow computations (tolerance 3 pc/h, attributed to the published values' own rounding of intermediate flow rates), the Step 4 lane-flow assignment including the de facto lane checks, and a serde round-trip of a fully analyzed fixture.
+Fixtures live at `tests/ExampleCases/hcm/Roundabouts/case1.json` (HCM Chapter 33 Example Problem 1: four-leg single-lane roundabout with a yielding WB bypass and a nonyielding SB bypass, 2% heavy vehicles, PHF = 0.94, 50 p/h crossing the NB entry) and `case2.json` (Example Problem 2: multilane roundabout — NB single-lane entry against two circulating lanes, SB two-lane `LT|R` entry against two circulating lanes, EB/WB two-lane `LT|TR` entries against one circulating lane, 5% heavy vehicles EB/WB and 2% NB/SB, PHF = 0.95). The Rust integration test is `tests/chapter22_integration.rs` (`test_roundabout_example_problem_1_full_pipeline`, `test_roundabout_example_problem_2_full_pipeline`, `test_roundabout_fixture_roundtrip`); the Python-bound equivalent is `tests/test_chapter22_integration.py`. Declared tolerances (module doc comment of `chapter22_integration.rs`): LOS exact, control delays within +-0.5 s/veh, capacities within +-5 veh/h. Example Problem 1 reproduces entry capacities c_NB = 597, c_SB = 618, c_EB = 824, c_WB = 694 veh/h and bypass capacity c_bypass,WB = 851 veh/h; v/c x_NB = 0.70; per-lane delays 22.6/14.0/0/22.0/26.8/20.2 s/veh with LOS C/B/A/C/D/C (Exhibit 33-8); approach delays d_WB = 23.3 s/veh (LOS C), d_SB = 4.7 s/veh (LOS A); intersection delay 17.5 s/veh (LOS C); Q95,NB = 5.7 veh. Example Problem 2 reproduces c_NB = 607, c_SB,L = 651, c_SB,R = 723, c_EB = 675 (both lanes), c_WB = 964 veh/h (both lanes); per-lane delays including d_NB = 11.8 s/veh (LOS B) and d_EB,R = 16.1 s/veh (LOS C, the only LOS-C lane in this fixture); approach delays d_SB = 13.9, d_EB = 15.1, d_WB = 8.3 s/veh; intersection delay 12.3 s/veh (LOS B); Q95,NB = 1.9 veh. Additional per-step unit tests in `src/hcm/roundabouts/tests.rs` spot-check the seven capacity equations directly at the fixtures' own conflicting-flow values (e.g. `capacity_single_lane(796.0) ~= 613` pc/h, within 1.5 pc/h), the calibration-equation round-trip, both pedestrian-impedance exhibits, the Step 1-3 conflicting/exiting flow computations (tolerance 3 pc/h, attributed to the published values' own rounding of intermediate flow rates), the Step 4 lane-flow assignment including the de facto lane checks, and a serde round-trip of a fully analyzed fixture.
 
 ## Deferred
 
-No equations from Chapter 22 Sections 3 or 4 appear unimplemented or stubbed. The one explicitly noted simplification is the nonyielding-bypass zero-delay/zero-capacity treatment described above, which reproduces the one fixture case that exercises it (Example Problem 1's SB bypass) but is not a literal HCM equation. No `todo!()` markers or `VERIFY-HCM` comments were found in `roundabouts.rs` or `tests.rs`.
+No equations from Chapter 22 Sections 3 or 4 appear unimplemented or stubbed. The one explicitly noted simplification is the nonyielding-bypass zero-delay/zero-capacity treatment described above, which reproduces the one fixture case that exercises it (Example Problem 1's SB bypass) but is not a literal HCM equation. Equation 22-15 (per-movement weighted heavy-vehicle factor) is not implemented, per the input-model limitation noted above. No `todo!()` markers or `VERIFY-HCM` comments were found in `roundabouts.rs` or `tests.rs`.

--- a/docs/hcm/procedures/chapter23-alternative.md
+++ b/docs/hcm/procedures/chapter23-alternative.md
@@ -1,6 +1,6 @@
 # HCM Chapter 23, Part C — Alternative Intersections (RCUT / MUT / DLT)
 
-This document walks through the Rust translation of HCM 7th Edition Chapter 23, Part C ("Alternative Intersection Evaluation"), which follows the same ten-step Exhibit 23-47 framework used for interchanges in Part B (`chapter23.md`), applied to restricted crossing U-turns (RCUT), median U-turns (MUT), and displaced left-turn intersections (DLT). Only the steps genuinely specific to Part C are implemented in `src/hcm/chapter23/alternative_intersections.rs`: junction-level control delays for signalized junctions and the Chapter 18 flow-profile procedure are explicitly out of scope and enter the module as pre-computed `JunctionStep::Provided` inputs, per the module doc comment's step-by-step scoping list (Steps 1-4 largely reuse Chapter 19/20/34 machinery documented elsewhere; only Steps 1's O-D redistribution, 5's U-turn crossover adjustment and DLT offset, 6's STOP-junction evaluation, 7's EDTT, 9's ETT assembly/aggregation, and 10's LOS are modeled here). Sources are EPUB `178_Ch23_pt3_01.xhtml` through `182_Ch23_pt3_05.xhtml` (introduction through applications), cross-checked against Chapter 34 Example Problems 12-17 (`269_Ch34_02b.xhtml`/`269_Ch34_02c.xhtml`, Exhibits 34-123 through 34-150). `docs/hcm/VERIFICATION.md` exists at this branch's tip with a "Chapter 23 Part C (feat/hcm-ch23-alternative-intersections)" section that is the authoritative source for the deviations below.
+This document walks through the Rust translation of HCM 7th Edition Chapter 23, Part C ("Alternative Intersection Evaluation"), which follows the same ten-step Exhibit 23-47 framework used for interchanges in Part B (`chapter23.md`), applied to restricted crossing U-turns (RCUT), median U-turns (MUT), and displaced left-turn intersections (DLT). Only the steps genuinely specific to Part C are implemented in `src/hcm/ramp_terminals/alternative_intersections.rs`: junction-level control delays for signalized junctions and the Chapter 18 flow-profile procedure are explicitly out of scope and enter the module as pre-computed `JunctionStep::Provided` inputs, per the module doc comment's step-by-step scoping list (Steps 1-4 largely reuse Chapter 19/20/34 machinery documented elsewhere; only Steps 1's O-D redistribution, 5's U-turn crossover adjustment and DLT offset, 6's STOP-junction evaluation, 7's EDTT, 9's ETT assembly/aggregation, and 10's LOS are modeled here). Sources are EPUB `178_Ch23_pt3_01.xhtml` through `182_Ch23_pt3_05.xhtml` (introduction through applications), cross-checked against Chapter 34 Example Problems 12-17 (`269_Ch34_02b.xhtml`/`269_Ch34_02c.xhtml`, Exhibits 34-123 through 34-150). `docs/hcm/VERIFICATION.md` exists at this branch's tip with a "Chapter 23 Part C (feat/hcm-ch23-alternative-intersections)" section that is the authoritative source for the deviations below.
 
 ## Step-by-step walkthrough
 
@@ -10,7 +10,7 @@ This document walks through the Rust translation of HCM 7th Edition Chapter 23, 
 | Step 5 (part) — U-turn crossover saturation adjustment | Exhibit 23-52 | `uturn_saturation_adjustment(median_width_ft)` | `alternative_intersections.rs` | median width (ft) | adjustment factor (0.80/0.85/0.95, unitless) |
 | Step 5 (part) — Default STOP headways for a U-turn crossover | Chapter 23 Step 5 text | `UTURN_CROSSOVER_DEFAULT_CRITICAL_HEADWAY_S` (4.4 s), `UTURN_CROSSOVER_DEFAULT_FOLLOWUP_HEADWAY_S` (2.6 s) | `alternative_intersections.rs` | — | default t_c/t_f (s) |
 | Step 5 (DLT) — Supplemental-intersection offset | Eqs. 23-63 through 23-68 | `dlt_offset` | `alternative_intersections.rs` | `td_dlt_ft`, `sf_dlt_mph`, `lag_dlt_s`, `lag_th_s`, `offset_supp_s`, `offset_main_s`, `cycle_s` | `DltOffsetResult` (`tt_dlt_s`, `st_dlt_s`, `st_th_s`, `offset_supp_s`, all s) |
-| Step 6 — STOP-controlled junction performance | Eq. 20-18 (potential capacity), Eq. 20-61 (control delay), Eq. 20-66 (Q95) | `stop_junction_delay` (calls `common::gap_acceptance::potential_capacity`, `common::delay::control_delay_unsignalized`, `chapter20::twsc::Twsc::queue_95`) | `alternative_intersections.rs` | `flow_veh_h`, `conflicting_flow_veh_h`, `critical_headway_s`, `followup_headway_s`, `analysis_period_h` | `StopJunctionResult` (`capacity_veh_h`, `vc_ratio`, `control_delay_s`, `queue_95_veh`) |
+| Step 6 — STOP-controlled junction performance | Eq. 20-18 (potential capacity), Eq. 20-61 (control delay), Eq. 20-66 (Q95) | `stop_junction_delay` (calls `common::gap_acceptance::potential_capacity`, `common::delay::control_delay_unsignalized`, `twsc::twsc::Twsc::queue_95`) | `alternative_intersections.rs` | `flow_veh_h`, `conflicting_flow_veh_h`, `critical_headway_s`, `followup_headway_s`, `analysis_period_h` | `StopJunctionResult` (`capacity_veh_h`, `vc_ratio`, `control_delay_s`, `queue_95_veh`) |
 | Step 6 — Signalized/merge junction performance | Chapter 19 IQA (external); zero delay for a passing merge | `JunctionStep::Provided`/`JunctionStep::Merge` variants, matched in `AltMovement::evaluate` | `alternative_intersections.rs` | supplied `control_delay_s`/`vc_gt_1`/`rq_gt_1` (Provided); none (Merge) | per-junction delay (s/veh) folded into `AltMovementResult.junction_delays_s` |
 | Step 7 — Extra distance travel time (RCUT with merges) | Eq. 23-58 | `edtt_merge` | `alternative_intersections.rs` | `dist_to_crossover_ft`, `dist_from_crossover_ft`, `free_flow_speed_mph`, `accel_decel_s` (10 s minor-left / 15 s minor-through constants) | EDTT (s/veh) |
 | Step 7 — Extra distance travel time (RCUT/MUT with STOP or signal) | Eq. 23-59 | `edtt_stop_or_signal` | `alternative_intersections.rs` | `dist_to_crossover_ft`, `dist_from_crossover_ft`, `free_flow_speed_mph` | EDTT (s/veh) |
@@ -19,17 +19,147 @@ This document walks through the Rust translation of HCM 7th Edition Chapter 23, 
 | Step 9/10 (DLT) — Weighted-average control delay and LOS | Eq. 23-69 | `dlt_weighted_average_delay`, `DisplacedLeftTurn::intersection_ett`, `DisplacedLeftTurn::los` | `alternative_intersections.rs` | `DltDelayCell` `(flow_veh_h, control_delay_s)` per junction, `total_od_demand_veh_h` | `ETT_DLT` (s/veh, = control delay); `LevelOfService` |
 | Step 10 — LOS (RCUT/MUT) | Exhibit 23-13 | `los_alternative_intersection_od` (Part B's `exhibits.rs`, re-used) | `alternative_intersections.rs` (call site in `AltMovement::evaluate`) | ETT (s/veh), v/c>1 and R_Q>1 flags | `LevelOfService` |
 
+### Step 1, 5, and 7 equations (step-table rows not covered in the prose subsections below)
+
+```
+Equation 23-57:  v_i = V_i / PHF                                                      [veh/h]
+  v_i  = demand flow rate for movement i                                             (veh/h)
+  V_i  = demand volume for movement i                                               (veh/h)
+  PHF  = peak hour factor                                                           (unitless, 0 < PHF <= 1)
+This is the same PHF-based flow-rate conversion used throughout the HCM, not a distinct Part-C-specific O-D formula; the EPUB's Step 1 text ("The standard turning movement demand pattern ... is converted into left turns, through vehicles, and right turns at each component junction") describes redistributing the converted flow rates to component junctions, a table the analyst supplies (matching Exhibits 34-124/34-127/34-131/34-135).
+Implemented in: analyst input — AltMovement.demand_veh_h and the per-junction flow fields of JunctionStep (ramp_terminals/alternative_intersections.rs); no dedicated function, since the PHF conversion and O-D-to-junction redistribution are supplied pre-computed.
+
+Exhibit 23-52: U-turn crossover saturation flow adjustment factor by median width
+  median width < 35 ft            -> 0.80  (narrow)
+  35 ft <= median width <= 80 ft  -> 0.85  (typical)
+  median width > 80 ft            -> 0.95  (very wide)
+Applied as an extra saturation flow adjustment factor at the U-turn crossover lane group of the Chapter 19 (`signalized`) analysis (Step 5). These are code constants/thresholds rather than an equation.
+Implemented in: ramp_terminals/alternative_intersections.rs::uturn_saturation_adjustment
+
+Step 5 default STOP-controlled U-turn crossover headways (HCM Chapter 23 Step 5 discussion text, not a numbered equation):
+  UTURN_CROSSOVER_DEFAULT_CRITICAL_HEADWAY_S  = 4.4 s   (t_c, observed at a three-through-lane, 55-mi/h reference site)
+  UTURN_CROSSOVER_DEFAULT_FOLLOWUP_HEADWAY_S  = 2.6 s   (t_f, same reference site)
+Used only when field data or representative local data are unavailable; feed Equation 20-18 (potential capacity) at a U-turn crossover.
+Implemented in: ramp_terminals/alternative_intersections.rs (module constants UTURN_CROSSOVER_DEFAULT_CRITICAL_HEADWAY_S, UTURN_CROSSOVER_DEFAULT_FOLLOWUP_HEADWAY_S)
+
+Equation 23-58:  EDTT = (D_t + D_f) / (1.47 · S_f) + a                                 [s]
+  EDTT = extra distance travel time                                                  (s)
+  D_t  = distance from the main junction to the U-turn crossover                     (ft)
+  D_f  = distance from the U-turn crossover back to the main junction                (ft)
+  1.47 = conversion factor from mi/h to ft/s
+  S_f  = major-street free-flow speed                                               (mi/h)
+  a    = deceleration/acceleration delay term: 10 s for a minor-street left turn (EDTT_MERGE_ACCEL_DECEL_MINOR_LEFT_S), 15 s for a minor-street through movement (EDTT_MERGE_ACCEL_DECEL_MINOR_THROUGH_S) (s)
+EDTT is experienced as a round trip from the main junction to the U-turn crossover and back (RCUTs with merges only).
+Implemented in: ramp_terminals/alternative_intersections.rs::edtt_merge
+
+Equation 23-59:  EDTT = (D_t + D_f) / (1.47 · S_f)                                     [s]
+  D_t, D_f, S_f as defined in Equation 23-58 above
+No acceleration/deceleration term, because it is already captured by the STOP or signal control-delay computation (RCUTs/MUTs with STOP signs or signals).
+Implemented in: ramp_terminals/alternative_intersections.rs::edtt_stop_or_signal
+```
+
 ### Journey construction (`AltMovement`, `JunctionStep`, `AlternativeIntersection`)
 
 `AltIntersectionForm` enumerates the six Part C forms (`RcutFourLeg`, `RcutThreeLeg`, `MutFourLeg`, `MutThreeLeg`, `DltPartial`, `DltFull`; Exhibits 23-41 through 23-45, 23-53, 23-54). An `AltMovement` is one O-D movement's journey: a label, an `Approach` (Eb/Wb/Nb/Sb, for Equation 23-61 aggregation), a demand flow rate (the aggregation weight), an ordered `Vec<JunctionStep>` (the Exhibit 23-48/23-49/23-50 traversal table for that movement, constructed by the analyst/fixture rather than derived automatically from an O-D table — the module doc comment is explicit that "the redistribution table is the analyst's input"), and a Step 7 EDTT scalar (zero for movements that are not rerouted). `JunctionStep` is a three-variant enum: `Provided` (an externally computed control delay — a Chapter 19 signalized junction, or a merge whose weaving delay is nonzero — plus `vc_gt_1`/`rq_gt_1` flags), `Stop` (evaluated in-module via `stop_junction_delay`, with optional `storage_ft`/`queue_spacing_ft` for the queue-storage-ratio LOS-F check), and `Merge` (zero delay, a free-flow merge onto the major street). `AltMovement::evaluate` walks the journey, sums the per-junction control delays, adds EDTT (Equation 23-60, `ett_s = total_control_delay_s + edtt_s`), ORs the `vc_gt_1`/`rq_gt_1` flags across every junction on the journey (forcing a stricter LOS if any junction is over capacity or over storage), and looks up LOS via `los_alternative_intersection_od`. `AlternativeIntersection` (an ordered `Vec<AltMovement>` plus the form) exposes `evaluate()` (all movements), `approach_ett(Approach)` (Equation 23-61, demand-weighted mean ETT within one approach, `None` if that approach carries no demand), and `intersection_ett()` (Equation 23-62, the same weighting over every movement).
+
+```
+Equation 23-60:  ETT = Σd_i + ΣEDTT                                                   [s/veh]
+  ETT  = experienced travel time for the O-D movement                                (s/veh)
+  d_i  = control delay at each junction i encountered on the path through the facility (s)
+  EDTT = extra distance travel time experienced (Equations 23-58/23-59, Step 7 (and Step 8 weaving delay if folded in)) (s)
+Implemented in: ramp_terminals/alternative_intersections.rs::AltMovement::evaluate (`ett_s = total_control_delay_s + edtt_s`)
+
+Equation 23-61:  ETT_A = Σ(ETT_j · v_j) / Σv_j                                         [s/veh]
+  ETT_A = approach experienced travel time                                           (s/veh)
+  ETT_j = experienced travel time for movement j (Equation 23-60)                     (s/veh)
+  v_j   = demand flow rate for movement j                                            (veh/h)
+  j     = ranges over all movements on the approach of interest
+Implemented in: ramp_terminals/alternative_intersections.rs::AlternativeIntersection::approach_ett
+
+Equation 23-62:  ETT_I = Σ(ETT_k · v_k) / Σv_k                                         [s/veh]
+  ETT_I = intersection experienced travel time                                       (s/veh)
+  ETT_k = experienced travel time for movement k (Equation 23-60)                     (s/veh)
+  v_k   = demand flow rate for movement k                                            (veh/h)
+  k     = ranges over all movements at the intersection
+Implemented in: ramp_terminals/alternative_intersections.rs::AlternativeIntersection::intersection_ett
+```
 
 ### DLT (displaced left-turn) intersections
 
 DLTs are modeled as an extension of the urban-street/signalized-intersection procedures rather than through the `AlternativeIntersection`/`AltMovement` journey machinery (per the module doc comment: "analyzed as extensions of the urban-street/signalized-intersection procedures"). `dlt_offset` implements the full Step 5 offset chain: Equation 23-63 (`TT_DLT = TD_DLT/(1.467 S_f,DLT)`, the displaced-left-turn roadway travel time), Equations 23-64/23-65 (`ST_DLT = LAG_DLT + O_SUPP`, `ST_TH = LAG_TH + O_MAIN`, the system start times of the DLT phase and the major-street through phase), and Equations 23-66 through 23-68 (`O_SUPP(s) = O_SUPP - ST_DLT + ST_TH - TT_DLT`, wrapped into `[0, C)` by repeated addition/subtraction of the cycle length rather than a modulo operation — functionally equivalent but written as an explicit `while` loop in the code). `DisplacedLeftTurn` holds the Exhibit 34-145/34-150 weighted-average control-delay table as `Vec<DltDelayCell>` (`flow_veh_h`, `control_delay_s` per component junction) plus the O-D demand total; `dlt_weighted_average_delay`/`DisplacedLeftTurn::intersection_ett` implement Equation 23-69 (`ETT_DLT = Sigma(d_j v_j) / Sigma v_OD`), with the doc comment noting "for DLT intersections, ETT is assumed equal to control delay (Step 7 EDTT is negligible)."
 
+```
+Equation 23-63:  TT_DLT = TD_DLT / (S_f,DLT · 1.47)                                    [s]
+  TT_DLT  = displaced left-turn roadway travel time                                  (s)
+  TD_DLT  = travel distance from the upstream supplemental-intersection crossover stop line to the main-intersection stop line (ft)
+  S_f,DLT = free-flow speed of the displaced left-turn roadway                       (mi/h)
+  1.47    = conversion factor from mi/h to ft/s
+Implemented in: ramp_terminals/alternative_intersections.rs::dlt_offset
+
+Equation 23-64:  ST_DLT = LAG_DLT + O_SUPP                                             [s]
+  ST_DLT  = system start time of the displaced left-turn phase at the upstream supplemental intersection (s)
+  LAG_DLT = duration between the reference point and the start of the DLT phase at the supplemental intersection, from input phase splits (s)
+  O_SUPP  = initial offset at the upstream supplemental intersection                 (s)
+Implemented in: ramp_terminals/alternative_intersections.rs::dlt_offset
+
+Equation 23-65:  ST_TH = LAG_TH + O_MAIN                                               [s]
+  ST_TH   = system start time of the major-street through phase at the main intersection (s)
+  LAG_TH  = duration between the reference point and the start of the major-street through phase at the main intersection, from input phase splits (s)
+  O_MAIN  = offset at the downstream main intersection                              (s)
+Implemented in: ramp_terminals/alternative_intersections.rs::dlt_offset
+
+Equation 23-66:  O_SUPP(s) = O_SUPP − ST_DLT + ST_TH − TT_DLT                          [s]
+  O_SUPP(s) = adjusted offset at the upstream supplemental intersection, chosen so that ST_TH = ST_DLT + TT_DLT (s)
+  O_SUPP    = initial supplemental-intersection offset (Equation 23-64 input)         (s)
+  ST_DLT    = system start time of the DLT phase (Equation 23-64)                     (s)
+  ST_TH     = system start time of the major-street through phase (Equation 23-65)    (s)
+  TT_DLT    = displaced left-turn roadway travel time (Equation 23-63)                (s)
+The manual prints the last term as "TT_LTD" (a typo for TT_DLT); written here and implemented per the derivation/prose, not the literal typo (see Deviations item 4 below; Example 16 reproduces O_SUPP = 45.2 s vs. the published 45 s, from rounding TT_DLT 6.8 to 7 before subtracting).
+Implemented in: ramp_terminals/alternative_intersections.rs::dlt_offset
+
+Equations 23-67/23-68 (wrap the adjusted offset into the valid range [0, C)):
+  If O_SUPP ≥ C  then  O_SUPP = O_SUPP − C      (Equation 23-67)
+  If O_SUPP < 0  then  O_SUPP = O_SUPP + C       (Equation 23-68)
+  C = background system cycle length                                                 (s)
+The manual prints Equation 23-68's guard as "if O_SUPP < C", while the accompanying Step 9 prose reads "if any offset value is lower than zero"; written and implemented here per the prose (guard is O_SUPP < 0), not the literal printed guard (see Deviations item 4 below). The code applies both corrections in a `while` loop rather than a single `if`, functionally equivalent for any O_SUPP within a few cycle lengths of [0, C).
+Implemented in: ramp_terminals/alternative_intersections.rs::dlt_offset
+
+Equation 23-69:  ETT_DLT = Σ(d_j · v_j) / Σv_OD                                        [s/veh]
+  ETT_DLT = weighted average experienced travel time for the DLT intersection         (s/veh)
+  d_j     = control delay at component junction j                                    (s/veh)
+  v_j     = flow rate through component junction j                                   (veh/h)
+  v_OD    = O-D demand volumes; Σv_OD must equal the conventional-intersection movement-demand total, to avoid double-counting trips within the spatial boundaries (Exhibit 23-5) (veh/h)
+For DLT intersections, ETT is assumed equal to control delay (Step 7 EDTT/Step 8 weaving delay are assumed negligible per the EPUB: "EDTT and weaving delay are assumed to be negligible for DLT intersections").
+Implemented in: ramp_terminals/alternative_intersections.rs::dlt_weighted_average_delay, DisplacedLeftTurn::intersection_ett
+```
+
 ### Junction analysis reuse
 
-Step 6's STOP-controlled junction evaluation (`stop_junction_delay`) is a thin wrapper composing three primitives from other chapters rather than new machinery: `common::gap_acceptance::potential_capacity` (Equation 20-18), `common::delay::control_delay_unsignalized` (Equation 20-61), and `chapter20::twsc::Twsc::queue_95` (Equation 20-66). Its doc comment is explicit about scope: it "models a rank-2 movement with no capacity impedance from higher-rank conflicting streams (the movement capacity equals the potential capacity), which is the situation at RCUT/MUT crossovers and the redistributed main-junction minor movements" — higher-rank impedance, when it matters, must be applied through the full Chapter 20 `Twsc` engine directly rather than through this Part-C-specific wrapper. Signalized junction delays are never recomputed by this module; they are supplied as `JunctionStep::Provided` values, which the module doc comment attributes to the Chapter 19 incremental-queue-accumulation (IQA) procedure documented in `chapter19.md`/`chapter19-actuated.md`.
+Step 6's STOP-controlled junction evaluation (`stop_junction_delay`) is a thin wrapper composing three primitives from other chapters rather than new machinery: `common::gap_acceptance::potential_capacity` (Equation 20-18), `common::delay::control_delay_unsignalized` (Equation 20-61), and `twsc::twsc::Twsc::queue_95` (Equation 20-66). Its doc comment is explicit about scope: it "models a rank-2 movement with no capacity impedance from higher-rank conflicting streams (the movement capacity equals the potential capacity), which is the situation at RCUT/MUT crossovers and the redistributed main-junction minor movements" — higher-rank impedance, when it matters, must be applied through the full Chapter 20 `Twsc` engine directly rather than through this Part-C-specific wrapper. Signalized junction delays are never recomputed by this module; they are supplied as `JunctionStep::Provided` values, which the module doc comment attributes to the Chapter 19 incremental-queue-accumulation (IQA) procedure documented in `chapter19.md`/`chapter19-actuated.md`.
+
+```
+Equation 20-18:  c_p,x = v_c,x · e^(−v_c,x·t_c,x / 3600) / (1 − e^(−v_c,x·t_f,x / 3600))     [veh/h]
+  c_p,x  = potential capacity of minor movement x                                    (veh/h)
+  v_c,x  = conflicting flow rate for movement x                                      (veh/h)
+  t_c,x  = critical headway for movement x (default 4.4 s at a U-turn crossover, see UTURN_CROSSOVER_DEFAULT_CRITICAL_HEADWAY_S above) (s)
+  t_f,x  = follow-up headway for movement x (default 2.6 s at a U-turn crossover, see UTURN_CROSSOVER_DEFAULT_FOLLOWUP_HEADWAY_S above) (s)
+Documented in more depth in docs/hcm/procedures/chapter20.md ("Step 5 — Potential capacities"); stop_junction_delay always uses the base gap-acceptance form (no upstream-signal platoon adjustment, no higher-rank impedance), per the scope note above.
+Implemented in: common/gap_acceptance.rs::potential_capacity
+
+Equation 20-61:  d = 3600/c + 900·T·[x − 1 + √((x − 1)² + (3600/c)·x / (450·T))] + 5          [s/veh]
+  d  = control delay                                                                  (s/veh)
+  c  = capacity of the subject movement (Equation 20-18 potential capacity in this Part-C wrapper) (veh/h)
+  x  = v/c ratio, degree of utilization (unitless)
+  T  = analysis period (typically 0.25 h)                                             (h)
+Documented in more depth in docs/hcm/procedures/chapter20.md ("Step 11 — Movement and lane control delay, LOS, queue").
+Implemented in: common/delay.rs::control_delay_unsignalized
+
+Equation 20-66:  Q_95 = 900·T·[x − 1 + √((x − 1)² + (3600/c)·x / (150·T))] · (c / 3600)       [veh]
+  Q_95 = 95th-percentile queue                                                        (veh)
+  x, c, T as in Equation 20-61 above
+Documented in more depth in docs/hcm/procedures/chapter20.md ("Step 11 — Movement and lane control delay, LOS, queue").
+Implemented in: twsc/twsc.rs::Twsc::queue_95
+```
 
 ## Deviations (cross-referenced to `docs/hcm/VERIFICATION.md`)
 

--- a/docs/hcm/procedures/chapter23.md
+++ b/docs/hcm/procedures/chapter23.md
@@ -1,6 +1,6 @@
 # HCM Chapter 23, Part B — Interchange Ramp Terminals
 
-This document walks through the Rust translation of HCM 7th Edition Chapter 23, Part B ("Interchange Ramp Terminals," final design and operational analysis for signalized interchanges including DDIs), which follows the nine computational steps of Exhibit 23-22 and is documented at the top of `src/hcm/chapter23/ramp_terminals.rs`. Sources are EPUB `175_Ch23_pt2_03.xhtml` (core methodology), `176_Ch23_pt2_04.xhtml` (extensions), and `271_Ch34_04.xhtml` (the Chapter 34 O-D/turning-movement worksheets); numeric conventions are cross-checked against Chapter 34 Example Problems 1, 3, 4, 5, and 6 (`269_Ch34_02*.xhtml`). The code lives in `src/hcm/chapter23/ramp_terminals.rs` (the `Interchange` facility struct and the nine-step pipeline) and `src/hcm/chapter23/exhibits.rs` (LOS tables and the interchange-specific adjustment-factor equations); several saturation-flow-adjustment and delay building blocks are re-used directly from `crate::hcm::chapter19` (lane-width/heavy-vehicle/parking/bus-blockage/area-type factors, default lane utilization, platoon ratio, back-of-queue terms) and `crate::hcm::common::delay` (uniform/incremental/initial-queue delay, progression factor, upstream filtering, roundabout control delay).
+This document walks through the Rust translation of HCM 7th Edition Chapter 23, Part B ("Interchange Ramp Terminals," final design and operational analysis for signalized interchanges including DDIs), which follows the nine computational steps of Exhibit 23-22 and is documented at the top of `src/hcm/ramp_terminals/ramp_terminals.rs`. Sources are EPUB `175_Ch23_pt2_03.xhtml` (core methodology), `176_Ch23_pt2_04.xhtml` (extensions), and `271_Ch34_04.xhtml` (the Chapter 34 O-D/turning-movement worksheets); numeric conventions are cross-checked against Chapter 34 Example Problems 1, 3, 4, 5, and 6 (`269_Ch34_02*.xhtml`). The code lives in `src/hcm/ramp_terminals/ramp_terminals.rs` (the `Interchange` facility struct and the nine-step pipeline) and `src/hcm/ramp_terminals/exhibits.rs` (LOS tables and the interchange-specific adjustment-factor equations); several saturation-flow-adjustment and delay building blocks are re-used directly from `crate::hcm::signalized` (lane-width/heavy-vehicle/parking/bus-blockage/area-type factors, default lane utilization, platoon ratio, back-of-queue terms) and `crate::hcm::common::delay` (uniform/incremental/initial-queue delay, progression factor, upstream filtering, roundabout control delay).
 
 ## Step-by-step walkthrough
 
@@ -20,9 +20,93 @@ This document walks through the Rust translation of HCM 7th Edition Chapter 23, 
 
 `InterchangeForm` enumerates the nine computational forms covered (`Diamond` also covers compressed/tight urban diamonds, which differ only in intersection spacing; `Ddi`; the four partial-cloverleaf variants `ParcloA2Q`/`ParcloA4Q`/`ParcloAB2Q`/`ParcloAB4Q`/`ParcloB2Q`/`ParcloB4Q` — six variants total; and `Spui`). `od_from_turning_movements(form, tm: &TurningMovements) -> OdDemands` implements the forward direction (Chapter 34 Exhibits 34-163 through 34-170) and `turning_movements_from_od(form, od: &OdDemands) -> TurningMovements` implements the algebraic inverse (Exhibits 34-171 through 34-177), both as an exhaustive `match` over `InterchangeForm` with one arm per form (Diamond/DDI share an arm since both use the Exhibit 34-169/34-176 diamond mapping; the six parclo variants and SPUI each have their own arm, so all eight distinct O-D <-> turning-movement mappings enumerated in the task are present). `TurningMovements` carries `_ii`-suffixed fields (e.g., `nb_left_ii`) for the AB/B-4Q parclo forms where a movement exists at both intersections. `OdDemands` (fields `a` through `n`, the fourteen Exhibit 23-20/34-162 O-D letters) provides `get(OdMovement)`, `phf_adjusted(phf)` (`v = V/PHF` on all fourteen letters), and `total()`.
 
+```
+PHF adjustment (Chapter 34 worksheet arithmetic; Exhibit 34-5 convention, `OdDemands::phf_adjusted`):
+  v_x = V_x / PHF     for each O-D letter x in {A..N}     [veh/h]
+  V_x  = unadjusted (peak 15-min-equivalent) O-D demand for letter x    (veh/h)
+  PHF  = peak hour factor                                              (unitless, 0 < PHF <= 1; PHF <= 0 treated as 1.0)
+  total() = Sigma_x v_x over all fourteen letters A..N                 (veh/h)
+Implemented in: ramp_terminals/ramp_terminals.rs::OdDemands::phf_adjusted, ::total
+```
+
+The O-D <-> turning-movement conversion itself (`od_from_turning_movements` / `turning_movements_from_od`) is pure lookup-table data reproduced from Chapter 34 Exhibits 34-163 through 34-177 (and its inverse), not an equation: each interchange form gets one `match` arm that composes the fourteen O-D letters as fixed linear combinations (sums and differences) of the turning-movement fields, and the per-form arms are cross-checked against the exhibits rather than re-derived here.
+
 ### Step 3 — Saturation-flow adjustments
 
 `step_3_saturation_flows` computes Equation 23-14 (`s = s0 x N x f_w x f_HVg x f_p x f_bb x f_a x f_LT x f_RT x f_v x f_LU x f_DDI`) per lane group, reusing the Chapter 19 factors (`f_w`, `f_HVg`, `f_p`, `f_bb`, `f_a`) directly and adding four interchange-specific adjustments: (1) traffic pressure `f_v` (Equation 23-15, `traffic_pressure_factor` in `exhibits.rs`, flow-weighted between the left-turn and through/right tabulated forms for shared lane groups, capped at `TRAFFIC_PRESSURE_DEMAND_CAP` = 30 veh/cycle/ln); (2) lane utilization `f_LU` (Equations 23-16/23-17 with Exhibit 23-24 for non-DDI external arterial approaches, dispatched by `arterial_lane_utilization_model` to one of five coefficient-row groupings; Equation 23-18 with Exhibit 23-26 for DDI external crossovers via `ddi_pct_v_lmax`; and the plain Chapter 19 Exhibit 19-15 default via `default_lane_utilization_factor` for ramp/internal/SPUI approaches); (3) turn-radius adjustments `f_LT`/`f_RT` (Equations 23-19 through 23-23, `turn_radius_factor` + `left_turn_radius_adjustment`/`right_turn_radius_adjustment`, flow-weighted across shared lane groups per the Chapter 23 text: "the adjustment factor for turn radii is estimated as the average (weighted on the basis of flows) of the respective movements"); and (4) the DDI crossover factor `f_DDI` (constant `F_DDI` = 0.913, applied only to the four DDI through-movement lane groups).
+
+```
+Equation 23-14:  s = s0 · N · f_w · f_HVg · f_p · f_bb · f_a · f_LT · f_RT · f_Lpb · f_Rpb · f_v · f_LU · f_DDI     [veh/h]
+  s0     = base saturation flow rate per lane                        (pc/h/ln, default BASE_SATURATION_FLOW_METRO = 1,900 for metro pop. >= 250,000)
+  N      = number of lanes in the lane group                          (ln)
+  f_w    = lane-width adjustment (crate::hcm::signalized::exhibits::lane_width_factor)        (unitless)
+  f_HVg  = heavy-vehicle/grade adjustment (::heavy_vehicle_grade_factor)                       (unitless)
+  f_p    = parking adjustment (::parking_factor)                                               (unitless)
+  f_bb   = bus-blockage adjustment (::bus_blockage_factor)                                     (unitless)
+  f_a    = area-type adjustment (::area_type_factor; 0.90 CBD else 1.0)                        (unitless)
+  f_LT   = left-turn adjustment, radius-modified (Eq. 23-20/23-21)                              (unitless)
+  f_RT   = right-turn adjustment, radius-modified (Eq. 23-22/23-23)                             (unitless)
+  f_Lpb  = pedestrian-bicycle adjustment for left turns (Chapter 19; not modeled, = 1.0)        (unitless)
+  f_Rpb  = pedestrian-bicycle adjustment for right turns (Chapter 19; not modeled, = 1.0)       (unitless)
+  f_v    = traffic-pressure adjustment (Eq. 23-15)                                              (unitless)
+  f_LU   = lane-utilization adjustment (Eq. 23-16/23-17 or 23-18)                                (unitless)
+  f_DDI  = DDI crossover adjustment (constant F_DDI = 0.913; DDI through lane groups only)      (unitless)
+Implemented in: ramp_terminals/ramp_terminals.rs::Interchange::step_3_saturation_flows
+```
+
+```
+Equation 23-15 (Interchange Saturation Flow Adjustment No. 1 — traffic pressure):
+  f_v = 1 / (1.07 - 0.00672 · min(v_i', 30))     (left turn)
+  f_v = 1 / (1.07 - 0.00486 · min(v_i', 30))     (through or right turn)
+  v_i' = demand flow rate per cycle per lane                              (veh/cycle/ln)
+  TRAFFIC_PRESSURE_DEMAND_CAP = 30                                        (veh/cycle/ln; v_i' above this uses 30)
+  For a lane group shared by several movements, f_v is the flow-weighted average of the left-turn and through/right forms (Chapter 23 text; code: p_lt · f_v_left + (1 - p_lt) · f_v_thru).
+Implemented in: ramp_terminals/exhibits.rs::traffic_pressure_factor; ramp_terminals/ramp_terminals.rs::Interchange::step_3_saturation_flows
+```
+
+```
+Equations 23-16 / 23-17 (Interchange Saturation Flow Adjustment No. 2 — lane utilization, external arterial approaches of diamond/parclo interchanges):
+Equation 23-16:  f_LU = 1 / (%V_Lmax · N)     [unitless]
+  %V_Lmax = percent of total approach flow in the highest-volume lane, as a decimal   (unitless)
+  N       = number of lanes in the lane group                                        (ln)
+
+Equation 23-17:  %V_Li = 1/n + a1·(v_R/(v_L+v_R+v_T)) + a2·(v_L/(v_L+v_R+v_T)) + a3·(D · v_L / 10^6)     [unitless]
+  %V_Li  = percent of traffic in lane Li (L1 = leftmost)                              (unitless)
+  n      = number of lanes in the lane group                                          (ln)
+  a1,a2,a3 = coefficients for the interchange-type/lane-position model (Exhibit 23-24) (unitless, ft^-1 for a3 scaling)
+  D      = distance between the two intersections, capped at LANE_UTILIZATION_MAX_SPACING_FT = 800  (ft; valid below 800 ft)
+  v_R    = O-D demand through the first intersection then turning right at the second (0 if an exclusive right-turn lane exists)  (veh/h)
+  v_L    = O-D demand through the first intersection then turning left at the second   (veh/h)
+  v_T    = O-D demand through both intersections                                       (veh/h)
+  %V_Lmax = max(%V_Li) over the modeled lanes (leftmost, rightmost, and by-subtraction middle lane(s))
+  Known deviation (already tracked): see Deviations item 1 (Eq. 23-17/Exhibit 23-24 does not reproduce the book's own %V_Lmax worked values).
+Implemented in: ramp_terminals/exhibits.rs::lane_utilization_factor_from_max, ::pct_volume_in_lane, ::pct_v_lmax_arterial; ramp_terminals/ramp_terminals.rs::Interchange::lane_utilization
+```
+
+```
+Equation 23-18 (DDI external-crossover lane utilization, with Exhibit 23-26 coefficients):
+  %V_Li,DDI = a1 · LTDR + a2     [unitless]
+  a1, a2 = coefficients for the DDI lane configuration and LTDR regime (Exhibit 23-26)   (unitless)
+  LTDR   = left-turn demand ratio = left-turn demand at the external crossover / total approach volume   (decimal)
+  The highest %V_Li,DDI over the configuration's regimes is used as %V_Lmax in Equation 23-16.
+Implemented in: ramp_terminals/exhibits.rs::ddi_pct_v_lmax; ramp_terminals/ramp_terminals.rs::Interchange::lane_utilization
+```
+
+```
+Equations 23-19 through 23-23 (Interchange Saturation Flow Adjustment No. 4 — turn radius):
+Equation 23-19:  f_R = 1 / (1 + 5.61/R)     [unitless]
+  R = radius of curvature of the left- or right-turning path at the center of the path   (ft)
+
+Equation 23-20 (protected, exclusive left-turn lane):  f_LT = f_R
+Equation 23-21 (protected, shared left-turn lane):      f_LT = 1 / (1 + P_LT · (1/f_R - 1))
+  P_LT = proportion of left turns in the lane group (1.0 for an exclusive lane)   (decimal)
+
+Equation 23-22 (protected, exclusive right-turn lane):  f_RT = f_R
+Equation 23-23 (protected, shared right-turn lane):     f_RT = 1 / (1 + P_RT · (1/f_R - 1))
+  P_RT = proportion of right turns in the lane group (1.0 for an exclusive lane)  (decimal)
+  For a lane group shared by several movements, f_R is first flow-weighted across the group's movements (p · f_R_movement + (1 - p)), then entered into Eq. 23-21/23-23 (see Deviations item 8, which documents the flow-weighting convention reproducing Exhibit 34-7's published EB EXT-TH&R values).
+Implemented in: ramp_terminals/exhibits.rs::turn_radius_factor, ::left_turn_radius_adjustment, ::right_turn_radius_adjustment; ramp_terminals/ramp_terminals.rs::Interchange::step_3_saturation_flows (shared_chain closure), ::turn_proportions
+```
 
 ### Step 4 — The four lost-time / queue-interaction mechanisms
 
@@ -33,23 +117,226 @@ Four distinct mechanisms feed into the adjusted lost time `t_L'`/`t_L''` (Equati
 3. **Demand starvation** (Equations 23-38/23-39): `demand_starvation_initial_queue` computes the initial internal queue `Q_initial` (veh) from the ramp-left and arterial feed flows/lanes, the common green windows `CG_RD`/`CG_UD` (each floored at the per-phase lost time `t_L`), and the internal saturation headway `h_I`; `demand_starvation_lost_time` then converts it to `L_DS = max(CG_DS - Q_initial h_I, 0)`. Wired into "Pass 2" for the internal through-movement lane groups of both directions, explicitly skipped for DDIs ("zero for DDIs per the Chapter 23 text").
 4. **Closely spaced adjacent intersections** (Equation 23-40): `adjacent_intersection_lost_time` is a standalone free function (algebraically identical to `downstream_queue_lost_time`) exposed for an analyst to apply outside the pipeline, since — per its doc comment — "the facility pipeline models the interchange itself" and the full adjacent-intersection interaction (a further lane-utilization reduction plus a separate Chapter 19 evaluation of the adjacent intersection) is left to the analyst; the chapter itself directs the use of alternative tools when a downstream queue and demand starvation act on the same approach simultaneously.
 
+```
+Equations 23-24 / 23-25 / 23-26: adjusted lost time
+Equation 23-24 (arterial):  t_L' = l1 + L_D-A + Y - e     [s]
+Equation 23-25 (ramp):      t_L' = l1 + L_D-R + L_OL-DDI + Y - e     [s]
+Equation 23-26 (internal):  t_L'' = l1 + L_DS + Y - e     [s]
+  l1       = start-up lost time                                          (s, default START_UP_LOST_TIME = 2.0)
+  L_D-A    = lost time on the external arterial approach due to a downstream queue (Eq. 23-29)   (s)
+  L_D-R    = lost time on the external ramp approach due to a downstream queue (Eq. 23-30)        (s)
+  L_OL-DDI = lost time on a signalized DDI off-ramp movement due to overlap phasing (Eq. 23-37)   (s)
+  L_DS     = lost time due to demand starvation on an internal approach (Eq. 23-38)               (s)
+  Y        = yellow-plus-all-red change-and-clearance interval                                   (s, `yellow_all_red_s`)
+  e        = extension of effective green time into the clearance interval                        (s, default EXTENSION_OF_EFFECTIVE_GREEN = 2.0)
+  Code combines L_D + overlap_lost_time_s into one "additional lost time" argument for external/ramp groups, and L_DS alone for internal groups (both floored at 0 by `adjusted_lost_time`).
+Implemented in: ramp_terminals/ramp_terminals.rs::adjusted_lost_time, ::Interchange::step_4_effective_green_adjustments
+
+Equations 23-27 / 23-28: effective green
+Equation 23-27 (external, downstream-queue-adjusted):  g' = G + Y - t_L'     [s]
+Equation 23-28 (internal, demand-starvation-adjusted):  g'' = G + Y - t_L''  [s]
+  G = displayed green time (total_green_s)                                 (s)
+Implemented in: ramp_terminals/ramp_terminals.rs::Interchange::step_4_effective_green_adjustments (`effective_green_s` field)
+```
+
+```
+Equations 23-29 / 23-30 (Lost Time Adjustment No. 1 — downstream internal link queue on arterial/ramp):
+Equation 23-29 (arterial):  L_D-A = G_A - 0.106·DQ_A - 5.39·CG_UD/C     [s, floored at 0]
+Equation 23-30 (ramp):      L_D-R = G_R - 0.106·DQ_R - 5.39·CG_RD/C     [s, floored at 0]
+  G_A, G_R = green interval for the external arterial / ramp approach                  (s)
+  DQ_A, DQ_R = distance to the downstream queue at the start of the respective green (Eq. 23-31/23-32)  (ft)
+  CG_UD  = common green time between the upstream arterial through and downstream through green   (s)
+  CG_RD  = common green time between the upstream ramp and downstream through green               (s)
+  C      = cycle length                                                                            (s)
+  Both L_D-A and L_D-R are forced to 0 if negative, and forced to 0 if DQ_A/DQ_R > DOWNSTREAM_QUEUE_LOST_TIME_MAX_DISTANCE_FT = 200 ft.
+
+Equations 23-31 / 23-32: DQ_A = D - Q_A;  DQ_R = D - Q_R     [ft]
+  D = distance corresponding to storage space between the two intersections     (ft, `distance_between_intersections_ft`)
+  Q_A, Q_R = average per-lane queue length on the internal link at the start of the arterial/ramp green (Eq. 23-33/23-34)   (ft)
+
+Equations 23-33 / 23-34: average per-lane downstream queue length
+  Q = (0.0107 · v_feed/N_feed - 7.96 · G_D/C - 0.082 · CG + 7.96 · G_feed/C) · L_h     [ft, floored at 0]
+  v_feed, N_feed = flow (veh/h) and lanes of the *other* upstream movement feeding the internal link (ramp feed for Eq. 23-33/arterial phase; arterial feed for Eq. 23-34/ramp phase)
+  G_feed = green interval of that feeding movement                              (s)
+  G_D    = green interval of the downstream internal through movement           (s)
+  CG     = common green (CG_UD for Eq. 23-33, CG_RD for Eq. 23-34) between the subject upstream movement and the downstream through green   (s)
+  C      = cycle length                                                         (s)
+  L_h    = average queue spacing in a stationary queue                          (ft/veh, default DEFAULT_QUEUE_SPACING_FT = 25)
+Implemented in: ramp_terminals/ramp_terminals.rs::downstream_queue_length_ft, ::downstream_queue_lost_time, ::Interchange::step_4_effective_green_adjustments (Pass 1)
+```
+
+```
+Equation 23-37 (Lost Time Adjustment No. 2 — DDI overlap phasing on a signalized off-ramp movement):
+  L_OL-DDI = (W + L - D) / (1.467 · S_f)     [s, floored at 0]
+  W   = width of the clear zone for the longest conflicting vehicle path, along the centerline of the outside lane   (ft)
+  L   = design vehicle length, typically 20                                    (ft)
+  D   = distance from the ramp movement stop bar to the conflict point         (ft)
+  S_f = free-flow (design) speed of the vehicle                                (mi/h)
+  Known deviation (already tracked): see Deviations item 2 (Chapter 34 Exhibit 34-63 implies (W + L + D); the printed -D form is implemented as-is).
+Implemented in: ramp_terminals/ramp_terminals.rs::ddi_overlap_lost_time
+```
+
+```
+Equations 23-38 / 23-39 (Lost Time Adjustment No. 3 — demand starvation on internal approaches; zero for DDIs):
+Equation 23-38:  L_DS = CG_DS - Q_Initial · h_I     [s, floored at 0]
+  CG_DS    = common green time with demand starvation potential                (s)
+  Q_Initial = queue stored at the internal approach at the start of the demand-starvation interval (Eq. 23-39)   (veh)
+  h_I      = saturation headway for the internal through approach = 3,600 / (internal saturation flow per lane)  (s)
+
+Equation 23-39:
+  Q_Initial = [ v_Ramp-L·C/(N_Ramp-L·3,600) - (CG_RD - t_L)/h_I ] + [ v_Arterial·C/(N_Arterial·3,600) - (CG_UD - t_L)/h_I ]     [veh]
+  v_Ramp-L, v_Arterial = upstream ramp-left / arterial-through flow                 (veh/h)
+  N_Ramp-L, N_Arterial = lanes for the upstream ramp-left / arterial-through movement (ln)
+  C        = cycle length                                                          (s)
+  CG_RD    = common green time between upstream ramp and downstream through green  (s, floored at t_L)
+  CG_UD    = common green time between upstream arterial through and downstream through green   (s, floored at t_L)
+  t_L      = lost time per phase (Eq. 23-24 / 23-25) of the feeding approaches      (s)
+  h_I      = saturation headway for the internal through approach                  (s)
+  Valid for CG_RD, CG_UD >= t_L (values below t_L are replaced by t_L); assumes no approach is oversaturated.
+Implemented in: ramp_terminals/ramp_terminals.rs::demand_starvation_initial_queue, ::demand_starvation_lost_time, ::Interchange::step_4_effective_green_adjustments (Pass 2)
+```
+
+```
+Equation 23-40 (Step 5 — closely spaced adjacent intersections; standalone free function, not wired into the pipeline):
+  L_D-Ui = G_Ui - 0.106·DQ_i - 5.39·CG_UiD/C     [s, floored at 0]
+  G_Ui   = green interval for upstream approach i                              (s)
+  DQ_i   = distance to the downstream queue at the start of upstream green i, from Eq. 23-31/23-34's DQ/Q construction  (ft)
+  CG_UiD = common green time between upstream approach i and the downstream through green   (s)
+  C      = cycle length                                                        (s)
+  Algebraically identical in form to Equations 23-29/23-30; the full adjacent-intersection interaction additionally subtracts 0.05 from the Chapter 19 lane-utilization factor and requires a separate Chapter 19 evaluation of the adjacent intersection (left to the analyst; see Deferred).
+Implemented in: ramp_terminals/ramp_terminals.rs::adjacent_intersection_lost_time
+```
+
 ### Step 6 — YIELD-controlled turn capacity (three regimes)
 
 The YIELD-turn capacity model combines three distinct capacity regimes into one weighted-average capacity over the cycle (Equation 23-47): the **gap-acceptance regime** `c_GA` (Equation 23-42, the Siegloch form, `yield_gap_acceptance_capacity`, a function of critical/follow-up headway and conflicting flow); the **no-conflicting-flow regime** `c_NCF` (Equation 23-44, `yield_no_conflict_capacity = 3,600/t_f`, active whenever the conflicting movement is red); and the **queue-clearance/blocked regime**, where gap acceptance cannot begin until the conflicting queue clears (`t_CQ`, via `yield_time_to_clear_queue_random` for isolated/random-arrival interchanges — Equation 23-54 — or `yield_time_to_clear_queue_coordinated` for coordinated interchanges — Equation 23-55, which the doc comment notes "reduces to Equation 23-54 when P = g/C") plus the geometric clearance time for the last queued vehicle (`yield_clearance_time`, Equation 23-56). `yield_turn_capacity` assembles all three into `c_YCT = [c_GA (g - t_CQ - t_clear) + c_NCF (C - g)] / C`, flooring the gap-acceptance interval at zero per the Chapter 34 Example Problem 6 (Exhibit 34-68) convention.
+
+```
+Regime 1 — blocked by conflicting platoon (capacity c_b = 0; proportion of time blocked):
+Equation 23-41 (iterative, time-step-based urban street procedure form):  p_b,x = t_p'/dt / C     [decimal]
+  t_p'/dt = blocked period duration expressed in time steps                    (steps)
+  dt      = time-step duration                                                 (s/step)
+  C       = cycle length                                                       (s)
+  Not computed by this stand-alone facility (no urban-street time-step engine); approximated instead by Equation 23-53 below.
+
+Equation 23-53 (stand-alone-interchange approximation of p_b,x):  p_b,x' = (t_CQ + t_clear) / C     [decimal]
+  t_CQ    = time to clear the conflicting queue (Eq. 23-54 or 23-55)            (s)
+  t_clear = time for the last queued vehicle to clear the stop-bar-to-conflict-point distance (Eq. 23-56)   (s)
+  C       = cycle length of the DDI crossover signal                           (s)
+Implemented in: ramp_terminals/ramp_terminals.rs::yield_turn_capacity (the (g - t_CQ - t_clear) term folds p_b,x' and p_GA,x into one interval rather than computing them as separate proportions)
+```
+
+```
+Regime 2 — gap acceptance in conflicting traffic:
+Equation 23-42 (Siegloch):  c_GA = (3,600/t_f) · exp( -(t_c - t_f/2) · q_c / 3,600 )     [veh/h]
+  t_c = critical headway            (s; Exhibit 23-36 defaults DDI_LEFT_CRITICAL_HEADWAY_S = 3.9 left, DDI_RIGHT_CRITICAL_HEADWAY_S = 1.8 right)
+  t_f = follow-up headway           (s; defaults DDI_LEFT_FOLLOW_UP_HEADWAY_S = 2.6 left, DDI_RIGHT_FOLLOW_UP_HEADWAY_S = 2.4 right)
+  q_c = conflicting flow rate       (veh/h)
+Implemented in: ramp_terminals/ramp_terminals.rs::yield_gap_acceptance_capacity
+
+Equation 23-43 (proportion of time in the gap-acceptance regime):  p_GA,x = (g - (t_CQ + t_clear)) / C     [decimal]
+  g   = effective green time of the DDI crossover movement          (s)
+  t_CQ, t_clear as above; C = cycle length of the crossover signal  (s)
+Implemented in: ramp_terminals/ramp_terminals.rs::yield_turn_capacity (folded into the ga_time term, floored at 0)
+```
+
+```
+Regime 3 — no conflicting flow:
+Equation 23-44:  c_NCF = 3,600 / t_f     [veh/h]
+Implemented in: ramp_terminals/ramp_terminals.rs::yield_no_conflict_capacity
+
+Equation 23-45 (proportion of time with no conflicting flow):  p_NCF,x = r/C = (C - g)/C = 1 - g/C     [decimal]
+  r = effective red time of the DDI crossover movement   (s)
+  g, C as above
+Implemented in: ramp_terminals/ramp_terminals.rs::yield_turn_capacity (folded into the (C - g) term)
+```
+
+```
+Combined YIELD-turn capacity:
+Equation 23-46 (weighted-sum form):  c_YCT = c_b·p_b,x + c_GA·p_GA,x + c_NCF·p_NCF,x     [veh/h]
+  c_b = capacity during the blocked regime = 0
+
+Equation 23-47 (simplified, implemented form):  c_YCT = (1/C) · [ c_GA·(g - t_CQ - t_clear) + c_NCF·(C - g) ]     [veh/h]
+  All symbols as defined above; the gap-acceptance interval (g - t_CQ - t_clear) is floored at 0 (Chapter 34 Example Problem 6, Exhibit 34-68 note).
+Implemented in: ramp_terminals/ramp_terminals.rs::yield_turn_capacity
+```
+
+```
+Time to clear the conflicting queue (feeds t_CQ above):
+Equation 23-54 (isolated interchange, random arrivals):  t_CQ,free = r · v_app / (s_DDI - v_app)     [s]
+  r      = duration of the effective red interval for the conflicting movement     (s)
+  v_app  = conflicting approach flow rate                                          (veh/h)
+  s_DDI  = saturation flow rate for the DDI approach                               (veh/h)
+  If s_DDI <= v_app the queue never clears; code returns r (the full red).
+Implemented in: ramp_terminals/ramp_terminals.rs::yield_time_to_clear_queue_random
+
+Equation 23-55 (coordinated interchange):  t_CQ,coord = C·(1 - P) / [ s_DDI/v_app - P·(g/C)^-1 ]     [s]
+  P = proportion of conflicting arrivals during green                              (decimal)
+  g = duration of the effective green interval for the conflicting movement        (s)
+  C = cycle length of the crossover signal                                         (s)
+  Reduces algebraically to Equation 23-54 when P = g/C. Valid only when: P·v_app·(C/g) < S_DDI (equivalently P < S_DDI·g/(v_app·C)); v_app·C <= S_DDI·g (undersaturated); and t_CQ,coord <= g.
+Implemented in: ramp_terminals/ramp_terminals.rs::yield_time_to_clear_queue_coordinated
+```
+
+```
+Equation 23-56 (clearance time for the last queued vehicle):
+  t_clear = x_clear / (1.47 · S_f,DDI)     [s]
+  x_clear   = distance between the DDI crossover stop bar and the yield conflict point   (ft)
+  S_f,DDI   = free-flow speed between the stop bar and the conflict point                (mi/h)
+  Validated against Chapter 34 Exhibit 34-67 (200 ft at 25 mi/h -> 5.5 s).
+Implemented in: ramp_terminals/ramp_terminals.rs::yield_clearance_time
+```
 
 ### Step 8 — Control delay and O-D aggregation
 
 `step_8_control_delay` dispatches per lane group on `LaneGroupControl`: `FreeFlow` groups carry zero control delay (Chapter 23 Step 6 text); `YieldControlled` groups use the Chapter 22 roundabout control-delay procedure (`common::delay::control_delay_roundabout`, Equation 22-17) per the Chapter 23 Step 8 text and Chapter 34 Example Problem 6's explicit instruction to do so, though this is flagged `VERIFY-HCM` since Exhibit 34-70's published delays are not reproducible from Equation 22-17 (see Deviations); `Signalized` groups use the standard Chapter 19 uniform delay (`uniform_delay`, Equation 19-19, with `progression_factor` for P = R_p g/C), incremental delay evaluated **on a per-lane basis** (`incremental_delay_signalized` called with `capacity/lanes`, matching the Chapter 34 interchange worksheets' per-lane saturation-flow/d2 convention rather than the lane-group capacity — a documented `VERIFY-HCM` convention choice, see Deviations), and initial-queue delay (`initial_queue_delay`). Back-of-queue and queue storage ratio reuse the Chapter 19/31 building blocks directly (`first_term_back_of_queue`, `second_term_back_of_queue`, `average_vehicle_spacing`, `queue_storage_ratio_eq`). Step 9's `od_path(OdMovement) -> Vec<InterchangeMovement>` maps each of the fourteen O-D letters to the ordered sequence of lane groups it traverses (form- and SPUI-dependent; DDI left-onto-freeway movements traverse only the external crossover since the internal crossover is free-flowing for that path), and `step_9_od_ett_and_los` sums each path's control delays, adds the Equation 23-50 extra-distance travel time (`extra_distance_travel_time`, EDTT — negative for right turns per the Exhibit 23-8 sign convention), looks up LOS via `los_signalized_interchange_od` (Exhibit 23-10, forcing a stricter LOS whenever any traversed lane group has v/c or queue-storage-ratio exceeding 1.0), and aggregates the demand-weighted interchange-level ETT and LOS (Equations 23-51/23-52).
 
+```
+Equation 23-48 (v/c ratio for lane group i, Step 7):
+  X_i = (v/c)_i = v_i / (s_i · (g_i/C)) = v_i·C / (s_i·g_i)     [unitless]
+  v_i = actual or projected demand flow rate for lane group i     (veh/h)
+  s_i = saturation flow rate for lane group i (Eq. 23-14)         (veh/h)
+  g_i = effective green time for lane group i; use g' (Eq. 23-27) if a downstream-queue lost time applies, g'' (Eq. 23-28) if a demand-starvation lost time applies   (s)
+  C   = cycle length                                              (s)
+  For YIELD-controlled turns, capacity is c_YCT (Eq. 23-47) directly rather than s_i·g_i/C.
+Implemented in: ramp_terminals/ramp_terminals.rs::Interchange::step_6_and_7_capacity_vc_queue
+```
+
+```
+Equation 23-13 / 23-49 (experienced travel time per O-D movement, identical form introduced early in the chapter and restated at Step 8):
+  ETT = Sigma d_i + Sigma EDTT     [s/veh]
+  d_i  = control delay at junction i encountered on the O-D's path through the interchange (Chapter 19 d1+d2+d3 for signalized groups, Chapter 22 Eq. 22-17 control_delay_roundabout for YIELD-controlled groups, 0 for free-flow groups)   (s/veh)
+  EDTT = extra distance travel time for any diverted path segment (Eq. 23-50)   (s/veh)
+Implemented in: ramp_terminals/ramp_terminals.rs::Interchange::step_9_od_ett_and_los
+```
+
+```
+Equation 23-50 (extra distance travel time):
+  EDTT = D_t / (1.47 · v_D) + a     [s]
+  D_t = signed distance traveled along the diverted movement (loop ramp, or extra distance from the interchange centerline for diamonds/DDIs), positive for left turns / small positive for DDI arterial crossings, negative for right turns (Exhibit 23-8 sign convention)   (ft)
+  v_D = design speed of the loop ramp or diverted movement                     (mi/h)
+  a   = deceleration/acceleration delay into and out of the turn, EDTT_LOOP_RAMP_ACCEL_DECEL_S = 5 for a loop ramp movement, 0 in the Chapter 34 diamond examples   (s)
+Implemented in: ramp_terminals/ramp_terminals.rs::extra_distance_travel_time
+```
+
+```
+Equations 23-51 / 23-52 (demand-weighted ETT aggregation; Equation 23-51 is per-approach and structurally identical to Equation 23-52, which the code implements at the interchange level):
+Equation 23-51 (approach):     ETT_A = Sigma_j(ETT_j · v_j) / Sigma_j(v_j)     [s/veh],  j in {movements on the approach}
+Equation 23-52 (interchange):  ETT_I = Sigma_k(ETT_k · v_k) / Sigma_k(v_k)     [s/veh],  k in {all movements at the interchange}
+  ETT_j / ETT_k = experienced travel time for movement j / k     (s/veh)
+  v_j / v_k     = demand flow rate for movement j / k            (veh/h)
+Implemented in: ramp_terminals/ramp_terminals.rs::Interchange::step_9_od_ett_and_los (interchange-level Eq. 23-52 only; Eq. 23-51's per-approach aggregation is not separately exposed)
+```
+
 ## Deviations (cross-referenced to `docs/hcm/VERIFICATION.md`)
 
-`docs/hcm/VERIFICATION.md` does not exist at this branch's tip; its "Chapter 23 (feat/hcm-ch23-ramp-terminals)" section, read from a later branch's history, and the inline `// VERIFY-HCM` comments already present in `ramp_terminals.rs` on this branch, record: (1) the Equation 23-17/Exhibit 23-24 lane-utilization model does not reproduce the book's own worked values (Chapter 34 Example 6: 0.497 computed vs. 0.5056 published; Example 3: 0.625 vs. 0.5551) — the printed equation is implemented as-is, with an `lane_utilization_override` input available for fixtures/callers that need the published value directly; (2) Equation 23-37 (DDI overlap lost time) is printed as `(W + L - D)/(1.467 S_f)` but Chapter 34 Exhibit 34-63 implies `(W + L + D)` (the published 6.5/4.9 s values match the `+D` form) — the printed `-D` form is implemented, and fixtures supply the published overlap lost times directly via `overlap_lost_time_s`; (3) incremental delay d2 is evaluated on a per-lane basis (`capacity/lanes`) rather than the lane-group basis Chapter 34 Example 5 (DDI) appears to use — the two conventions differ for multilane groups near saturation, and the per-lane convention is what reproduces the Chapter 34 Exhibits 34-12 through 34-15 per-lane saturation-flow/d2 tables; (4) Exhibit 34-70's published YIELD-turn delays are not reproducible from Equation 22-17 even though the capacities (Equation 23-47/`c_YCT`) all reproduce exactly — e.g., M7 computes 9.1 s vs. published 34.7 s at `c_YCT` = 795 veh/h; (5) Chapter 34 Example 5's published DDI uniform delays are internally inconsistent with Equation 19-19 under any tabulated arrival type — equation-based results are asserted instead (9 of 10 O-D LOS letters still match the published table; O-D E computes LOS C at 33.9 s/veh vs. published LOS B at 24.7 s/veh, attributed in the integration test comment to the per-lane incremental delay on the 3-lane external crossover at X = 0.84); (6) Example 5 applied the through-movement Equation 23-15 traffic-pressure form to the ramp-left movements where the left-turn form seems intended — the left-turn form is implemented as printed (approximately a 1% delta on the affected saturation flows); (7) Exhibit 34-9's common-green value (CGRD = 34) counts only the phase-3 overlap, while a literal interval-intersection of the two green windows gives 39 s (`common_green_time` implements the literal interval intersection; no effect on any published outcome since the discrepancy occurs off the critical path); (8) the shared-lane-group right-turn saturation-flow-adjustment convention flow-weights `f_R` via Equation 23-23 (matching the Exhibit 34-7 published EB EXT-TH&R values of f_R = 0.991/f_RT = 0.999), which is the convention `shared_chain`/`turn_proportions` implement.
+`docs/hcm/VERIFICATION.md` exists at this branch's tip; its "Chapter 23 (feat/hcm-ch23-ramp-terminals)" section, together with the inline `// VERIFY-HCM` comments in `ramp_terminals.rs`, records: (1) the Equation 23-17/Exhibit 23-24 lane-utilization model does not reproduce the book's own worked values (Chapter 34 Example 6: 0.497 computed vs. 0.5056 published; Example 3: 0.625 vs. 0.5551) — the printed equation is implemented as-is, with an `lane_utilization_override` input available for fixtures/callers that need the published value directly; (2) Equation 23-37 (DDI overlap lost time) is printed as `(W + L - D)/(1.467 S_f)` but Chapter 34 Exhibit 34-63 implies `(W + L + D)` (the published 6.5/4.9 s values match the `+D` form) — the printed `-D` form is implemented, and fixtures supply the published overlap lost times directly via `overlap_lost_time_s`; (3) incremental delay d2 is evaluated on a per-lane basis (`capacity/lanes`) rather than the lane-group basis Chapter 34 Example 5 (DDI) appears to use — the two conventions differ for multilane groups near saturation, and the per-lane convention is what reproduces the Chapter 34 Exhibits 34-12 through 34-15 per-lane saturation-flow/d2 tables; (4) Exhibit 34-70's published YIELD-turn delays are not reproducible from Equation 22-17 even though the capacities (Equation 23-47/`c_YCT`) all reproduce exactly — e.g., M7 computes 9.1 s vs. published 34.7 s at `c_YCT` = 795 veh/h; (5) Chapter 34 Example 5's published DDI uniform delays are internally inconsistent with Equation 19-19 under any tabulated arrival type — equation-based results are asserted instead (9 of 10 O-D LOS letters still match the published table; O-D E computes LOS C at 33.9 s/veh vs. published LOS B at 24.7 s/veh, attributed in the integration test comment to the per-lane incremental delay on the 3-lane external crossover at X = 0.84); (6) Example 5 applied the through-movement Equation 23-15 traffic-pressure form to the ramp-left movements where the left-turn form seems intended — the left-turn form is implemented as printed (approximately a 1% delta on the affected saturation flows); (7) Exhibit 34-9's common-green value (CGRD = 34) counts only the phase-3 overlap, while a literal interval-intersection of the two green windows gives 39 s (`common_green_time` implements the literal interval intersection; no effect on any published outcome since the discrepancy occurs off the critical path); (8) the shared-lane-group right-turn saturation-flow-adjustment convention flow-weights `f_R` via Equation 23-23 (matching the Exhibit 34-7 published EB EXT-TH&R values of f_R = 0.991/f_RT = 0.999), which is the convention `shared_chain`/`turn_proportions` implement.
 
 ## Validation
 
 Fixtures live under `tests/ExampleCases/hcm/RampTerminals/` as `case1.json` and `case2.json`, exercised by `tests/chapter23_integration.rs` and mirrored by `tests/test_chapter23_integration.py`. `case1.json` reproduces Chapter 34, Example Problem 1 (conventional diamond interchange, published O-D results in Exhibit 34-16): `test_case1_diamond_lane_groups` and `test_case1_diamond_od_results` assert, for all ten nonzero O-D movements (A through J), demand at ±1.0 veh/h, control delay at ±1.0 s/veh, EDTT at ±0.1 s/veh, ETT at ±1.0 s/veh, and LOS exactly, plus that no O-D has v/c or queue-storage-ratio exceeding 1.0; the interchange-level ETT is asserted at 52.4 s/veh ±1.0 against the Exhibit 34-16 totals row, with LOS C exactly. `case2.json` reproduces Chapter 34, Example Problem 5 (DDI with signal control, published results in Exhibits 34-62/34-63/34-65): `test_case2_ddi_results` asserts adjusted saturation flows against the Exhibit 34-62 lane-group totals (tolerances 5-55 veh/h/ln depending on lane group, the external crossovers carrying the widest tolerance due to the documented f_LU-rounding and traffic-pressure-form deviations above), effective green times against Exhibit 34-63 (±0.1 s, with several lane groups computing slightly above the book's rounded-down published values), zero demand-starvation lost time for the DDI internal through movement, and O-D ETT/LOS against the equation-based expectations (±0.5 s/veh) with the published Exhibit 34-65 values recorded inline in code comments for every O-D — nine of ten O-D LOS letters match the published table exactly, with O-D E being the one documented exception (see Deviations). The demand-weighted interchange ETT is asserted at 34.9 s/veh ±0.5 with LOS C. `test_serde_round_trip` confirms a fully analyzed `Interchange` round-trips through JSON with results intact.
 
-Unit tests in `src/hcm/chapter23/tests.rs` (26 tests) spot-check individual equations and exhibits directly: the three LOS tables (`test_exhibit_23_10_signalized_interchange_los`, `test_exhibit_23_13_alternative_intersection_los`, `test_exhibit_23_14_roundabout_interchange_los`); the traffic-pressure and turn-radius factor tables (`test_exhibit_23_23_traffic_pressure`, `test_exhibit_23_27_turn_radius`, `test_turn_radius_adjustments`); the lane-utilization equations (`test_equation_23_16_lane_utilization_factor`, `test_equation_23_17_diamond_lane_utilization`, `test_exhibit_23_24_three_lane_model`, `test_exhibit_23_26_ddi_lane_utilization`); the common-green helper (`test_exhibit_34_9_common_green`, exercising the Exhibit 34-9 discrepancy noted above); the four Step 4 lost-time mechanisms individually (`test_equation_23_34_downstream_queue_length`, `test_equation_23_30_downstream_queue_lost_time`, `test_equations_23_38_39_demand_starvation`, `test_adjusted_lost_time_and_effective_green`, `test_equation_23_37_ddi_overlap_lost_time`); the YIELD three-regime capacity chain (`test_exhibit_34_67_blocked_regime`, `test_equation_23_55_coordinated_reduces_to_random`, `test_exhibit_34_68_gap_acceptance_capacity`, `test_equation_23_47_yield_capacity`); the EDTT equation (`test_equation_23_50_edtt`); the O-D <-> turning-movement conversion (`test_exhibit_34_176_diamond_turning_movements`, `test_od_turning_movement_round_trip` — round-tripping `od_from_turning_movements`/`turning_movements_from_od` for multiple forms); the PHF adjustment and roundabout-interchange O-D movement table (`test_exhibit_34_5_phf_adjustment`, `test_exhibit_34_161_roundabout_movements`); and pipeline-level smoke/regression tests (`test_step_1_lane_group_demands`, `test_full_pipeline_smoke`, `test_step_4_demand_starvation_engaged`).
+Unit tests in `src/hcm/ramp_terminals/tests.rs` (26 tests) spot-check individual equations and exhibits directly: the three LOS tables (`test_exhibit_23_10_signalized_interchange_los`, `test_exhibit_23_13_alternative_intersection_los`, `test_exhibit_23_14_roundabout_interchange_los`); the traffic-pressure and turn-radius factor tables (`test_exhibit_23_23_traffic_pressure`, `test_exhibit_23_27_turn_radius`, `test_turn_radius_adjustments`); the lane-utilization equations (`test_equation_23_16_lane_utilization_factor`, `test_equation_23_17_diamond_lane_utilization`, `test_exhibit_23_24_three_lane_model`, `test_exhibit_23_26_ddi_lane_utilization`); the common-green helper (`test_exhibit_34_9_common_green`, exercising the Exhibit 34-9 discrepancy noted above); the four Step 4 lost-time mechanisms individually (`test_equation_23_34_downstream_queue_length`, `test_equation_23_30_downstream_queue_lost_time`, `test_equations_23_38_39_demand_starvation`, `test_adjusted_lost_time_and_effective_green`, `test_equation_23_37_ddi_overlap_lost_time`); the YIELD three-regime capacity chain (`test_exhibit_34_67_blocked_regime`, `test_equation_23_55_coordinated_reduces_to_random`, `test_exhibit_34_68_gap_acceptance_capacity`, `test_equation_23_47_yield_capacity`); the EDTT equation (`test_equation_23_50_edtt`); the O-D <-> turning-movement conversion (`test_exhibit_34_176_diamond_turning_movements`, `test_od_turning_movement_round_trip` — round-tripping `od_from_turning_movements`/`turning_movements_from_od` for multiple forms); the PHF adjustment and roundabout-interchange O-D movement table (`test_exhibit_34_5_phf_adjustment`, `test_exhibit_34_161_roundabout_movements`); and pipeline-level smoke/regression tests (`test_step_1_lane_group_demands`, `test_full_pipeline_smoke`, `test_step_4_demand_starvation_engaged`).
 
 `tests/test_chapter23_integration.py` exercises the PyO3 bindings against both fixtures: `test_od_results`, `test_interchange_ett_and_los`, `test_lane_group_results`, `test_json_round_trip` for the diamond (`case1.json`), and `test_od_los`, `test_free_flow_right_turns`, `test_interchange_ett_and_los`, `test_ddi_saturation_flows` for the DDI (`case2.json`).
 

--- a/docs/hcm/procedures/chapter24.md
+++ b/docs/hcm/procedures/chapter24.md
@@ -1,6 +1,6 @@
 # HCM Chapter 24 — Off-Street Pedestrian and Bicycle Facilities
 
-This document walks through the Rust translation of HCM 7th Edition Chapter 24, which covers three distinct methodologies for off-street facilities that serve only nonmotorized traffic: exclusive pedestrian facilities (walkways, cross-flow areas, stairways), pedestrians on shared-use paths, and bicyclists on shared-use or exclusive off-street bicycle facilities. All three live in the single file `src/hcm/chapter24/offstreet_pedbike.rs`; there is no separate `exhibits.rs` for this chapter, and the exhibit tables (Exhibits 24-1 through 24-6, 24-14 through 24-16) are transcribed inline as LOS-lookup functions and constant arrays alongside the equation code they support. Cross-references are to HCM Chapter 35 ("Pedestrians and Bicycles: Supplemental") for the worked example problems, and to Hummer et al.'s FHWA shared-use-path research (HCM Chapter 24 Ref. 5) for the numerical-integration parameters of the bicycle methodology.
+This document walks through the Rust translation of HCM 7th Edition Chapter 24, which covers three distinct methodologies for off-street facilities that serve only nonmotorized traffic: exclusive pedestrian facilities (walkways, cross-flow areas, stairways), pedestrians on shared-use paths, and bicyclists on shared-use or exclusive off-street bicycle facilities. All three live in the single file `src/hcm/offstreet_pedbike/offstreet_pedbike.rs`; there is no separate `exhibits.rs` for this chapter, and the exhibit tables (Exhibits 24-1 through 24-6, 24-14 through 24-16) are transcribed inline as LOS-lookup functions and constant arrays alongside the equation code they support. Cross-references are to HCM Chapter 35 ("Pedestrians and Bicycles: Supplemental") for the worked example problems, and to Hummer et al.'s FHWA shared-use-path research (HCM Chapter 24 Ref. 5) for the numerical-integration parameters of the bicycle methodology.
 
 ## Step-by-step walkthrough
 
@@ -16,6 +16,77 @@ This document walks through the Rust translation of HCM 7th Edition Chapter 24, 
 
 `ExclusivePedestrianFacility::analyze()` runs all five steps in order. Cross-flow areas use the Exhibit 24-1/24-2 tables but with a distinct LOS E-F space threshold (`CROSS_FLOW_LOS_F_SPACE_THRESHOLD` = 13 ft²/p, note c of both exhibits) and a capacity that is the sum of both crossing flows (17 p/min/ft).
 
+#### Equations (exclusive pedestrian facilities)
+
+```
+Equation 24-1:  W_E = W_T − W_O     [ft]
+  W_T = total walkway width                                          (ft)
+  W_O = fixed-object width allowance (Exhibit 24-9; for stairways includes a 2.5-ft reverse-flow lane) (ft)
+Implemented in: offstreet_pedbike/offstreet_pedbike.rs::determine_effective_walkway_width
+```
+
+```
+Equation 24-2:  v_15 = v_h / (4 · PHF)     [p]
+Equation 24-3:  v_p = v_15 / (15 · W_E)     [p/ft/min]
+  v_15 = pedestrian volume during the peak 15 min                                (p)
+  v_h  = pedestrian demand during the analysis hour                              (p/h)
+  PHF  = peak hour factor, default 0.85 (DEFAULT_PHF)                            (decimal)
+  v_p  = pedestrian flow per unit width                                          (p/ft/min)
+  W_E  = effective walkway width (Equation 24-1)                                 (ft)
+  If a field-measured peak 15-min volume is supplied directly, it is used in place of v_15 and Equation 24-2 is bypassed.
+Implemented in: offstreet_pedbike/offstreet_pedbike.rs::calculate_pedestrian_flow_rate
+```
+
+```
+Equation 24-4:  A_p = S_p / v_p     [ft²/p]
+  A_p = average pedestrian space                                                 (ft²/p)
+  S_p = pedestrian speed, default 300 ft/min (DEFAULT_PEDESTRIAN_SPEED_FT_MIN)    (ft/min)
+  v_p = pedestrian flow per unit width (Equation 24-3)                           (p/ft/min)
+Implemented in: offstreet_pedbike/offstreet_pedbike.rs::calculate_average_pedestrian_space
+```
+
+```
+Exhibit 24-1 (Random-Flow LOS Criteria for Walkways): LOS from average pedestrian space A_p (ft²/p)
+  A_p > 60          -> LOS A   (v_p ≤ 5 p/min/ft,   v/c ≤ 0.21)
+  60 ≥ A_p > 40     -> LOS B   (v_p >5-7,            v/c >0.21-0.31)
+  40 ≥ A_p > 24     -> LOS C   (v_p >7-10,           v/c >0.31-0.44)
+  24 ≥ A_p > 15     -> LOS D   (v_p >10-15,          v/c >0.44-0.65)
+  15 ≥ A_p > 8      -> LOS E   (v_p >15-23,          v/c >0.65-1.00)
+  A_p ≤ 8           -> LOS F   (variable)
+  Note c (cross-flow): the LOS E-F space threshold becomes CROSS_FLOW_LOS_F_SPACE_THRESHOLD = 13 ft²/p instead of 8 ft²/p.
+Implemented in: offstreet_pedbike/offstreet_pedbike.rs::walkway_random_flow_los
+```
+
+```
+Exhibit 24-2 (Platoon-Adjusted LOS Criteria for Walkways): LOS from average pedestrian space A_p (ft²/p), flow rate averaged over 5 min
+  A_p > 530         -> LOS A   (flow ≤0.5 p/min/ft)
+  530 ≥ A_p > 90    -> LOS B   (>0.5-3)
+  90 ≥ A_p > 40     -> LOS C   (>3-6)
+  40 ≥ A_p > 23     -> LOS D   (>6-11)
+  23 ≥ A_p > 11     -> LOS E   (>11-18)
+  A_p ≤ 11          -> LOS F   (>18)
+  Note c (cross-flow): the LOS E-F space threshold becomes 13 ft²/p (CROSS_FLOW_LOS_F_SPACE_THRESHOLD).
+Implemented in: offstreet_pedbike/offstreet_pedbike.rs::walkway_platoon_flow_los
+```
+
+```
+Exhibit 24-3 (LOS Criteria for Stairways): LOS from average pedestrian space A_p (ft²/p)
+  A_p > 20          -> LOS A   (v_p ≤ 5 p/min/ft,   v/c ≤ 0.33)
+  20 ≥ A_p > 17     -> LOS B   (v_p >5-6,            v/c >0.33-0.41)
+  17 ≥ A_p > 12     -> LOS C   (v_p >6-8,            v/c >0.41-0.53)
+  12 ≥ A_p > 8      -> LOS D   (v_p >8-11,           v/c >0.53-0.73)
+  8 ≥ A_p > 5       -> LOS E   (v_p >11-15,          v/c >0.73-1.00)
+  A_p ≤ 5           -> LOS F   (variable)
+Implemented in: offstreet_pedbike/offstreet_pedbike.rs::stairway_los
+```
+
+```
+Volume-to-capacity ratio (Chapter 24, Step 5; not a numbered HCM equation):  v/c = v_p / c
+  v_p = pedestrian flow per unit width (Equation 24-3)                           (p/ft/min)
+  c   = facility capacity (p/min/ft): CAPACITY_WALKWAY_RANDOM = 23, CAPACITY_WALKWAY_PLATOON = 18, CAPACITY_CROSS_FLOW = 17 (sum of both crossing flows), CAPACITY_STAIRWAY = 15 (ascending direction)
+Implemented in: offstreet_pedbike/offstreet_pedbike.rs::calculate_volume_to_capacity_ratio
+```
+
 ### 2. Pedestrians on shared-use paths (`SharedUsePathPedestrian`, Exhibit 24-4)
 
 | Step | Equation | Rust function | Inputs (units) | Outputs (units) |
@@ -24,6 +95,35 @@ This document walks through the Rust translation of HCM 7th Edition Chapter 24, 
 | LOS | Exhibit 24-4 | `determine_los` (delegates to `shared_use_path_pedestrian_los`) | `total_events_per_hour` (F, events/h) | `los: LevelOfService` |
 
 For a one-way path, meeting events are zero (`F_m = 0`, since there is no opposing bicycle flow); `test_one_way_path_has_no_meeting_events` in `tests.rs` confirms this. `analyze()` runs both steps in order.
+
+#### Equations (pedestrians on shared-use paths)
+
+```
+Equation 24-5:  F_p = (Q_sb / PHF) · (1 − S_p/S_b)     [events/h]
+Equation 24-6:  F_m = (Q_ob / PHF) · (1 + S_p/S_b)     [events/h]
+Equation 24-7:  F = F_p + 0.5 · F_m                     [events/h]
+  F_p  = number of passing events                                               (events/h)
+  F_m  = number of meeting events                                               (events/h)
+  F    = total (weighted) number of events                                      (events/h)
+  Q_sb = bicycle demand in the same direction as the pedestrian                  (bicycles/h)
+  Q_ob = bicycle demand in the opposing direction                                (bicycles/h)
+  PHF  = peak hour factor, default 0.85 (DEFAULT_PHF)                           (decimal)
+  S_p  = mean pedestrian speed, default 3.4 mi/h                                (mi/h; any unit consistent with S_b)
+  S_b  = mean bicycle speed, default 12.8 mi/h                                  (mi/h; any unit consistent with S_p)
+  If field-measured peak 15-min directional bicycle flow rates are known, they substitute directly for the Q_sb/PHF and Q_ob/PHF terms. For one-way paths, F_m = 0 (no opposing bicycle flow).
+Implemented in: offstreet_pedbike/offstreet_pedbike.rs::calculate_bicycle_passing_and_meeting_events
+```
+
+```
+Exhibit 24-4 (Pedestrian LOS Criteria for Shared-Use Paths): LOS from the total weighted event rate F (events/h)
+  F ≤ 38            -> LOS A
+  38 < F ≤ 60       -> LOS B
+  60 < F ≤ 103      -> LOS C
+  103 < F ≤ 144     -> LOS D
+  144 < F ≤ 180     -> LOS E
+  F > 180           -> LOS F
+Implemented in: offstreet_pedbike/offstreet_pedbike.rs::shared_use_path_pedestrian_los
+```
 
 ### 3. Bicyclists on shared-use/exclusive off-street bicycle facilities (`OffStreetBicycleFacility`, Exhibit 24-11, BLOS)
 
@@ -40,25 +140,223 @@ For a one-way path, meeting events are zero (`F_m = 0`, since there is no opposi
 
 `OffStreetBicycleFacility::analyze()` runs Steps 1-8 in order. For an exclusive bicycle facility, set the bicycle mode split to 1.0 and all others to zero (`test_exclusive_bicycle_facility_zero_nonbike_modes` in `tests.rs` exercises this). `PathUserMode` (`Bicycle`, `Pedestrian`, `Runner`, `InlineSkater`, `ChildBicyclist`) indexes every per-mode array (`REQUIRED_PASSING_DISTANCE_FT`, `TWO_LANE_BLOCKING_FREQUENCY`, `DEFAULT_PATH_USER_GROUPS`) consistently.
 
+#### Equations (Steps 1-4: flow rates, active passings, meetings, effective lanes)
+
+```
+Equation 24-8:  q_i = (Q_T · p_i) / PHF     [modal users/h]
+  q_i  = hourly directional path flow rate for user group i                     (modal users/h)
+  Q_T  = total hourly directional path demand                                   (path users/h)
+  p_i  = path mode split for user group i (Exhibit 24-6 defaults, DEFAULT_PATH_USER_GROUPS) (decimal)
+  PHF  = peak hour factor, default 0.85 (DEFAULT_PHF)                          (decimal)
+  Computed separately for the subject direction (Q_T from subject_demand, or two_way_demand · directional_split) and the opposing direction (zero when is_one_way).
+Implemented in: offstreet_pedbike/offstreet_pedbike.rs::calculate_directional_flow_rates
+```
+
+```
+Equation 24-9:   P(v_i) = P[v_i < U·(1 − x/L)]
+Equation 24-10:  P(v_i) = 0.5·[F(x − dx) + F(x)]
+Equation 24-11:  A_i = Σ_j P(v_i) · (q_i/μ_i) · (1/t) · dx_j     [passings/min]
+Equation 24-12:  A_T = Σ_i A_i                                    [passings/min]
+  P(v_i) = probability that the average bicyclist passes a mode-i user present at the start of the segment (decimal)
+  v_i    = speed of a path user of mode i, normally distributed with mean μ_i and std dev σ_i (mi/h)
+  U      = speed of the average bicyclist (average_speed of the Bicycle mode group)              (mi/h)
+  x      = distance from the average bicyclist to the user                     (mi)
+  L      = length of the path segment, segment_length                          (mi)
+  F(x)   = normal_cdf(U·(1 − x/L), μ_i, σ_i), the standard-normal CDF of the mode-i speed distribution
+  dx_j   = length of discrete integration piece j; L is divided into n = round(L / PATH_INTEGRATION_STEP_MI) pieces of size dx = L/n, PATH_INTEGRATION_STEP_MI = 0.01 mi (mi)
+  q_i    = directional hourly flow rate of mode i (Equation 24-8)              (modal users/h)
+  μ_i    = average speed of mode i                                              (mi/h)
+  t      = path segment travel time for the average bicyclist = (L/U) · 60      (min)
+  A_i    = expected active passings per minute of mode i by the average bicyclist (passings/min)
+  A_T    = total expected active passings per minute during the peak 15 min     (passings/min)
+Implemented in: offstreet_pedbike/offstreet_pedbike.rs::calculate_active_passings_per_minute
+```
+
+```
+Equation 24-13:  M_1 = (U/60) · Σ_i (q_i/μ_i)                      [meetings/min]
+Equation 24-14:  P(v_O,i) = P(v_i > X·U/L)
+Equation 24-15:  M_2,i = Σ_j P(v_O,i) · (q_i/μ_i) · (1/t) · dx_j    [meetings/min]
+Equation 24-16:  M_T = M_1 + Σ_i M_2,i                              [meetings/min]
+  M_1      = meetings per minute of opposing-direction users already on the segment when the average bicyclist enters (meetings/min)
+  U        = speed of the average bicyclist                                    (mi/h)
+  q_i      = opposing-direction hourly flow rate of mode i (Equation 24-8)      (modal users/h)
+  μ_i      = average speed of mode i                                            (mi/h)
+  P(v_O,i) = probability of meeting an opposing user of mode i located beyond the segment; computed as 1 − normal_cdf(X·U/L, μ_i, σ_i) (decimal)
+  X        = distance of the opposing user beyond the end of the segment; the supply length x* is set equal to L, which captures ≥99% of meetings (mi)
+  L        = segment_length                                                     (mi)
+  t        = path segment travel time for the average bicyclist                 (min)
+  dx_j     = discrete integration piece length, same discretization as Equation 24-11 (mi)
+  M_2,i    = expected meetings per minute with mode-i users beyond the segment at entry (meetings/min)
+  M_T      = total expected meetings per minute during the peak 15 min; M_T = 0 for one-way paths (meetings/min)
+Implemented in: offstreet_pedbike/offstreet_pedbike.rs::calculate_meetings_per_minute
+```
+
+```
+Exhibit 24-14 (Effective Lanes by Path Width): lanes from path width W (ft)
+  8.0 ft ≤ W ≤ 10.5 ft    -> 2 lanes
+  11.0 ft ≤ W ≤ 14.5 ft   -> 3 lanes
+  15.0 ft ≤ W ≤ 20.0 ft   -> 4 lanes
+  The exhibit is undefined at W < 8, 10.5 < W < 11, 14.5 < W < 15, and W > 20 ft; the implemented banding is W < 11 -> 2, W < 15 -> 3, else -> 4 (see Deviations item 3 below).
+Implemented in: offstreet_pedbike/offstreet_pedbike.rs::determine_number_of_effective_lanes
+```
+
 ### The 25-modal-pair delayed-passing model (Step 5, two-lane paths)
 
 For a two-lane path, `calculate_probability_of_delayed_passing` computes the blocked-lane probability for each of the 5 path-user modes in the subject direction (`probability_blocked(passing_distance_ft, density)`, Equation 24-17, a Poisson model `P_n,i = 1 - e^{-p_i k_i}`) and each of the 5 modes in the opposing direction, then evaluates `delayed_passing_probability_two_lane(p_ns, p_no)` (Equation 24-20, the closed-form solution of Equations 24-18/24-19) for every one of the resulting 5x5 = 25 (subject-mode, opposing-mode) pairs, combining them via Equation 24-33 (`P_Tds = 1 - Prod_m(1 - P_m,ds)`) as a nested nested loop over `i in 0..NUM_PATH_MODES` and `j in 0..NUM_PATH_MODES`. A documented `VERIFY-HCM` note on this function states that for each pair, the required passing distance of the *subject* (passed) mode `p_i` is applied to *both* the subject and opposing blocked-lane probabilities (rather than each direction using its own mode's passing distance) — this reproduces HCM Chapter 35 Example Problem 2 exactly (`P_n,ped` = 0.1908 computed with a 100-ft passing distance, and `P_Tds` = 0.8334), but the printed text of Equation 24-17 is ambiguous on which mode's distance governs each side of a cross-mode pair.
 
+```
+Equation 24-17 (Poisson blocked-lane probability, general form — applies to both the subject and opposing directions):
+  P_n,i = 1 − e^(−p_i · k_i)
+  P_n,i = probability that the passing section is blocked by mode i                        (decimal)
+  p_i   = distance required to pass mode i (Exhibit 24-15, REQUIRED_PASSING_DISTANCE_FT[i]; converted ft -> mi by /5280 in code) (mi)
+  k_i   = density of users of mode i = q_i / μ_i                                            (users/mi)
+Implemented in: offstreet_pedbike/offstreet_pedbike.rs::probability_blocked
+```
+
+```
+Two-lane paths — Equations 24-18/24-19 (simultaneous) and 24-20 (closed-form solution, the form actually used by the code):
+Equation 24-18:  P_ds = P_no·P_ns + P_no·(1 − P_ns)·(1 − P_do)
+Equation 24-19:  P_do = P_no·P_ns + P_ns·(1 − P_no)·(1 − P_ds)
+Equation 24-20:  P_ds = [P_no·P_ns + P_no·(1 − P_ns)²] / [1 − P_no·P_ns·(1 − P_no)·(1 − P_ns)]
+  P_ds = probability of delayed passing in the subject direction                            (decimal)
+  P_do = probability of delayed passing in the opposing direction                           (decimal)
+  P_ns = probability of a blocked lane in the subject direction (Equation 24-17)             (decimal)
+  P_no = probability of a blocked lane in the opposing direction (Equation 24-17)            (decimal)
+  Equation 24-20 solves the simultaneous Equations 24-18/24-19 directly for P_ds without needing P_do.
+Implemented in: offstreet_pedbike/offstreet_pedbike.rs::delayed_passing_probability_two_lane
+```
+
+```
+Modal-pair table structure (two-lane path): the methodology evaluates every one of NUM_PATH_MODES × NUM_PATH_MODES = 5 × 5 = 25 (subject-mode i, opposing-mode j) pairs over the 5 PathUserMode values (Bicycle, Pedestrian, Runner, InlineSkater, ChildBicyclist) in each direction, then combines them with Equation 24-33:
+  product = 1
+  for i in 0..NUM_PATH_MODES:                     # subject-direction mode being passed
+    p_i  = REQUIRED_PASSING_DISTANCE_FT[i]
+    P_ns = probability_blocked(p_i, k_s[i])        # Equation 24-17, subject direction
+    for j in 0..NUM_PATH_MODES:                    # opposing-direction mode
+      P_no   = probability_blocked(p_i, k_o[j])    # Equation 24-17, opposing direction — uses the subject mode's p_i for both sides (see Deviations item 1 below)
+      P_m,ds = delayed_passing_probability_two_lane(P_ns, P_no)   # Equation 24-20
+      product *= (1 − P_m,ds)
+  P_Tds = 1 − product                              # Equation 24-33
+
+Equation 24-33 (combination across the 25 modal pairs — applies only to the two-lane branch; the three- and four-lane branches instead aggregate over modes directly, per mode, before Equations 24-23/24-24 or the four-lane form, and so do not perform a further pairwise product):
+  P_Tds = 1 − Π_m (1 − P_m,ds)
+  P_Tds  = total probability of delayed passing across all 25 modal pairs (two-lane paths only) (decimal)
+  P_m,ds = probability of delayed passing for modal pair m (Equation 24-20)                   (decimal)
+  Π_m    = product taken over all 25 modal pairs m
+Implemented in: offstreet_pedbike/offstreet_pedbike.rs::calculate_probability_of_delayed_passing
+```
+
 For three-lane paths, Equations 24-21 through 24-32 are implemented as mode-aggregated single-lane-blockage (`p_ns`, `p_no`) and double-lane-blockage (`p_bs`, `p_bo`) sums (using `TWO_LANE_BLOCKING_FREQUENCY`, Exhibit 24-16, as the "frequency of blocking of two lanes" weight per mode) substituted into Equation 24-23 (a correlation term `d`) and Equation 24-24 (the combined `P_ds`, clamped to `[0,1]`). A second documented `VERIFY-HCM` note states that Equations 24-29/24-30 as printed read `1 - e^{p_i k} - P_b` (a positive exponent), which is implemented instead as `1 - e^{-p_i k} - P_b` (at-least-one-lane blockage probability minus the two-lane blockage probability) — the positive-exponent form as printed would not correspond to any sensible probability decomposition, and no published worked example exists for three-lane paths to confirm the correct sign independently. Four-lane paths are treated as operating like a divided four-lane highway, where `P_ds` simply equals the probability that both subject-direction lanes are blocked, `P_bs` (Equations 24-25/24-27, no opposing-direction interaction).
+
+```
+Three-lane paths — Equations 24-21/24-22 (simultaneous, mode-aggregated) and 24-23/24-24 (closed-form solution used by the code):
+Equation 24-21:  P_ds = P_ns·[P_bo + P_no·(1 − P_do)] + P_bs
+Equation 24-22:  P_do = P_no·[P_bs + P_ns·(1 − P_ds)] + P_bo
+Equation 24-23:  D = [(P_bs − P_bo) + (P_ns·P_bo − P_no·P_bs)] / (1 − P_ns·P_no)
+Equation 24-24:  P_ds = [P_ns·(P_bo + P_no·(1 + D)) + P_bs] / (1 + P_ns·P_no)
+  P_ds, P_do = probability of delayed passing in the subject/opposing direction (a single aggregate value, not per modal pair) (decimal)
+  P_ns, P_no = mode-aggregated probability that a single lane is blocked in the subject/opposing direction (Equations 24-31/24-32) (decimal)
+  P_bs, P_bo = mode-aggregated probability that both lanes are blocked in the subject/opposing direction (Equations 24-27/24-28) (decimal)
+  D          = P_ds − P_do, the correlation term obtained by solving the simultaneous Equations 24-21/24-22               (decimal)
+  Equation 24-24 substitutes D (Equation 24-23) back into Equation 24-21 for a closed form; the code clamps the result to [0,1].
+Implemented in: offstreet_pedbike/offstreet_pedbike.rs::calculate_probability_of_delayed_passing (three-lane branch)
+```
+
+```
+Equations 24-25/24-26 (per-mode two-lane blockage) and 24-27/24-28 (summed over the 5 modes):
+Equation 24-25:  P_bs,i = F_i · P_ns,i
+Equation 24-26:  P_bo,i = F_i · P_no,i
+Equation 24-27:  P_bs = Σ_i P_bs,i
+Equation 24-28:  P_bo = Σ_i P_bo,i
+  P_bs,i, P_bo,i = probability that a mode-i user blocks two lanes in the subject/opposing direction              (decimal)
+  F_i            = frequency with which mode i blocks two lanes (Exhibit 24-16, TWO_LANE_BLOCKING_FREQUENCY[i])   (decimal)
+  P_ns,i, P_no,i = probability of at least one blocked lane for mode i, per mode (Equation 24-17, before summing) (decimal)
+  P_bs, P_bo     = total two-lane blockage probability, subject/opposing direction, summed over the 5 modes       (decimal)
+Implemented in: offstreet_pedbike/offstreet_pedbike.rs::calculate_probability_of_delayed_passing (three-lane and four-lane branches)
+```
+
+```
+Equations 24-29/24-30 (per-mode single-lane-only blockage) and 24-31/24-32 (summed over the 5 modes):
+Equation 24-29 (as printed in HCM):     P_ns,i = 1 − e^(p_i·k_s,i) − P_bs,i
+Equation 24-30 (as printed in HCM):     P_no,i = 1 − e^(p_i·k_o,i) − P_bo,i
+Equation 24-29 (as implemented, code): P_ns,i = 1 − e^(−p_i·k_s,i) − P_bs,i
+Equation 24-30 (as implemented, code): P_no,i = 1 − e^(−p_i·k_o,i) − P_bo,i
+Equation 24-31:  P_ns = Σ_i P_ns,i
+Equation 24-32:  P_no = Σ_i P_no,i
+  P_ns,i, P_no,i = probability that mode i blocks exactly a single lane in the subject/opposing direction   (decimal)
+  p_i            = required passing distance for mode i (Exhibit 24-15, REQUIRED_PASSING_DISTANCE_FT[i])    (mi)
+  k_s,i, k_o,i   = density of mode-i users in the subject/opposing direction                                 (users/mi)
+  P_bs,i, P_bo,i = two-lane blockage probability for mode i (Equations 24-25/24-26)                          (decimal)
+  (see Deviations item 2 below for the sign convention: the code uses the negative-exponent implemented form, since the printed positive exponent does not reduce to a sensible at-least-one-lane-blocked-minus-two-lane-blocked decomposition of Equation 24-17's e^(−p_i·k) form)
+Implemented in: offstreet_pedbike/offstreet_pedbike.rs::calculate_probability_of_delayed_passing (three-lane branch)
+```
+
+```
+Four-lane paths — Equations 24-25 and 24-27 (no opposing-direction interaction; the path operates like a divided four-lane highway):
+  P_ds = P_bs = Σ_i F_i · P_ns,i
+  P_ds   = probability of delayed passing, equal to the probability that both subject-direction lanes are blocked (decimal)
+  F_i    = frequency with which mode i blocks two lanes (Exhibit 24-16, TWO_LANE_BLOCKING_FREQUENCY[i])          (decimal)
+  P_ns,i = probability of at least one blocked lane for mode i in the subject direction (Equation 24-17)          (decimal)
+  No passing occurs in the leftmost (opposing-direction) lanes, so P_ds is independent of opposing-direction users.
+Implemented in: offstreet_pedbike/offstreet_pedbike.rs::calculate_probability_of_delayed_passing (four-lane branch)
+```
+
+```
+Equation 24-34:  DP_m = A_T · P_Tds · PHF     [delayed passings/min]
+  DP_m  = delayed passings per minute                                                       (delayed passings/min)
+  A_T   = total active passings per minute (Equation 24-12)                                 (passings/min)
+  P_Tds = total probability of delayed passing (Equation 24-33 for two lanes; the aggregate P_ds for three/four lanes) (decimal)
+  PHF   = peak hour factor, default 0.85; converts A_T from peak-15-min to hourly conditions, since the delayed-passing factor was calibrated on hourly volumes (decimal)
+Implemented in: offstreet_pedbike/offstreet_pedbike.rs::calculate_delayed_passings_per_minute
+```
 
 ### The events-based BLOS chain and shared-use-path ped LOS
 
 Both the pedestrian and bicycle methodologies in this chapter are ultimately events-based: shared-use-path pedestrian LOS (Exhibit 24-4) is driven by a single combined passing-plus-half-meeting event rate `F` (Equation 24-7), while bicycle BLOS (Equation 24-35) is driven by a weighted event rate `E = M_T + 10 A_T` (meetings per minute plus ten times active passings per minute, reflecting that active passing maneuvers are a much stronger disamenity than simple meetings) combined with path-width, centerline, and delayed-passing terms. The `normal_cdf` helper (built on an `erf` approximation per Abramowitz & Stegun 7.1.26, |error| < 1.5e-7) underlies the Equations 24-9/24-10 speed-distribution integration used by both the active-passings and meetings-per-minute calculations, discretized at `PATH_INTEGRATION_STEP_MI` = 0.01 mi per the Chapter 24 research-finding note that this step size is appropriate for Equation 24-11 and subsequent equations.
 
+#### Equations (Steps 7-8: BLOS score and low-volume adjustment)
+
+```
+Equation 24-35:  BLOS = 5.446 − 0.00809·E − 15.86·RW − 0.287·CL − DP
+  BLOS = bicycle level-of-service score                                                     (decimal)
+  E    = weighted events per minute = M_T + 10·A_T                                           (events/min)
+  RW   = reciprocal of path width = 1 / path_width                                           (1/ft)
+  CL   = 1 if the path has a centerline stripe, else 0                                        (decimal)
+  DP   = min(DP_m · 0.5, 1.5)                                                                 (decimal)
+  M_T  = meetings per minute (Equation 24-16)                                                (meetings/min)
+  A_T  = active passings per minute (Equation 24-12)                                         (passings/min)
+  DP_m = delayed passings per minute (Equation 24-34)                                        (delayed passings/min)
+Implemented in: offstreet_pedbike/offstreet_pedbike.rs::determine_blos
+```
+
+```
+Exhibit 24-5 (LOS Criteria for Bicycles on Shared-Use and Exclusive Paths): LOS from the BLOS score
+  BLOS > 4.0          -> LOS A
+  4.0 ≥ BLOS > 3.5    -> LOS B
+  3.5 ≥ BLOS > 3.0    -> LOS C
+  3.0 ≥ BLOS > 2.5    -> LOS D
+  2.5 ≥ BLOS > 2.0    -> LOS E
+  BLOS ≤ 2.0          -> LOS F
+Implemented in: offstreet_pedbike/offstreet_pedbike.rs::bicycle_los_from_score
+```
+
+```
+Step 8 low-volume LOS adjustment (Chapter 24 text; not a numbered HCM equation): overrides the Exhibit 24-5 result using the weighted events per minute E from Equation 24-35
+  E ≤ 5                                          -> LOS A
+  5 < E ≤ 10 and Exhibit 24-5 result ≠ LOS A     -> LOS B
+  otherwise                                       -> unchanged (Exhibit 24-5 result)
+Implemented in: offstreet_pedbike/offstreet_pedbike.rs::adjust_los_for_low_volume_paths
+```
+
 ## Deviations (cross-referenced to `docs/hcm/VERIFICATION.md`)
 
-`docs/hcm/VERIFICATION.md` does not exist at this branch's tip; its "Chapter 24 (feat/hcm-ch24-offstreet-pedbike)" section, read from a later branch's history, and the inline `// VERIFY-HCM` comments already present in `offstreet_pedbike.rs` on this branch, record five items: (1) the Equation 24-17 modal-pair passing-distance ambiguity documented above — the implementation reproduces the worked example (`P_Tds` = 0.8334) using the subject-mode distance for both sides of each pair; an alternative reading (each side using its own mode's required passing distance) gives 0.8241 instead; (2) the likely sign typo in Equations 24-29/24-30 (`1 - e^{p_i k} - P_b` as printed vs. the implemented `1 - e^{-p_i k} - P_b`), unconfirmed by any published three-lane worked example; (3) Exhibit 24-14 (effective lanes by path width) is undefined for widths <8 ft, 10.5-11 ft, 14.5-15 ft, and >20 ft — the documented interpolation rule used is the simple `<11 -> 2, <15 -> 3, else -> 4` banding implemented in `determine_number_of_effective_lanes` (note the code comment there also observes the methodology's own stated inapplicability above 20 ft); (4) Chapter 35 Example Problem 2's book value M1 = 5.36 is computed with a runner speed of 6.6 mi/h, which appears to be a typo for the Exhibit 24-6 default of 6.5 mi/h (the exact value at 6.5 mi/h is 5.38, the value this implementation reproduces); (5) the published child-bicycle flow rate "9/h" in the same example is a truncation of the exact computed value 9.44 (not a rounding difference the code needs to correct for, simply a note that the published figure is not the full-precision intermediate).
+`docs/hcm/VERIFICATION.md` exists at this branch's tip; its "Chapter 24 (feat/hcm-ch24-offstreet-pedbike)" section, together with the inline `// VERIFY-HCM` comments in `offstreet_pedbike.rs`, records five items: (1) the Equation 24-17 modal-pair passing-distance ambiguity documented above — the implementation reproduces the worked example (`P_Tds` = 0.8334) using the subject-mode distance for both sides of each pair; an alternative reading (each side using its own mode's required passing distance) gives 0.8241 instead; (2) the likely sign typo in Equations 24-29/24-30 (`1 - e^{p_i k} - P_b` as printed vs. the implemented `1 - e^{-p_i k} - P_b`), unconfirmed by any published three-lane worked example; (3) Exhibit 24-14 (effective lanes by path width) is undefined for widths <8 ft, 10.5-11 ft, 14.5-15 ft, and >20 ft — the documented interpolation rule used is the simple `<11 -> 2, <15 -> 3, else -> 4` banding implemented in `determine_number_of_effective_lanes` (note the code comment there also observes the methodology's own stated inapplicability above 20 ft); (4) Chapter 35 Example Problem 2's book value M1 = 5.36 is computed with a runner speed of 6.6 mi/h, which appears to be a typo for the Exhibit 24-6 default of 6.5 mi/h (the exact value at 6.5 mi/h is 5.38, the value this implementation reproduces); (5) the published child-bicycle flow rate "9/h" in the same example is a truncation of the exact computed value 9.44 (not a rounding difference the code needs to correct for, simply a note that the published figure is not the full-precision intermediate).
 
 ## Validation
 
 Fixtures live under `tests/ExampleCases/hcm/OffStreetPedBike/` as `case1.json` and `case2.json`, exercised by `tests/chapter24_integration.rs` and mirrored by `tests/test_chapter24_integration.py`. `case1.json` reproduces HCM Chapter 35, Example Problem 1 (pedestrian LOS on shared-use and exclusive paths): `test_example_problem_1_pedestrian_los` asserts the shared-use-path passing/meeting/total event rates, the shared-use-path pedestrian LOS letter exactly, and the exclusive-path effective width, unit flow rate, pedestrian space, and LOS letter exactly, with numeric assertions at roughly half a unit of the last published significant figure (the module doc comment states published results are "rounded to two or three significant figures and were computed with rounded intermediate values," so tolerances are widened per-assertion where documented). `case2.json` reproduces Chapter 35, Example Problem 2 (bicycle LOS): `test_example_problem_2_bicycle_los` asserts active passings per minute, meetings per minute, effective lanes (exactly), the probability of delayed passing, delayed passings per minute, the BLOS score (±0.01), and the LOS letter exactly, reproducing the documented `P_Tds` = 0.8334 and M1 = 5.38 (not the book's printed 5.36, per Deviation item 4).
 
-Unit tests in `src/hcm/chapter24/tests.rs` (28 tests) cover every step and exhibit lookup individually: `test_step1_determine_effective_walkway_width` through `test_step5_volume_to_capacity_ratio` for the exclusive-pedestrian-facility pipeline, plus `test_exhibit_24_1_walkway_random_flow_los_thresholds`, `test_exhibit_24_2_walkway_platoon_flow_los_thresholds`, `test_exhibit_24_3_stairway_los_thresholds`, and `test_cross_flow_los_ef_threshold` for the three LOS tables and the cross-flow capacity/threshold override; `test_step2_passing_and_meeting_events`, `test_step3_shared_path_pedestrian_los`, `test_one_way_path_has_no_meeting_events`, `test_peak_15min_flow_rates_bypass_phf`, and `test_exhibit_24_4_shared_path_pedestrian_los_thresholds` for the shared-use-path pedestrian methodology; and for the bicycle BLOS methodology, `test_step1_directional_flow_rates`, `test_step2_active_passings_per_minute`, `test_step3_meetings_per_minute`, `test_step4_effective_lanes_exhibit_24_14` (all three width bands), `test_step5_blocked_lane_and_pair_probabilities` and `test_step5_total_probability_of_delayed_passing` (spot-checking the 25-modal-pair combination directly), `test_step6_delayed_passings_per_minute`, `test_step7_blos_score_and_los`, `test_step8_low_volume_adjustment`, `test_exhibit_24_5_bicycle_los_thresholds`, `test_exclusive_bicycle_facility_zero_nonbike_modes`, `test_one_way_bicycle_path_has_no_meetings`, and `test_normal_cdf_reference_values` (the shared speed-distribution CDF helper, checked against known standard-normal reference values).
+Unit tests in `src/hcm/offstreet_pedbike/tests.rs` (28 tests) cover every step and exhibit lookup individually: `test_step1_determine_effective_walkway_width` through `test_step5_volume_to_capacity_ratio` for the exclusive-pedestrian-facility pipeline, plus `test_exhibit_24_1_walkway_random_flow_los_thresholds`, `test_exhibit_24_2_walkway_platoon_flow_los_thresholds`, `test_exhibit_24_3_stairway_los_thresholds`, and `test_cross_flow_los_ef_threshold` for the three LOS tables and the cross-flow capacity/threshold override; `test_step2_passing_and_meeting_events`, `test_step3_shared_path_pedestrian_los`, `test_one_way_path_has_no_meeting_events`, `test_peak_15min_flow_rates_bypass_phf`, and `test_exhibit_24_4_shared_path_pedestrian_los_thresholds` for the shared-use-path pedestrian methodology; and for the bicycle BLOS methodology, `test_step1_directional_flow_rates`, `test_step2_active_passings_per_minute`, `test_step3_meetings_per_minute`, `test_step4_effective_lanes_exhibit_24_14` (all three width bands), `test_step5_blocked_lane_and_pair_probabilities` and `test_step5_total_probability_of_delayed_passing` (spot-checking the 25-modal-pair combination directly), `test_step6_delayed_passings_per_minute`, `test_step7_blos_score_and_los`, `test_step8_low_volume_adjustment`, `test_exhibit_24_5_bicycle_los_thresholds`, `test_exclusive_bicycle_facility_zero_nonbike_modes`, `test_one_way_bicycle_path_has_no_meetings`, and `test_normal_cdf_reference_values` (the shared speed-distribution CDF helper, checked against known standard-normal reference values).
 
 `tests/test_chapter24_integration.py` exercises the PyO3 bindings against the same two fixtures: `test_shared_use_path_pedestrian_los`, `test_exclusive_path_pedestrian_los`, `test_bicycle_los_on_shared_use_path`, and `test_low_volume_path_adjustment`.
 

--- a/docs/hcm/procedures/common-infrastructure.md
+++ b/docs/hcm/procedures/common-infrastructure.md
@@ -38,6 +38,139 @@ Units throughout: delays s/veh, capacities veh/h, analysis period `t_h` in hours
 | Control delay d = d1+d2+d3 | 19-18 | `control_delay_signalized(d1, d2, d3)` | s/veh each | Ch. 19 |
 | Aggregation | 19-28 / 20-64 (also 19-29 / 20-65 intersectionwide) | `aggregate_control_delay(&[(d, v)])` | (s/veh, veh/h) pairs | Ch. 19 and Ch. 20 approach/intersection rollups |
 
+#### Full equation set, Eqs 19-18 through 19-28 and 19-44 through 19-49
+
+Every equation and constant below was cross-checked against the HCM 7th Edition MathML source (`resources/epub/OEBPS/137_Ch19_03.xhtml`, `138_Ch19_04.xhtml`) in the user's main checkout; all match the current Rust implementation exactly, with no discrepancies found.
+
+```
+Equation 19-21:  y = min(1, X)·(g/C)
+  y = flow ratio (unitless)
+  X = lane group volume-to-capacity ratio (unitless)
+  g/C = effective green ratio (unitless)
+Implemented in: common/delay.rs::flow_ratio
+```
+
+```
+Equation 19-20:  PF = [(1 − P)/(1 − g/C)] · [(1 − y)/(1 − min(1, X)·P)] · [1 + y·(1 − P·C/g)/(1 − g/C)]
+  PF = progression adjustment factor (unitless; 1.0 for random arrivals when P = g/C at low X)
+  P = proportion of vehicles arriving during the green indication (decimal, 0–1)
+  g/C = effective green ratio (unitless)
+  X = lane group volume-to-capacity ratio (unitless)
+  y = flow ratio, min(1, X)·g/C (Eq 19-21)
+  Guard: returns 1.0 (no adjustment) when g/C ≥ 1.0 — the analytic limit, since term1 and term3 would otherwise divide by 1 − g/C = 0 (see the Deviations section for the residual, narrower unguarded edge case)
+Implemented in: common/delay.rs::progression_factor
+```
+
+```
+Equation 19-19:  d1 = PF·[0.5·C·(1 − g/C)²] / [1 − min(1, X)·(g/C)]
+  d1 = uniform delay, s/veh
+  C = cycle length, s
+  g = effective green time, s
+  X = lane group volume-to-capacity ratio (unitless)
+  PF = progression adjustment factor (Eq 19-20; 1.0 for random arrivals)
+  Guard: returns 0.0 when g/C ≥ 1.0 (no red interval), the analytic limit of the formula as g/C → 1 for both X ≥ 1 and X < 1
+Implemented in: common/delay.rs::uniform_delay
+```
+
+```
+Equation 19-6:  I = 1.0 − 0.91·X_u^2.68, floored at 0.090
+  I = upstream filtering adjustment factor (unitless, range [0.090, 1.0])
+  X_u = weighted volume-to-capacity ratio of upstream movements feeding the subject movement group, capped at 1.0
+  Constants: I_ISOLATED = 1.0 (intersections ≥0.6 mi from the nearest upstream signal, HCM Chapter 19 Eq 19-6 discussion); I_MIN = 0.090 (the equation's own floor)
+Implemented in: common/delay.rs::upstream_filtering_factor
+```
+
+```
+Equation 19-23:  k_min = −0.375 + 0.354·PT − 0.0910·PT² + 0.00889·PT³, floored at 0.04
+  k_min = minimum incremental delay factor for an actuated phase (unitless)
+  PT = passage time (unit extension) controller setting, s
+  Constant: K_MIN_LOWER_BOUND = 0.04 (the equation's own floor)
+Implemented in: common/delay.rs::incremental_delay_factor_min
+```
+
+```
+Equation 19-22:  k = (1 − 2·k_min)·(v/c_a − 0.5) + k_min, clamped to [k_min, 0.50]
+  k = incremental delay factor for an actuated phase (unitless)
+  k_min = minimum incremental delay factor (Eq 19-23)
+  v/c_a = ratio of demand flow rate to available capacity for the phase (Eq 19-24)
+  Constant: K_PRETIMED = 0.50 is used directly in place of this equation for pretimed, coordinated, and recall-to-maximum phases (HCM Chapter 19, Step 8, Part C)
+Implemented in: common/delay.rs::incremental_delay_factor_actuated
+```
+
+```
+Equation 19-26:  d2 = 900·T·[(X_A − 1) + sqrt((X_A − 1)² + (8·k·I·X_A)/(c_A·T))]
+  d2 = incremental delay, s/veh
+  T = analysis period duration, h (default 0.25 h = 15 min, DEFAULT_ANALYSIS_PERIOD_H in common/time_period.rs)
+  X_A = ratio of flow to capacity for the incremental delay calculation (Eq 19-27, X_A = v/c_A)
+  k = incremental delay factor dependent on controller type (0.50 for pretimed, K_PRETIMED; Eqs 19-22/19-23 for actuated)
+  I = upstream filtering/metering adjustment factor (1.0 isolated intersection, I_ISOLATED; Eq 19-6 for the general case, floored at 0.090, I_MIN)
+  c_A = adjusted lane group capacity, veh/h
+Implemented in: common/delay.rs::incremental_delay_signalized (generic alias: common/delay.rs::incremental_delay, reused verbatim by the unsignalized family below with k·I fixed at 1.0 — see the algebraic-identity note in the source and the Deviations section)
+```
+
+```
+Equation 19-44:  d3 = [3,600/(v·T)] · { t_A·(Q_b + Q_e − Q_eo)/2 + (Q_e² − Q_eo²)/(2·c_A) − Q_b²/(2·c_A) }
+  d3 = initial queue delay, s/veh
+  v = demand flow rate, veh/h
+  T = analysis period duration, h (default 0.25 h)
+  t_A = duration of unmet demand in the analysis period, h (Eqs 19-47/19-49)
+  Q_b = initial queue at the start of the analysis period, veh
+  Q_e = queue at the end of the analysis period (residual queue), veh (Eq 19-45)
+  Q_eo = queue at the end of the analysis period if Q_b were 0.0 veh, veh (Eqs 19-46/19-48)
+  c_A = adjusted lane group capacity, veh/h
+  Special case: d3 = 0.0 s/veh whenever Q_b ≤ 0 (HCM Chapter 19, Step 8, Part B)
+Implemented in: common/delay.rs::initial_queue_delay
+```
+
+```
+Equation 19-45:  Q_e = Q_b + t_A·(v − c_A)
+  Q_e = residual queue at the end of the analysis period, veh
+  Q_b = initial queue at the start of the analysis period, veh
+  t_A = duration of unmet demand, h (Eqs 19-47/19-49)
+  v = demand flow rate, veh/h
+  c_A = adjusted lane group capacity, veh/h
+Implemented in: common/delay.rs::initial_queue_delay (inline); common/delay.rs::queue_end_of_period computes the same Q_e standalone for multiperiod residual-queue hand-off (HCM Chapter 17, Section 3 / Chapter 29, Section 3)
+```
+
+```
+Equation 19-46:  Q_eo = T·(v − c_A)                    [case v ≥ c_A]
+Equation 19-47:  t_A = T                                [case v ≥ c_A]
+  Q_eo = queue at the end of the analysis period if Q_b were 0.0 veh, veh
+  T = analysis period duration, h
+  v = demand flow rate, veh/h
+  c_A = adjusted lane group capacity, veh/h
+Implemented in: common/delay.rs::initial_queue_delay, common/delay.rs::queue_end_of_period (the `v >= capacity` branch)
+```
+
+```
+Equation 19-48:  Q_eo = 0.0 veh                                    [case v < c_A]
+Equation 19-49:  t_A = min(Q_b/(c_A − v), T)                       [case v < c_A]
+  Q_eo = queue at the end of the analysis period if Q_b were 0.0 veh, veh
+  Q_b = initial queue, veh
+  c_A = adjusted lane group capacity, veh/h
+  v = demand flow rate, veh/h
+  T = analysis period duration, h
+Implemented in: common/delay.rs::initial_queue_delay, common/delay.rs::queue_end_of_period (the `v < capacity` branch, with the `.min(t_h)` cap matching the HCM's own "≤ T" qualifier on Eq 19-49)
+```
+
+```
+Equation 19-18:  d = d1 + d2 + d3
+  d = control delay per vehicle, s/veh
+  d1 = uniform delay, s/veh (Eq 19-19)
+  d2 = incremental delay, s/veh (Eq 19-26)
+  d3 = initial queue delay, s/veh (Eqs 19-44 through 19-49)
+Implemented in: common/delay.rs::control_delay_signalized
+```
+
+```
+Equation 19-28:  d_A,j = Σ(d_i·v_i) / Σ(v_i)     for movements/lane groups i = 1..m_j in approach/group j
+  d_A,j = aggregated control delay for approach/lane group j, s/veh
+  d_i = control delay of movement/lane group i, s/veh
+  v_i = flow rate of movement/lane group i, veh/h
+  The same weighted-average form aggregates to intersectionwide delay (Eq 19-29) and is reused for TWSC approach/intersection delay (Eqs 20-64/20-65)
+Implemented in: common/delay.rs::aggregate_control_delay
+```
+
 Constants: `K_PRETIMED = 0.50` (Ch. 19 Step 8 Part C recommendation for pretimed/coordinated/recall-to-max phases), `K_MIN_LOWER_BOUND = 0.04` (Eq 19-23 floor), `I_ISOLATED = 1.0` (Eq 19-6 discussion, intersections ≥0.6 mi from the nearest upstream signal), `I_MIN = 0.090` (Eq 19-6 floor). `initial_queue_delay` implements the Eq 19-45/19-46/19-47/19-48/19-49 case split (`v >= c_A`: Q_eo = T(v-c_A), t_A = T; `v < c_A`: Q_eo = 0, t_A = min(Q_b/(c_A - v), T)) and returns 0.0 for Q_b ≤ 0 per Ch. 19 Step 8 Part B. `uniform_delay` caps X at 1.0 inside the denominator (`x.min(1.0)`), matching the min(1, X) term in Eq 19-19.
 
 Both `uniform_delay` and `progression_factor` now guard `g_over_c >= 1.0` (no red interval) as an early return rather than letting their respective denominators (`1 - min(1,X)·g/C` for `uniform_delay`; `1 - g/C` in both the term1 and term3 factors of `progression_factor`) hit zero. `uniform_delay` returns `0.0`: taking `g/C -> 1^-` with `X >= 1` fixed, `0.5 C (1-g/C)^2 / (1-g/C) = 0.5 C (1-g/C) -> 0`, and for `X < 1` the unguarded formula already gives the same `0` (its denominator tends to `1 - X > 0`), so the guard changes no observable value, it only replaces the `X >= 1` `0/0` with the correct limit. `progression_factor` returns `1.0` (no adjustment) at `g/C >= 1.0`, matching the guard already used at its chapter23 `ramp_terminals.rs` call site (`if g_over_c < 1.0 { progression_factor(..) } else { 1.0 }`) — PF's value is moot there since `uniform_delay` (its only consumer) tends to 0 regardless of PF in that limit. `test_uniform_delay_g_over_c_one_exact`, `test_uniform_delay_g_over_c_near_one_continuity`, `test_uniform_delay_x_above_one_at_g_over_c_one`, and `test_progression_factor_g_over_c_one_returns_one` cover the exact boundary, the `g/C = 0.9999` continuity approach, and `X > 1` at `g/C = 1.0`.
@@ -49,6 +182,41 @@ Both `uniform_delay` and `progression_factor` now guard `g_over_c >= 1.0` (no re
 | TWSC movement control delay | 20-61 | `control_delay_unsignalized(volume, capacity, t_h)` | v_x (veh/h), c_m,x (veh/h), T (h) | 20 |
 | Roundabout lane control delay | 22-17 | `control_delay_roundabout(volume, capacity, t_h)` | lane v (veh/h), c (veh/h), T (h) | 22 |
 | AWSC lane control delay | 21-30 | `control_delay_awsc(service_time_s, departure_headway_s, x, t_h)` | t_s (s), h_d (s), x = v·h_d/3600 (unitless), T (h) | 21 |
+
+#### Full equation set, Eqs 20-61, 21-30, 22-17
+
+Cross-checked against `resources/epub/OEBPS/146_Ch20_03.xhtml` (Eq 20-61), `155_Ch21_03.xhtml` (Eq 21-30), and `164_Ch22_03.xhtml` (Eq 22-17); all three EPUB sources were available and all match the Rust implementation exactly.
+
+```
+Equation 20-61:  d = 3,600/c_m,x + 900·T·[(v_x/c_m,x − 1) + sqrt((v_x/c_m,x − 1)² + (3,600/c_m,x)·(v_x/c_m,x)/(450·T))] + 5
+  d = control delay, s/veh
+  v_x = movement demand flow rate, veh/h
+  c_m,x = movement capacity, veh/h
+  T = analysis period duration, h (default 0.25 h)
+  +5 s/veh = deceleration/acceleration stop penalty (full stop assumed for the TWSC minor-street/major-street-left movement)
+Implemented in: common/delay.rs::control_delay_unsignalized
+```
+
+```
+Equation 21-30:  d = t_s + 900·T·[(x − 1) + sqrt((x − 1)² + h_d·x/(450·T))] + 5
+  d = control delay, s/veh
+  t_s = service time, s
+  h_d = departure headway, s
+  x = degree of utilization, x = v·h_d/3,600 (unitless)
+  T = analysis period duration, h
+  +5 s/veh = deceleration/acceleration stop penalty (all-way stop control, every vehicle stops)
+Implemented in: common/delay.rs::control_delay_awsc
+```
+
+```
+Equation 22-17:  d = 3,600/c + 900·T·[(x − 1) + sqrt((x − 1)² + (3,600/c)·x/(450·T))] + 5·min(x, 1)
+  d = control delay, s/veh
+  c = lane capacity, veh/h
+  x = degree of saturation v/c (unitless)
+  T = analysis period duration, h
+  5·min(x, 1) = YIELD-control stop penalty, scaling toward 0 s/veh as conflict vanishes (x → 0) instead of the full +5 s/veh STOP penalty used by Eqs 20-61/21-30
+Implemented in: common/delay.rs::control_delay_roundabout
+```
 
 All three share the `900T[(x-1) + sqrt((x-1)^2 + radicand)]` structure. The doc comment on `incremental_delay` records the algebraic identity that ties the family to the Chapter 19 form — the unsignalized radicand `(3600/c)·x/(450T)` equals `8x/(cT)`, i.e., Eq 19-26 with k·I = 1 — and the unit test `test_unsignalized_radicand_equals_generic_with_ki_one` verifies it numerically. The three forms differ only in their leading term and their stop penalty: TWSC is `3600/c + ... + 5` (full +5 s/veh stop penalty), roundabout is `3600/c + ... + 5·min(x, 1)` (yield control, penalty scales away at low conflict), AWSC is `t_s + ... + 5` (service time replaces 3600/c). These distinctions are each verified by a dedicated test (`test_control_delay_roundabout_yield_term`, `test_control_delay_awsc_zero_utilization`).
 
@@ -64,6 +232,61 @@ The Chapter 20 TWSC capacity core, reused by Chapters 22 (roundabouts) and 23 (r
 | Pedestrian blockage | 20-67 | `pedestrian_blockage_factor(v_ped, lane_width_ft, walking_speed_ft_s)` | p/h, ft, ft/s | proportion of time blocked |
 | Pedestrian impedance | 20-68 | `pedestrian_impedance_factor(f_pb)` | blockage factor | p_p clamped to [0, 1] |
 | Movement capacity | 20-22 / 20-26 / 20-36 | `movement_capacity(c_p, impedance)` | c_p (veh/h), combined impedance factor | c_m (veh/h) |
+
+#### Full equation set, Eq 20-18 and the impedance chain (Eqs 20-28, 20-35, 20-67, 20-68, 20-22/20-26/20-36)
+
+Cross-checked against `resources/epub/OEBPS/146_Ch20_03.xhtml` (Eqs 20-18, 20-28, 20-35, 20-22, 20-26) and `147_Ch20_04.xhtml` (Eqs 20-67, 20-68, 20-36); all match the current Rust implementation exactly.
+
+```
+Equation 20-18:  c_p,x = v_c,x·exp(−v_c,x·t_c,x/3,600) / [1 − exp(−v_c,x·t_f,x/3,600)]
+  c_p,x = potential capacity of minor movement x, veh/h
+  v_c,x = conflicting flow rate, veh/h
+  t_c,x = critical headway, s
+  t_f,x = follow-up headway, s
+  Limit: c_p,x → 3,600/t_f,x as v_c,x → 0 (returned explicitly for v_c,x ≤ 0)
+Implemented in: common/gap_acceptance.rs::potential_capacity
+```
+
+```
+Equation 20-28:  p0,j = 1 − v_j/c_m,j
+  p0,j = probability that movement j operates in a queue-free state (unitless, clamped to [0, 1])
+  v_j = demand flow rate of movement j, veh/h
+  c_m,j = movement capacity of movement j, veh/h
+  Extended by structural identity to the Rank 2 U-turn adjustment factors f_1U/f_4U (Eqs 20-24/20-25); flagged as a reviewer-confirm item in Deviations item 3 below, since the HCM presents those as formally distinct equations sharing the same 1 − v/c form
+Implemented in: common/gap_acceptance.rs::prob_queue_free
+```
+
+```
+Equation 20-35:  f_k = Π_j p0,j
+  f_k = vehicular impedance (capacity adjustment) factor for Rank 3 (and, combined with additional terms, Rank 4) movement k (unitless)
+  p0,j = queue-free probability of each impeding higher-rank movement j (Eq 20-28)
+  Product over an empty movement set returns 1.0 (no impedance)
+Implemented in: common/gap_acceptance.rs::vehicular_impedance_factor
+```
+
+```
+Equation 20-67:  f_pb = (v_x·w/S_p) / 3,600
+  f_pb = pedestrian blockage factor, proportion of time the lane is blocked by pedestrians (unitless)
+  v_x = pedestrian flow rate of the conflicting pedestrian movement, p/h
+  w = width of the lane the minor movement is negotiating into, ft
+  S_p = pedestrian walking speed, ft/s (default PEDESTRIAN_WALKING_SPEED_FT_S = 3.5 ft/s)
+Implemented in: common/gap_acceptance.rs::pedestrian_blockage_factor
+```
+
+```
+Equation 20-68:  p_p,x = 1 − f_pb
+  p_p,x = pedestrian impedance factor for movement x (unitless, clamped to [0, 1])
+  f_pb = pedestrian blockage factor (Eq 20-67)
+Implemented in: common/gap_acceptance.rs::pedestrian_impedance_factor
+```
+
+```
+Equations 20-22, 20-26, 20-36:  c_m = c_p · f
+  c_m = movement capacity, veh/h
+  c_p = potential capacity (Eq 20-18), veh/h
+  f = combined capacity adjustment factor: 1.0 for unimpeded Rank 2 major-street left turns (Eq 20-22); vehicular impedance × pedestrian impedance for Rank 3/4 movements and U-turns (Eqs 20-26, 20-36)
+Implemented in: common/gap_acceptance.rs::movement_capacity
+```
 
 The constant `PEDESTRIAN_WALKING_SPEED_FT_S = 3.5` transcribes the Chapter 20 Eq 20-67 variable-definition assumption. Note the composition responsibility is the caller's: `movement_capacity` takes a single pre-combined impedance argument, and the rank-2/3/4 wiring (which p_0 terms multiply into which movement, per the Chapter 20 rank hierarchy) is deliberately not encoded here — a chapter-20 implementation must assemble `vehicular_impedance_factor(...) * pedestrian_impedance_factor(...)` itself per movement rank. `test_movement_capacity_composition` demonstrates the intended composition.
 

--- a/docs/hcm/procedures/reliability-enhancements.md
+++ b/docs/hcm/procedures/reliability-enhancements.md
@@ -1,6 +1,6 @@
 # Reliability Enhancements: Chapter 17 Residual-Queue Carryover and Chapter 37 ATDM Strategy Models
 
-This document walks a reviewer through the two enhancements delivered on this branch, both closing documented deferrals in the reliability engines. The first is the HCM 7th Edition Chapter 17, Section 3 ("Facility Evaluation") residual-queue carryover between chronological analysis periods of the urban street reliability method: the initial-queue delay term d3 (Chapter 19 Equations 19-44 through 19-49) is now computed per boundary intersection with the queue Qb inherited from the previous analysis period, and the residual queue Qe (Equation 19-45) is carried forward, with a day-boundary reset rule. The second is a new HCM Chapter 37 ("ATDM: Supplemental") module transcribing the strategy-impact models that feed the Chapter 11 freeway and Chapter 17 urban reliability engines: Section 3 shoulder/median lane capacity models (Equation 37-1), Section 4 ramp metering (the 1.03 merge CAF and the Equation 37-2 ALINEA-derived metering rate), and Section 5 adaptive signal control (Exhibit 37-9's illustrative ranges). The code lives in `src/hcm/common/delay.rs` (`queue_end_of_period`, new), `src/hcm/chapter17/urban_reliability.rs` (carryover threading through the scenario loop), `src/hcm/common/atdm.rs` (new module), and convenience constructors in `src/hcm/chapter11/scenario_generation.rs` and `src/hcm/chapter17/urban_reliability.rs`. Interpretations and book gaps are catalogued in `docs/hcm/VERIFICATION.md` under "Reliability enhancements (Ch 17 carryover, Ch 37 ATDM) (feat/hcm-reliability-enhancements)" (items 1-6); this walkthrough cites those items rather than restating them.
+This document walks a reviewer through the two enhancements delivered on this branch, both closing documented deferrals in the reliability engines. The first is the HCM 7th Edition Chapter 17, Section 3 ("Facility Evaluation") residual-queue carryover between chronological analysis periods of the urban street reliability method: the initial-queue delay term d3 (Chapter 19 Equations 19-44 through 19-49) is now computed per boundary intersection with the queue Qb inherited from the previous analysis period, and the residual queue Qe (Equation 19-45) is carried forward, with a day-boundary reset rule. The second is a new HCM Chapter 37 ("ATDM: Supplemental") module transcribing the strategy-impact models that feed the Chapter 11 freeway and Chapter 17 urban reliability engines: Section 3 shoulder/median lane capacity models (Equation 37-1), Section 4 ramp metering (the 1.03 merge CAF and the Equation 37-2 ALINEA-derived metering rate), and Section 5 adaptive signal control (Exhibit 37-9's illustrative ranges). The code lives in `src/hcm/common/delay.rs` (`queue_end_of_period`, new), `src/hcm/urban_reliability/urban_reliability.rs` (carryover threading through the scenario loop), `src/hcm/common/atdm.rs` (new module), and convenience constructors in `src/hcm/freeway_reliability/scenario_generation.rs` and `src/hcm/urban_reliability/urban_reliability.rs`. Interpretations and book gaps are catalogued in `docs/hcm/VERIFICATION.md` under "Reliability enhancements (Ch 17 carryover, Ch 37 ATDM) (feat/hcm-reliability-enhancements)" (items 1-6); this walkthrough cites those items rather than restating them. Every equation named below is reproduced in full below its subsection, with a where-clause giving units and defaults, so this document is verifiable standalone against a Rust translation without opening the HCM manual; equation text is cross-checked against both the Rust source and the HCM 7th Edition EPUB MathML (Chapter 19: `135_Ch19_01.xhtml`-`142_Ch19_08.xhtml`; Chapter 37: `284_Ch37_01.xhtml`-`292_Ch37_09.xhtml`).
 
 ## Part 1: Chapter 17 residual-queue carryover
 
@@ -10,8 +10,42 @@ This document walks a reviewer through the two enhancements delivered on this br
 |---|---|---|---|
 | Initial queue delay d3 | Eq 19-44 through 19-49 | `common/delay.rs::initial_queue_delay` (pre-existing on this branch's base) | Qb (veh), v (veh/h), c_A (veh/h), T (h) -> d3 (s/veh) |
 | Residual queue at period end | Eq 19-45 (with t_A/Q_eo from Eq 19-46 through 19-49) | `common/delay.rs::queue_end_of_period` (new) | Qb (veh), v (veh/h), c_A (veh/h), T (h) -> Qe (veh, >= 0) |
-| Chronological queue hand-off | Ch 17 Sec. 3, "Facility Evaluation" | `chapter17/urban_reliability.rs::UrbanReliability::run` (the `queue_state`/`last_day` loop) and `::evaluate_scenario` (new `queue_in` parameter, `queue_out` return) | per-boundary-intersection queue vector (veh), one entry per segment |
+| Chronological queue hand-off | Ch 17 Sec. 3, "Facility Evaluation" | `urban_reliability/urban_reliability.rs::UrbanReliability::run` (the `queue_state`/`last_day` loop) and `::evaluate_scenario` (new `queue_in` parameter, `queue_out` return) | per-boundary-intersection queue vector (veh), one entry per segment |
 | Day-boundary reset | interpretation — VERIFICATION.md item 1 | `run` — `if last_day != Some(scenario.day_of_year) { queue_state = vec![0.0; n_seg]; }` | resets Qb to 0 at each day's first analysis period |
+
+#### Equations 19-44 through 19-49 in full
+
+These are the six equations that together define d3 (initial queue delay) and Qe (residual queue). Transcribed directly from the Chapter 19 MathML (`138_Ch19_04.xhtml`) and matching `common/delay.rs::initial_queue_delay` and `common/delay.rs::queue_end_of_period` term for term.
+
+```
+Equation 19-44:  d3 = (3,600 / (v T)) * [ t_A (Qb + Qe - Qeo)/2  +  (Qe^2 - Qeo^2)/(2 c_A)  -  Qb^2/(2 c_A) ]     [s/veh]
+  v     = demand flow rate for the analysis period                                          [veh/h]
+  T     = analysis period duration (ANALYSIS_PERIOD_H = 0.25 in this codebase)               [h]
+  t_A   = adjusted duration of unmet demand within the analysis period (Eq 19-47 or 19-49)    [h]
+  Qb    = initial queue at the start of the analysis period (0 if none)                      [veh]
+  Qe    = queue at the end of the analysis period, i.e. the residual queue (Eq 19-45)         [veh]
+  Qeo   = queue at the end of the analysis period if v >= c_A and Qb = 0 (Eq 19-46 or 19-48)  [veh]
+  c_A   = average lane-group capacity for the analysis period (Eq 19-42/19-43 in the book;
+          this implementation passes the ordinary lane-group capacity directly -- see the
+          "Documented simplification" note below and VERIFICATION.md item 2)                 [veh/h]
+By definition (HCM Chapter 19, Step 8, Part B): d3 = 0.0 s/veh whenever Qb = 0 (no initial queue).
+
+Equation 19-45:  Qe = Qb + t_A (v - c_A)                                                      [veh, clamped >= 0]
+  (same variables as above; this is the "residual queue" carried forward as the next period's Qb)
+
+If v >= c_A (the analysis period is oversaturated or exactly at capacity):
+  Equation 19-46:  Qeo = T (v - c_A)                                                          [veh]
+  Equation 19-47:  t_A = T                                                                    [h]
+
+If v < c_A (the analysis period is undersaturated):
+  Equation 19-48:  Qeo = 0.0 veh                                                               [veh]
+  Equation 19-49:  t_A = min( Qb / (c_A - v), T )                                             [h]
+    -- Qb / (c_A - v) is the time for the initial queue to dissipate at the excess-capacity
+       rate (c_A - v); if that time exceeds T, the queue does not fully clear within the
+       period and t_A is capped at T.
+```
+
+Implemented in: `common/delay.rs::initial_queue_delay(queue_initial_veh, v, capacity, t_h) -> d3` and `common/delay.rs::queue_end_of_period(queue_initial_veh, v, capacity, t_h) -> Qe`. Both functions independently re-derive `t_A`/`Qeo` from the same `v`/`capacity` comparison rather than sharing a helper, so the branch logic in each must be read side by side to confirm they agree (they do — verified by `test_queue_end_of_period_oversaturated_matches_eq_19_45` and the analogous `initial_queue_delay` tests in `common/delay.rs`). `queue_end_of_period` carries a defensive third branch (`else { t_h }`) that is unreachable in `f64` arithmetic once the `v >= capacity` and `capacity > v` arms are exhausted (it would only fire on a NaN comparison); documented as harmless dead code in the walkthrough prose above.
 
 `queue_end_of_period` implements Equation 19-45, `Qe = Qb + t_A (v - c_A)`, selecting `t_A = T` when v >= c_A (Equation 19-47) and `t_A = min(Qb / (c_A - v), T)` when v < c_A (Equation 19-49), clamped to Qe >= 0. Its doc comment quotes the governing Chapter 17 sentence ("the initial queue input value for the next analysis period is set equal to the residual queue output for the current analysis period") and notes the same hand-off appears in Chapter 29, Section 3 for the multiple-time-period/spillback technique. One code-reading note: the function's `t_A` selection has an unreachable third branch (`if v >= capacity ... else if capacity > v ... else t_h` — the `else` can only fire on NaN inputs); harmless but dead code.
 
@@ -19,11 +53,30 @@ In `evaluate_scenario`, the queue state is threaded per boundary-intersection th
 
 **The day-reset rule** (VERIFICATION.md item 1) is an interpretation, not a literal reading: the HCM text states the hand-off without an explicit exception at the boundary between one day's study period and the next day's, but a literal reading would carry a queue across the roughly 21-hour gap between, say, 9:45-10:00 a.m. Monday and 7:00-7:15 a.m. Tuesday. The module doc (the "Residual-queue carryover between analysis periods" section of `urban_reliability.rs`) defends the reset on three grounds: physical implausibility of a queue surviving the off-study-period gap, consistency with the Chapter 11 freeway reliability engine (each scenario/day evaluated from a fresh facility clone with no cross-scenario state), and the Chapter 29 Section 3 technique's queue hand-off being explicitly scoped to "subperiods" of one multi-period analysis. Implemented as: `queue_state` zeroed whenever the scenario's `day_of_year` differs from the previous scenario's.
 
+#### Day-boundary reset rule (interpretation, not an HCM equation)
+
+Stated as pseudocode since this is a modeling decision layered on top of the literal Chapter 17 hand-off sentence, not a numbered HCM equation:
+
+```
+For each scenario, taken in the chronological order produced by the Chapter 17 scenario generator
+(grouped by day_of_year, periods in order within each day):
+
+  if scenario.day_of_year != previous_scenario.day_of_year (or this is the first scenario):
+      queue_state[seg] = 0.0 for every boundary intersection seg      # Qb reset to 0
+  else:
+      queue_state[seg] = queue_out[seg] from the immediately preceding scenario   # Eq 19-45 hand-off
+
+  (result, queue_out) = evaluate_scenario(scenario, queue_state)
+  queue_state = queue_out
+```
+
+`queue_state: Vec<f64>` has one entry per boundary intersection (`self.facility.segments` order); `queue_out[i]` for segment `i` is exactly `queue_end_of_period(queue_state[i], through_demand_veh_h, c_veh_h, ANALYSIS_PERIOD_H)` (Eq 19-45). Implemented in: `urban_reliability/urban_reliability.rs::UrbanReliability::run` (the `queue_state`/`last_day` loop shown above) calling `::evaluate_scenario` per scenario. This rule assumes `self.scenarios` is already chronologically ordered — true for the Chapter 17 scenario generator's output, but not re-verified defensively inside `run`.
+
 **Documented simplification — the Equations 19-38 through 19-43 capacity blend is not implemented** (VERIFICATION.md item 2). The full Chapter 19, Section 4 initial-queue extension computes a blended average capacity `cA` from a separate saturated capacity `cs` (serving the backlog) and the ordinary capacity `c`, weighted by the unmet-demand duration, and re-derives d1 with a saturated/baseline uniform-delay blend. This implementation passes the scenario's ordinary lane-group capacity directly as `cA` into both `initial_queue_delay` and `queue_end_of_period` — exact when there is no initial queue, an approximation otherwise. The module doc argues the approximation is reasonable because d2 and d3 are additive and `cA` differs from `c` only during the typically short unmet-demand interval within a 15-min period.
 
 ## Part 2: Chapter 37 ATDM strategy models (`common/atdm.rs`)
 
-The module doc explains the placement decision: Chapter 37 is supplemental content with no facility methodology of its own — its purpose (per Chapter 11, Section 4) is to translate strategies into CAF/SAF/DAF-shaped inputs for the reliability engines — so it lives under `common/` as pure equation/constant transcriptions, with the convenience constructors that build engine-facing objects placed in `chapter11`/`chapter17` to preserve the `common/` dependency direction (chapters depend on common, never the reverse).
+The module doc explains the placement decision: Chapter 37 is supplemental content with no facility methodology of its own — its purpose (per Chapter 11, Section 4) is to translate strategies into CAF/SAF/DAF-shaped inputs for the reliability engines — so it lives under `common/` as pure equation/constant transcriptions, with the convenience constructors that build engine-facing objects placed in `freeway_reliability`/`urban_reliability` to preserve the `common/` dependency direction (chapters depend on common, never the reverse).
 
 ### Section 3: shoulder and median lane strategies
 
@@ -33,26 +86,121 @@ The module doc explains the placement decision: Chapter 37 is supplemental conte
 | Shoulder-lane capacity by use variant | Ch 37 Sec. 3 text | `atdm.rs::ShoulderLaneUse` (enum: `AllTraffic`, `BusesOnly`, `HovOnly`), `atdm.rs::shoulder_lane_capacity_veh_h_ln` | veh/h/ln |
 | Average per-lane capacity with an open shoulder | Eq 37-1 | `atdm.rs::shoulder_lane_average_capacity_veh_h_ln` | veh/h/ln; `(CapShldr + CapMF x MFlanes) / (1 + MFlanes)` |
 | Total-capacity CAF equivalent | derived from Eq 37-1 | `atdm.rs::shoulder_lane_caf` | decimal, >= 1; `1 + CapShldr / (CapMF x MFlanes)` |
-| Chapter 11 engine hook | — | `chapter11/scenario_generation.rs::WorkZoneEvent::shoulder_lane_strategy` | builds a scheduled `WorkZoneEvent` with `active_day_ratio = 1.0` and the CAF above |
+| Chapter 11 engine hook | — | `freeway_reliability/scenario_generation.rs::WorkZoneEvent::shoulder_lane_strategy` | builds a scheduled `WorkZoneEvent` with `active_day_ratio = 1.0` and the CAF above |
 
 `BusesOnly`/`HovOnly` capacity is the lesser of the observed bus/HOV volume and a capacity value; the HCM never states the numeric default for that capacity when the user does not override it, so the implementation defaults it to a normal mixed-flow lane's capacity, making the observed vehicle count normally binding — VERIFICATION.md item 3 and a `VERIFY-HCM` comment on the enum variant. `shoulder_lane_caf` deliberately keeps the segment's lane count fixed for density purposes and expresses the whole effect as a total-capacity multiplier, the same simplification the Chapter 11 module already documents for incident lane closures (its doc comment says so explicitly).
 
+#### Equation 37-1 and the derived total-capacity CAF, in full
+
+Transcribed directly from the Chapter 37 MathML (`286_Ch37_03.xhtml`) and matching `atdm.rs::shoulder_lane_average_capacity_veh_h_ln` and `atdm.rs::shoulder_lane_caf`.
+
+```
+Equation 37-1:  AveCap(s) = [ CapShldr(s) + CapMFlanes(s) x MFlanes(s) ] / [ 1 + MFlanes(s) ]     [veh/h/ln]
+  AveCap(s)     = average capacity per lane for section s, across all MFlanes(s)+1 lanes         [veh/h/ln]
+  CapShldr(s)   = capacity per shoulder lane for section s (see shoulder_lane_capacity_veh_h_ln
+                  below; AUX_SHOULDER_CAPACITY_RATIO x CapMFlanes(s) = 0.5 x CapMFlanes(s) by
+                  default for the auxiliary-lane / all-traffic-no-override variant)             [veh/h/ln]
+  CapMFlanes(s) = capacity per mixed-flow (normal through) lane in section s                     [veh/h/ln]
+  MFlanes(s)    = number of mixed-flow lanes in section s (integer)                              [lanes]
+Per the HCM text: "The number of lanes on the freeway segments between adjacent on- and off-ramps
+is increased by one for the shoulder lane" -- i.e. the section now has MFlanes(s)+1 lanes total.
+
+Derived total-capacity CAF (not an HCM equation number; a re-expression of Eq 37-1 as a single
+multiplicative factor on the section's pre-existing total capacity, for engines such as the
+Chapter 11 freeway reliability engine's per-segment CAF schedule that model a capacity change as
+one CAF while holding the segment's lane count fixed for density purposes):
+
+  CAF = [ AveCap(s) x (MFlanes(s) + 1) ] / [ CapMFlanes(s) x MFlanes(s) ]
+      = 1 + CapShldr(s) / ( CapMFlanes(s) x MFlanes(s) )                                        [dimensionless, >= 1]
+  (the two forms are algebraically identical; substituting Eq 37-1's AveCap(s) into the first
+  form and canceling the common (MFlanes(s)+1) factor gives the second, closed form actually
+  implemented). Returns 1.0 (no effect) if MFlanes(s) = 0 or CapMFlanes(s) <= 0.
+```
+
+Implemented in: `common/atdm.rs::shoulder_lane_average_capacity_veh_h_ln(shoulder_capacity_veh_h_ln, mixed_flow_capacity_veh_h_ln, mixed_flow_lanes) -> AveCap(s)` and `common/atdm.rs::shoulder_lane_caf(shoulder_capacity_veh_h_ln, mixed_flow_capacity_veh_h_ln, mixed_flow_lanes) -> CAF`; hooked into the freeway engine via `freeway_reliability/scenario_generation.rs::WorkZoneEvent::shoulder_lane_strategy`.
+
 ### Section 4: ramp metering
 
-`RAMP_METERED_MERGE_CAF = 1.03` transcribes the Section 4 recommendation for freeway merge segments while metering operates; `WorkZoneEvent::ramp_metering_merge_strategy` (in `chapter11/scenario_generation.rs`) applies it to the listed merge segments on the metering schedule. `alinea_metering_rate` implements Equation 37-2 — `R(t) = (CM - VM(t)) / NR`, clamped to `[MinRate, MaxRate]` (defaults `ALINEA_DEFAULT_MIN_RATE_VEH_H_LN = 240`, `ALINEA_DEFAULT_MAX_RATE_VEH_H_LN = 900` veh/h/ln) and floored by the queue-storage constraint `R(t) > (VR(t) + QR(t-1) - QRS) / NR` — inputs are downstream capacity CM (veh/h), upstream volume VM (veh/h), ramp volume VR (veh/h), prior ramp queue QR (veh), ramp storage QRS (veh), and metered lane count NR; output is veh/h/ln, with `NR = 0` returning MaxRate. The constructor's doc is explicit that the ALINEA rate is not folded into the `WorkZoneEvent` (it caps a specific ramp's volume rather than producing a CAF/SAF/DAF), so an analyst applies it directly to a facility's on-ramp demand or via the Chapter 10 `ramp_metering` schedule.
+`RAMP_METERED_MERGE_CAF = 1.03` transcribes the Section 4 recommendation for freeway merge segments while metering operates; `WorkZoneEvent::ramp_metering_merge_strategy` (in `freeway_reliability/scenario_generation.rs`) applies it to the listed merge segments on the metering schedule. `alinea_metering_rate` implements Equation 37-2 — `R(t) = (CM - VM(t)) / NR`, clamped to `[MinRate, MaxRate]` (defaults `ALINEA_DEFAULT_MIN_RATE_VEH_H_LN = 240`, `ALINEA_DEFAULT_MAX_RATE_VEH_H_LN = 900` veh/h/ln) and floored by the queue-storage constraint `R(t) > (VR(t) + QR(t-1) - QRS) / NR` — inputs are downstream capacity CM (veh/h), upstream volume VM (veh/h), ramp volume VR (veh/h), prior ramp queue QR (veh), ramp storage QRS (veh), and metered lane count NR; output is veh/h/ln, with `NR = 0` returning MaxRate. The constructor's doc is explicit that the ALINEA rate is not folded into the `WorkZoneEvent` (it caps a specific ramp's volume rather than producing a CAF/SAF/DAF), so an analyst applies it directly to a facility's on-ramp demand or via the Chapter 10 `ramp_metering` schedule.
+
+#### Equation 37-2 in full, with clamps
+
+Transcribed directly from the Chapter 37 MathML (`287_Ch37_04.xhtml`) and matching `atdm.rs::alinea_metering_rate`.
+
+```
+Equation 37-2:  R(t) = ( CM - VM(t) ) / NR                                                       [veh/h/ln]
+
+subject to:     MinRate < R(t) < MaxRate
+                R(t) > [ VR(t) + QR(t-1) - QRS ] / NR
+
+  R(t)      = ramp-metering rate for analysis period t                                          [veh/h/ln]
+  CM        = capacity of the downstream section                                                [veh/h]
+  VM(t)     = volume on the upstream section for analysis period t                               [veh/h]
+  NR        = number of metered lanes on the ramp (integer)                                      [lanes]
+  VR(t)     = volume on the ramp during analysis period t                                        [veh/h]
+  QR(t-1)   = queue on the ramp at the end of the previous analysis period                        [veh]
+  QRS       = queue storage capacity of the ramp                                                  [veh]
+  MinRate   = user-defined minimum ramp-metering rate; default ALINEA_DEFAULT_MIN_RATE_VEH_H_LN
+              = 240                                                                              [veh/h/ln]
+  MaxRate   = user-defined maximum ramp-metering rate; default ALINEA_DEFAULT_MAX_RATE_VEH_H_LN
+              = 900                                                                              [veh/h/ln]
+
+Implementation detail (a defensive extension beyond the book's literal "<"/">" text): the two
+subject-to conditions are implemented as an inclusive clamp -- take the unconstrained rate,
+floor it at the queue-storage constraint, then clamp the result to [MinRate, MaxRate] -- rather
+than as strict open-interval inequalities, since a hard floor/ceiling is the only way to return a
+single well-defined R(t) in code. NR = 0 (no metered lanes) returns MaxRate (metering has no
+effect without a metered lane).
+```
+
+Implemented in: `common/atdm.rs::alinea_metering_rate(downstream_capacity_veh_h, upstream_volume_veh_h, ramp_volume_veh_h, ramp_queue_prev_veh, ramp_queue_storage_veh, metered_lanes, min_rate_veh_h_ln, max_rate_veh_h_ln) -> R(t)`. Not wired into any engine automatically (see the Deferred section).
 
 ### Section 5: adaptive signal control
 
-The HCM publishes no closed-form adaptive-signal method — Section 5 states "it has not been possible to develop a generalized method" and reports only a three-corridor simulation study (Exhibit 37-9: delay reductions 3%-24%, TTI reductions 3%-13%), transcribed as `ADAPTIVE_SIGNAL_DELAY_REDUCTION_PCT_RANGE` and `ADAPTIVE_SIGNAL_TTI_REDUCTION_PCT_RANGE`. `adaptive_signal_sat_flow_adjustment(target_pct)` converts a target delay-reduction percentage (default: the range midpoint, 13.5%; always clamped to the published 3-24 range) into a Chapter 17 saturation-flow adjustment via `1 / (1 - pct/100)` — a documented modeling simplification, not an HCM-derived equation, flagged `VERIFY-HCM` in the code and as VERIFICATION.md item 4; the rationale is that demand held at capacity then yields the same fractional reduction in the Chapter 19 incremental-delay term's implied excess demand, and the doc directs analysts to prefer directly calibrated values. `AtdmStrategy::adaptive_signal_control` (in `chapter17/urban_reliability.rs`) wraps this into a scheduled Chapter 17 strategy.
+The HCM publishes no closed-form adaptive-signal method — Section 5 states "it has not been possible to develop a generalized method" and reports only a three-corridor simulation study (Exhibit 37-9: delay reductions 3%-24%, TTI reductions 3%-13%), transcribed as `ADAPTIVE_SIGNAL_DELAY_REDUCTION_PCT_RANGE` and `ADAPTIVE_SIGNAL_TTI_REDUCTION_PCT_RANGE`. `adaptive_signal_sat_flow_adjustment(target_pct)` converts a target delay-reduction percentage (default: the range midpoint, 13.5%; always clamped to the published 3-24 range) into a Chapter 17 saturation-flow adjustment via `1 / (1 - pct/100)` — a documented modeling simplification, not an HCM-derived equation, flagged `VERIFY-HCM` in the code and as VERIFICATION.md item 4; the rationale is that demand held at capacity then yields the same fractional reduction in the Chapter 19 incremental-delay term's implied excess demand, and the doc directs analysts to prefer directly calibrated values. `AtdmStrategy::adaptive_signal_control` (in `urban_reliability/urban_reliability.rs`) wraps this into a scheduled Chapter 17 strategy.
 
-PyO3 bindings added: `shoulder_lane_caf`, `shoulder_lane_default_capacity_veh_h_ln`, `ramp_metered_merge_caf`, `alinea_metering_rate` (`src/copython/chapter11.rs`) and `adaptive_signal_sat_flow_adjustment` (`src/copython/chapter17.rs`).
+#### Exhibit 37-9 (illustrative ranges, transcribed constants) and the adaptive-signal sat-flow adjustment formula
+
+Exhibit 37-9 reports only the two illustrative percentage ranges below from a three-corridor simulation study; the HCM prints no formula, so only these two constants are transcribed into code (the rest of the exhibit's structure — per-corridor, per-direction breakdowns — is not carried into code, since no downstream computation consumes it):
+
+```
+Exhibit 37-9 (illustrative simulation-study ranges, not a design equation):
+  ADAPTIVE_SIGNAL_DELAY_REDUCTION_PCT_RANGE = (3.0, 24.0)   # delay reduction, percent
+  ADAPTIVE_SIGNAL_TTI_REDUCTION_PCT_RANGE   = (3.0, 13.0)   # travel time index (TTI) reduction, percent
+```
+
+The sat-flow adjustment formula below is a documented modeling simplification, not an HCM-derived equation (flagged `VERIFY-HCM` in `atdm.rs` and as VERIFICATION.md item 4):
+
+```
+adaptive_signal_sat_flow_adjustment:
+
+  pct = clamp( target_delay_reduction_pct (default: 13.5, the range midpoint), 3.0, 24.0 )      [%]
+  sat_flow_adjustment = 1 / (1 - pct/100)                                                        [dimensionless, >= 1]
+
+  target_delay_reduction_pct = analyst's desired delay reduction from adaptive signal control;
+                                None defaults to the midpoint of ADAPTIVE_SIGNAL_DELAY_REDUCTION_
+                                PCT_RANGE (13.5%); always clamped to the published 3-24 range     [%]
+  sat_flow_adjustment        = multiplicative adjustment to the boundary-intersection saturation
+                                flow rate, consumed by
+                                urban_reliability::AtdmStrategy::sat_flow_adjustment              [dimensionless]
+
+Rationale (not derived from an HCM formula): treating the target delay reduction as achieved
+through better green-time utilization at capacity, demand held at capacity yields the same
+fractional reduction in the Chapter 19 incremental-delay term's implied excess demand under this
+transform. Analysts should prefer a directly calibrated sat_flow_adjustment /
+effective_green_adjustment_s from their own simulation study over this default when available.
+```
+
+Implemented in: `common/atdm.rs::adaptive_signal_sat_flow_adjustment(target_delay_reduction_pct: Option<f64>) -> f64`; wrapped into a scheduled strategy by `urban_reliability/urban_reliability.rs::AtdmStrategy::adaptive_signal_control`.
+
+PyO3 bindings added: `shoulder_lane_caf`, `shoulder_lane_default_capacity_veh_h_ln`, `ramp_metered_merge_caf`, `alinea_metering_rate` (`src/copython/freeway_reliability.rs`) and `adaptive_signal_sat_flow_adjustment` (`src/copython/urban_reliability.rs`).
 
 ## Validation
 
 No published HCM example problem exercises either enhancement end-to-end with asserted numbers, so validation is a mix of exact equation-level unit tests, a synthetic mechanism test, and direction-of-effect integration tests, with the fixture-level metric movement documented as computed-vs-computed (before/after carryover) against the still-unreached published band:
 
 - **`common/delay.rs` unit tests** (in-module): `test_queue_end_of_period_no_initial_queue_undersaturated` (Qb = 0, v < cA gives Qe = 0), `test_queue_end_of_period_clears_within_period` (small Qb dissipates, Qe = 0), `test_queue_end_of_period_large_initial_queue_undersaturated` (t_A = T binds, Qe = Qb + T(v - cA) exactly), and an oversaturated Equation 19-45 check — all hand-computed values, exact or 1e-9 tolerance.
-- **`src/hcm/chapter17/tests.rs::test_residual_queue_carryover_and_day_reset`** — the synthetic mechanism test. A single-lane, deliberately over-capacity segment (demand 3,000 veh/h against a one-lane capacity of about 810 veh/h) with all-zero weather and Tuesdays-only RRP isolates the carryover: the second of two same-clock-hour analysis periods must show a strictly higher TTI than the first (it inherits a nonzero Qb), and the next day's first period must reproduce the previous day's period-1 TTI exactly (day reset, not persistence). Per the commit message, queues in this fixture build past 400 veh and drive TTI to about 8.3.
+- **`src/hcm/urban_reliability/tests.rs::test_residual_queue_carryover_and_day_reset`** — the synthetic mechanism test. A single-lane, deliberately over-capacity segment (demand 3,000 veh/h against a one-lane capacity of about 810 veh/h) with all-zero weather and Tuesdays-only RRP isolates the carryover: the second of two same-clock-hour analysis periods must show a strictly higher TTI than the first (it inherits a nonzero Qb), and the next day's first period must reproduce the previous day's period-1 TTI exactly (day reset, not persistence). Per the commit message, queues in this fixture build past 400 veh and drive TTI to about 8.3.
 - **`tests/chapter17_integration.rs::test_case1_example_problem_4`** (fixture `tests/ExampleCases/hcm/UrbanReliability/case1.json`, the Chapter 29 Example Problem 4 urban reliability case): the reliability metrics are asserted in wide bands with the exact computed values recorded in the assertion messages and the test's doc comment. The carryover moved every metric in the published direction without closing the gap: mean TTI 1.5249 -> 1.5449 (published 1.69/1.64), TTI-80 1.5883 -> 1.5927 (published 1.57/1.56, already within band), PTI 1.7311 -> 1.7462 (published 2.98/2.61 — the main remaining gap), reliability rating 99.54% -> 98.83% (published 93.2/94.1), annual through VHD 30,902 -> 32,083 veh-h, oversaturated scenarios 37 -> 70 of 3,120. The residual PTI gap is now attributed to other still-deferred elements (random 15-min demand variation, incident-duration defaults), not to the carryover mechanism — the corresponding update is written into VERIFICATION.md's Chapter 16/17 section, item 6.
 - **`tests/chapter17_integration.rs::test_case1_atdm_adaptive_signal_control`**: direction-of-effect only (Chapter 37 publishes no assertable effect size) — the strategy must not raise mean travel time, must not degrade PTI, and must not degrade the reliability rating relative to the base run.
 - **`tests/chapter11_integration.rs::ep7_atdm_shoulder_lane_strategy_improves_or_holds_reliability`** and **`::ep7_atdm_ramp_metering_strategy_improves_or_holds_reliability`** (fixture `tests/ExampleCases/hcm/FreewayReliability/case1.json`, the Chapter 25 EP7 freeway reliability case): direction-of-effect assertions (mean TTI, reliability rating, expected VHD must not degrade). Both deliberately apply the strategy facility-wide (all segments for the shoulder lane, all merge segments for metering) rather than to a single segment, because a partial capacity boost can shift the binding bottleneck downstream and legitimately worsen aggregate TTI/VHD — VERIFICATION.md item 6 documents this multi-segment interaction as engine behavior, not a bug.


### PR DESCRIPTION
Every chapter walkthrough in docs/hcm/procedures/ is now a self-contained computational reference: for each HCM step, the equations are written out in full (plain-math with complete where-clauses, units, and defaults), exhibit values limited to what the code transcribes (cited to the constants), and the implementing function given at the new topic paths. ~300 equation blocks across 21 files (+5,125 lines). Stacked on #41 (topic folder rename) — merge that first.

The pass double-checked every equation against both the code and the EPUB MathML independently. Newly found code-vs-manual discrepancies are flagged inline as **DISCREPANCY** and summarized here; a follow-up fix PR is in progress for them:

- Eq 25-41 (planning method): code multiplies by f_HV instead of dividing — latent, invisible at 0% trucks (the only fixture), understates d/c otherwise
- Chapter 15 (oldest code): Exhibit 15-5 class-5 capacity 1,500 vs manual 1,400; four trailing-digit coefficient typos (Exhibits 15-14/15-24/15-26/15-27); Eq 15-5 inputs unclamped; Eq 15-28 pmhvfl defaults 0.0 vs manual's fixed 0.4
- Chapter 19 actuated: Eq 31-9 actuated copy missing the cycle-length factor (milestone-1 copy correct); MAH shared-lane turning-proportion split absent; Eqs 31-123/31-127 shared-left available-capacity extension omitted
- Eq 25-33 printed erratum (book off by lane count; code correct)

Also resolved in prose: stale path references after the rename, two old author-doubt comments in ch15 (Step 9 equations are 15-36..38; no separate S_T exists), Exhibit 31-12 D_p2 subscript caution, and outdated deferral notes.