### PR TITLE
fix(release): build one wheel per matrix job (fixes trailing-data PyPI reject)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,13 +45,19 @@ jobs:
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
+          # Build ONLY this matrix job's interpreter. Building all three here
+          # (-i python3.10/3.11/3.12) made each of the three ubuntu matrix jobs
+          # emit all three manylinux wheels under identical filenames but with
+          # 1-2 byte differences (non-reproducible builds). The publish job's
+          # download-artifact merge-multiple then overwrote those collisions,
+          # and a smaller copy landing on a larger one left trailing bytes that
+          # PyPI rejects ("ZIP archive not accepted: Trailing data"). One wheel
+          # per matrix job = unique filenames = no collision.
           args: |
             --release
             --features with-python
             --out dist
-            -i python3.10
-            -i python3.11
-            -i python3.12
+            -i python${{ matrix.python-version }}
           manylinux: auto
         if: matrix.os == 'ubuntu-latest'
       
@@ -154,7 +160,11 @@ jobs:
   release-crates-io:
     name: Release crates.io
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
+    # Tags only. crates.io versions are immutable with no skip-existing, so a
+    # workflow_dispatch (used to re-complete a partial PyPI upload) must not
+    # re-attempt an already-published crate — it would fail the run. PyPI/
+    # TestPyPI publish steps use skip-existing and are safe to dispatch.
+    if: startsWith(github.ref, 'refs/tags/')
     environment:
       name: crates.io
       url: ${{ steps.set_url.outputs.env_url }}


### PR DESCRIPTION
**Fixes the partial v0.2.0 PyPI release.** Each ubuntu matrix job was building all three manylinux wheels (`-i python3.10/3.11/3.12`), producing same-named but byte-differing duplicates. `download-artifact merge-multiple` overwrote the collisions, and a smaller copy over a larger one left trailing bytes → PyPI `400 Trailing data` → upload aborted mid-way (no cp312 wheels, no sdist reached PyPI). Now each job builds only its own interpreter → unique filenames → no collision. Also guards `release-crates-io` to tags-only so the `workflow_dispatch` used to re-complete the PyPI upload won't fail on the already-published 0.2.0 crate.

After merge: dispatch the release on `dev` to complete 0.2.0 on PyPI (skip-existing fills the 5 missing files).