### PR TITLE
fix(release): decouple PyPI publish from tags-only changelog job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -200,7 +200,11 @@ jobs:
     environment:
       name: PyPI
       url: ${{ steps.set_url.outputs.env_url }}
-    needs: [build, sdist, changelog]
+    # Do NOT depend on `changelog` — it is tags-only (it builds a GitHub Release
+    # from the tag), so a workflow_dispatch skips it, which would in turn skip
+    # this publish (needs = skipped ⇒ skipped). PyPI publishing is independent
+    # of the GitHub-release-notes step; only the artifacts matter.
+    needs: [build, sdist]
     steps:
       - uses: actions/checkout@v6
       - name: Download all artifacts


### PR DESCRIPTION
The dispatch run built clean wheels and completed TestPyPI, but `release-pypi` was skipped: it `needs: [build, sdist, changelog]` and `changelog` is tags-only, so a workflow_dispatch skips changelog ⇒ skips the PyPI publish. Depend only on `[build, sdist]` like `release-testpypi`. Then a dispatch completes the real PyPI upload.