### PR TITLE
chore: library hygiene — LICENSE, River Falls gate test, honest coefficient docs

### DIFF
--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Rei Tamaru
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Rei Tamaru
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -195,9 +195,9 @@ The project uses GitHub Actions for CI/CD, including:
 - Building and publishing to Test PyPI on alpha releases
 - Building and publishing to Cargo and PyPI on new releases
 
-To test the alpha release from Test PyPI, use:
+To install a pre-release from Test PyPI, use (replace the version as needed):
 ```bash
-pip install --no-cache-dir --verbose -i https://test.pypi.org/simple/ transportations-library==0.1.9a4
+pip install --no-cache-dir --verbose -i https://test.pypi.org/simple/ transportations-library==<version>
 ```
 
 Versioning follows [Semantic Versioning](https://semver.org/).

--- a/src/hcm/common/adjustment_factors.rs
+++ b/src/hcm/common/adjustment_factors.rs
@@ -815,17 +815,18 @@ pub fn calculate_recurring_delay_rate(ffs: f64, peak_hour_speed: f64) -> f64 {
 /// Incident delay rate in hours per mile
 ///
 /// # Note
-/// TODO: VERIFY COEFFICIENTS - The coefficients below are assumed values.
-/// Need to verify from HCM Chapter 11 or Chapter 25 for exact Equation 11-3 formula.
-/// See docs/verification_notes.md for details.
+/// The per-lane `(a, b)` coefficients below are provisional and have not been
+/// confirmed against the manual; results from this function should be treated as
+/// approximate until then.
+/// [REF: HCM Ch.11 / Ch.25 — exact Eq. 11-3 form and a, b coefficients by lane count]
 pub fn calculate_incident_delay_rate(num_lanes: u32, vc_ratio: f64) -> f64 {
     // Cap values as specified in the methodology
     let n = num_lanes.min(4).max(2);
     let x = vc_ratio.min(1.0);
 
-    // Equation 11-3 coefficients depend on number of lanes
-    // IDR = a * X^b where a and b depend on N
-    // TODO: VERIFY - These coefficients are assumed, not from manual
+    // Equation 11-3 coefficients depend on number of lanes: IDR = a * X^b.
+    // [REF: HCM Ch.11/25] the (a, b) values below are provisional, not yet
+    // confirmed against the manual.
     let (a, b) = match n {
         2 => (0.000584, 6.32),
         3 => (0.000382, 5.42),

--- a/tests/test_river_falls_gate.py
+++ b/tests/test_river_falls_gate.py
@@ -1,0 +1,94 @@
+"""Regression gate: WIS 35/WIS 65 (River Falls Bypass), EB — HCM Ch.15 facility.
+
+This pins the project's canonical validation number. The directional operational
+analysis of the River Falls facility must yield a facility follower density of
+5.223 pc/mi/ln (LOS C). That value was validated against the analysis request and
+is the reference the rest of the codebase is checked against, but until now it was
+only reproducible by running scripts/analyze_river_falls.py by hand — a drift in
+the Ch.15 chain would not have failed any test. This test closes that gap.
+
+Inputs are verbatim from the analysis request; nothing is estimated. Two engine
+conventions that are easy to get wrong (both verified against the Rust source):
+  * ``spl`` is the POSTED SPEED LIMIT; the engine derives BFFS = 1.14 * spl.
+    PSL = 55 -> BFFS = 62.7.
+  * Complex-alignment segments must be built with ``is_hc=True``, and SubSegment
+    length is in FEET (the engine divides by 5280 internally) while Segment length
+    is in MILES. Passing subsegment length in miles, or leaving is_hc False,
+    silently drops the horizontal-curve speed penalty.
+"""
+
+import pytest
+
+tl = pytest.importorskip(
+    "transportations_library",
+    reason="Rust library wheel not installed; River Falls gate skipped",
+)
+from transportations_library import (  # noqa: E402
+    Segment,
+    SubSegment,
+    TwoLaneHighways,
+)
+
+LW, SW, APD, PHV, PHF, PSL, V, VO = 12.0, 6.0, 2.0, 0.08, 0.94, 55.0, 512.0, 512.0
+FT = 5280.0
+
+
+def _sub(length_ft, rad=None):
+    return (
+        SubSegment(length=length_ft, hor_class=1)
+        if rad is None
+        else SubSegment(length=length_ft, design_rad=rad, sup_ele=0.02)
+    )
+
+
+def _seg(pt, length_mi, grade, ss=None, hc=None):
+    return Segment(
+        passing_type=pt, length=length_mi, grade=grade, spl=PSL, is_hc=hc,
+        volume=V, volume_op=VO, phv=PHV, phf=PHF, subsegments=ss,
+    )
+
+
+def _river_falls_facility():
+    ss3 = [_sub(3200), _sub(2850, 840.0), _sub(2200), _sub(1800, 845.0), _sub(2300)]
+    ss5 = [_sub(1848), _sub(6600, 2520.0)]
+    len3 = sum(s.length for s in ss3) / FT  # feet -> miles for the segment length
+    len5 = sum(s.length for s in ss5) / FT
+    segments = [
+        _seg(0, 0.16, 1.0),                 # S1 passing-constrained
+        _seg(1, 0.64, 1.0),                 # S2 passing zone
+        _seg(0, len3, 0.0, ss3, hc=True),   # S3 passing-constrained, complex alignment
+        _seg(1, 0.625, 0.0),                # S4 passing zone
+        _seg(0, len5, 1.0, ss5, hc=True),   # S5 passing-constrained, complex alignment
+    ]
+    return TwoLaneHighways(
+        segments=segments, lane_width=LW, shoulder_width=SW, apd=APD, pmhvfl=PHV,
+    )
+
+
+def _facility_metrics(hwy):
+    tot_len = w_fd = w_spd = 0.0
+    for i in range(hwy.num_segments):
+        hwy.identify_vertical_class(i)
+        _, _, cap = hwy.determine_demand_flow(i)
+        hwy.determine_vertical_alignment(i)
+        hwy.determine_free_flow_speed(i)
+        ats = hwy.estimate_average_speed(i)[0]
+        hwy.estimate_percent_followers(i)
+        hwy.determine_follower_density_pc_pz(i)
+        hwy.determine_adjustment_to_follower_density(i)
+        s = hwy.segments[i]
+        tot_len += s.length
+        w_fd += s.followers_density * s.length
+        w_spd += ats * s.length
+    fac_fd, fac_spd = w_fd / tot_len, w_spd / tot_len
+    return tot_len, fac_fd, fac_spd, hwy.determine_facility_los(fac_fd, fac_spd)
+
+
+def test_river_falls_facility_follower_density_gate():
+    """The canonical gate: facility follower density 5.223 pc/mi/ln, LOS C."""
+    tot_len, fac_fd, fac_spd, fac_los = _facility_metrics(_river_falls_facility())
+    assert round(fac_fd, 3) == 5.223, f"facility follower density drifted: {fac_fd}"
+    assert fac_los == "C"
+    # Secondary pins so a compensating error in length/speed can't hide a drift.
+    assert round(tot_len, 3) == 5.364
+    assert round(fac_spd, 2) == 58.36


### PR DESCRIPTION
Post-release hygiene (the dev↔main reconcile already landed as #48).

- **LICENSE-MIT + LICENSE-APACHE** — the crate declared `MIT OR Apache-2.0` with no license text; add the canonical dual-license files.
- **tests/test_river_falls_gate.py** — pins the canonical gate (River Falls Ch.15 facility follower density **5.223**, LOS C), which was only reproducible by hand before. +1 test (115→116 pytest).
- **Honest coefficient docs** — `calculate_incident_delay_rate` rendered `TODO: VERIFY COEFFICIENTS - assumed values` on docs.rs and linked a nonexistent file; keep the provisional/approximate caveat, drop the dead link, add a `[REF]` marker.
- **README** — stale `==0.1.9a4` Test PyPI line → placeholder.

Verified: 614 Rust tests, 116 pytest, 0 failures; builds clean; CRLF preserved.