### PR TITLE
feat(ch13): full example-problem coverage — weaving design, service volumes, ML access cross-weave

### DIFF
--- a/src/copython/weaving.rs
+++ b/src/copython/weaving.rs
@@ -1,7 +1,9 @@
 //! Python bindings for HCM Chapter 13 (Freeway Weaving Segments).
 
 use crate::hcm::weaving::weaving::{
-    FacilityType, TerrainType, WeavingSegment as LibWeavingSegment, WeavingType,
+    cross_weave_gp_capacity as lib_cross_weave_gp_capacity, service_flow_rate_ideal as lib_sfi,
+    service_volumes as lib_service_volumes, DemandSplit, FacilityType, TerrainType,
+    WeavingSegment as LibWeavingSegment, WeavingType,
 };
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
@@ -291,7 +293,79 @@ impl WeavingSegment {
     }
 }
 
+/// Cross-weave capacity effect on the general purpose lanes near an ML access
+/// segment - HCM Equations 13-24 and 13-25.
+///
+/// Args:
+///     cw: cross-weave demand flow rate (pc/h), must be > 0.
+///     l_cw_min: cross-weave length L_cw-min (ft).
+///     n_gp: number of general purpose lanes.
+///     c_gp: unadjusted GP-lane capacity from Chapter 12 (veh/h).
+///
+/// Returns:
+///     (crf, caf, c_gpa) - capacity reduction factor, capacity adjustment
+///     factor, and adjusted GP-lane capacity (veh/h).
+///
+/// Raises:
+///     ValueError: if `cw` is not positive (the model takes its natural log).
+#[pyfunction]
+#[pyo3(name = "cross_weave_gp_capacity")]
+pub fn py_cross_weave_gp_capacity(
+    cw: f64,
+    l_cw_min: f64,
+    n_gp: u32,
+    c_gp: f64,
+) -> PyResult<(f64, f64, f64)> {
+    match lib_cross_weave_gp_capacity(cw, l_cw_min, n_gp, c_gp) {
+        Some(e) => Ok((e.crf, e.caf, e.c_gpa)),
+        None => Err(PyValueError::new_err(
+            "cross-weave demand flow rate (cw) must be > 0",
+        )),
+    }
+}
+
+/// Service flow rate under ideal conditions SFI (pc/h) for a target LOS density
+/// - HCM Chapter 27, Example Problem 5.
+///
+/// Args:
+///     segment: a WeavingSegment holding the fixed geometry.
+///     split: (ff, rf, fr, rr) demand fractions of the total flow, summing to 1.
+///     target_density: LOS threshold density (pc/mi/ln); 10/20/28/35 for A-D.
+///
+/// Returns:
+///     SFI (pc/h) - the largest ideal total flow rate held to that density.
+#[pyfunction]
+#[pyo3(name = "service_flow_rate_ideal")]
+pub fn py_service_flow_rate_ideal(
+    segment: &WeavingSegment,
+    split: (f64, f64, f64, f64),
+    target_density: f64,
+) -> f64 {
+    let (ff, rf, fr, rr) = split;
+    lib_sfi(
+        &segment.inner,
+        &DemandSplit { ff, rf, fr, rr },
+        target_density,
+    )
+}
+
+/// Convert an ideal-conditions service flow rate into prevailing service flow
+/// rate, service volume, and daily service volume - HCM Chapter 27, EP 5.
+///
+/// Returns:
+///     (sfi, sf, sv, dsv) where SF = SFI x f_HV, SV = SF x PHF,
+///     DSV = SV / (K x D).
+#[pyfunction]
+#[pyo3(name = "service_volumes")]
+pub fn py_service_volumes(sfi: f64, f_hv: f64, phf: f64, k: f64, d: f64) -> (f64, f64, f64, f64) {
+    let s = lib_service_volumes(sfi, f_hv, phf, k, d);
+    (s.sfi, s.sf, s.sv, s.dsv)
+}
+
 pub(crate) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<WeavingSegment>()?;
+    m.add_function(wrap_pyfunction!(py_cross_weave_gp_capacity, m)?)?;
+    m.add_function(wrap_pyfunction!(py_service_flow_rate_ideal, m)?)?;
+    m.add_function(wrap_pyfunction!(py_service_volumes, m)?)?;
     Ok(())
 }

--- a/src/hcm/weaving/weaving.rs
+++ b/src/hcm/weaving/weaving.rs
@@ -583,6 +583,165 @@ impl WeavingSegment {
 }
 
 // =============================================================================
+// Managed-lane access segments: cross-weave capacity effect (Eqs. 13-24/13-25)
+// =============================================================================
+
+/// Effect of cross-weaving traffic on the capacity of the general purpose (GP)
+/// lanes adjacent to a managed-lane (ML) access segment - HCM Equations 13-24
+/// and 13-25.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct CrossWeaveEffect {
+    /// Capacity reduction factor CRF (decimal) - Equation 13-24.
+    pub crf: f64,
+    /// Capacity adjustment factor CAF = 1 - CRF (decimal) - Equation 13-24.
+    pub caf: f64,
+    /// Adjusted GP-lane capacity c_GPA = c_GP x CAF (veh/h) - Equation 13-25.
+    pub c_gpa: f64,
+}
+
+/// Cross-weave capacity effect on the general purpose lanes adjacent to an ML
+/// access segment - HCM Chapter 13, Equations 13-24 and 13-25 (developed under
+/// NCHRP Project 03-96).
+///
+/// ```text
+/// CRF   = -0.0897 + 0.0252 ln(CW) - 0.00001453 L_cw_min + 0.002967 N_GP
+/// CAF   = 1 - CRF
+/// c_GPA = c_GP x CAF
+/// ```
+///
+/// Arguments:
+/// - `cw`: cross-weave demand flow rate (pc/h). Must be > 0 (the model takes
+///   its natural logarithm); returns `None` otherwise.
+/// - `l_cw_min`: cross-weave length L_cw-min (ft).
+/// - `n_gp`: number of general purpose lanes.
+/// - `c_gp`: unadjusted GP-lane capacity from Chapter 12 (veh/h).
+///
+/// The HCM states no numeric bounds on the regression. For a small `cw` the raw
+/// CRF can fall at or below zero (implying CAF >= 1); the value is returned
+/// unclamped so callers see the model's actual output, and results outside the
+/// NCHRP 03-96 calibration range should be treated with caution.
+pub fn cross_weave_gp_capacity(
+    cw: f64,
+    l_cw_min: f64,
+    n_gp: u32,
+    c_gp: f64,
+) -> Option<CrossWeaveEffect> {
+    if cw <= 0.0 {
+        return None;
+    }
+    let crf = -0.0897 + 0.0252 * cw.ln() - 0.00001453 * l_cw_min + 0.002967 * (n_gp as f64);
+    let caf = 1.0 - crf;
+    Some(CrossWeaveEffect {
+        crf,
+        caf,
+        c_gpa: c_gp * caf,
+    })
+}
+
+// =============================================================================
+// Service flow rates and service volumes (HCM Chapter 27, Example Problem 5)
+// =============================================================================
+
+/// Demand split of a weaving segment as fractions of the total flow rate v.
+/// The four fractions are expected to sum to 1.0.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct DemandSplit {
+    /// Freeway-to-freeway fraction of v.
+    pub ff: f64,
+    /// Ramp-to-freeway fraction of v.
+    pub rf: f64,
+    /// Freeway-to-ramp fraction of v.
+    pub fr: f64,
+    /// Ramp-to-ramp fraction of v.
+    pub rr: f64,
+}
+
+/// Service flow rates and volumes for one (LOS, geometry) cell - HCM Chapter 27,
+/// Example Problem 5.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct ServiceVolumes {
+    /// Service flow rate under ideal conditions SFI (pc/h).
+    pub sfi: f64,
+    /// Service flow rate under prevailing conditions SF = SFI x f_HV (veh/h).
+    pub sf: f64,
+    /// Service volume SV = SF x PHF (veh/h).
+    pub sv: f64,
+    /// Daily service volume DSV = SV / (K x D) (veh/day).
+    pub dsv: f64,
+}
+
+/// Service flow rate under ideal conditions SFI (pc/h) for a target LOS density
+/// - HCM Chapter 27, Example Problem 5.
+///
+/// Holds the segment's geometry (`template`) fixed and searches for the total
+/// ideal flow rate v, apportioned by `split`, whose resulting weaving density
+/// equals `target_density`. The search is done under equivalent ideal
+/// conditions (PHF = 1, no heavy vehicles, CAF = SAF = 1), consistent with the
+/// definition of SFI. Density rises monotonically with v below breakdown, so a
+/// bisection converges. This is the SFI for LOS A through D (density thresholds
+/// of 10/20/28/35 pc/mi/ln); the SFI at LOS E is the segment capacity, obtained
+/// from [`WeavingSegment::determine_capacity`] instead.
+pub fn service_flow_rate_ideal(
+    template: &WeavingSegment,
+    split: &DemandSplit,
+    target_density: f64,
+) -> f64 {
+    // Density of an ideal-conditions probe carrying total flow v.
+    let density_at = |v: f64| -> f64 {
+        let mut seg = template.clone();
+        seg.phf = 1.0;
+        seg.heavy_vehicle_pct = 0.0;
+        seg.caf = 1.0;
+        seg.saf = 1.0;
+        seg.v_ff = split.ff * v;
+        seg.v_rf = split.rf * v;
+        seg.v_fr = split.fr * v;
+        seg.v_rr = split.rr * v;
+        seg.run_analysis();
+        seg.get_density()
+    };
+
+    // Bracket the target, then bisect. `hi` grows until its density overshoots.
+    let mut lo = 0.0_f64;
+    let mut hi = 1000.0_f64;
+    let mut guard = 0;
+    while density_at(hi) < target_density && guard < 60 {
+        lo = hi;
+        hi *= 2.0;
+        guard += 1;
+    }
+    // 40 bisection steps take the bracket well below 1 pc/h wide.
+    for _ in 0..40 {
+        let mid = 0.5 * (lo + hi);
+        if density_at(mid) < target_density {
+            lo = mid;
+        } else {
+            hi = mid;
+        }
+    }
+    0.5 * (lo + hi)
+}
+
+/// Convert a service flow rate under ideal conditions (SFI, pc/h) into the
+/// prevailing-condition service flow rate, service volume, and daily service
+/// volume - HCM Chapter 27, Example Problem 5.
+///
+/// - `f_hv`: heavy-vehicle adjustment factor (SF = SFI x f_HV).
+/// - `phf`: peak hour factor (SV = SF x PHF).
+/// - `k`: K-factor, proportion of AADT in the analysis hour.
+/// - `d`: D-factor, directional proportion (DSV = SV / (K x D)).
+pub fn service_volumes(sfi: f64, f_hv: f64, phf: f64, k: f64, d: f64) -> ServiceVolumes {
+    let sf = sfi * f_hv;
+    let sv = sf * phf;
+    let dsv = if k > 0.0 && d > 0.0 {
+        sv / (k * d)
+    } else {
+        f64::INFINITY
+    };
+    ServiceVolumes { sfi, sf, sv, dsv }
+}
+
+// =============================================================================
 // Tests
 // =============================================================================
 
@@ -734,5 +893,46 @@ mod tests {
         assert!(seg.get_density() > 0.0);
         // Two-sided segments have no weaving-flow capacity limit
         assert!(seg.capacity_weaving.is_none());
+    }
+
+    #[test]
+    fn test_cross_weave_gp_capacity() {
+        // HCM Chapter 27, Example Problem 6: CW = 400, L_cw-min = 1,000, N_GP = 3.
+        let e = cross_weave_gp_capacity(400.0, 1000.0, 3, 7050.0).unwrap();
+        assert!((e.crf - 0.056).abs() < 0.001);
+        assert!((e.caf - (1.0 - e.crf)).abs() < 1e-12);
+
+        // Example Problem 7: CW = 100, L_cw-min = 1,500, N_GP = 2, c_GP = 4,800.
+        let e = cross_weave_gp_capacity(100.0, 1500.0, 2, 4800.0).unwrap();
+        assert!((e.crf - 0.0105).abs() < 0.0005);
+        assert!((e.c_gpa - 4750.0).abs() < 5.0);
+
+        // ln(CW) is undefined at or below zero demand.
+        assert!(cross_weave_gp_capacity(0.0, 1000.0, 2, 4800.0).is_none());
+    }
+
+    #[test]
+    fn test_service_flow_rate_monotone() {
+        let template = WeavingSegment {
+            num_lanes: 3,
+            num_weaving_lanes: 2,
+            ffs: 65.0,
+            interchange_density: 1.0,
+            lc_rf: 0,
+            lc_fr: 2,
+            length_short: 1500.0,
+            basic_freeway_capacity: 2350.0,
+            ..Default::default()
+        };
+        let split = DemandSplit { ff: 0.65, rf: 0.15, fr: 0.12, rr: 0.08 };
+        // Higher LOS thresholds admit strictly more flow.
+        let sfi_a = service_flow_rate_ideal(&template, &split, 10.0);
+        let sfi_c = service_flow_rate_ideal(&template, &split, 28.0);
+        assert!(sfi_c > sfi_a);
+        // The chain is a straight product; verify the arithmetic.
+        let sv = service_volumes(sfi_c, 0.952, 0.93, 0.08, 0.55);
+        assert!((sv.sf - sfi_c * 0.952).abs() < 1e-9);
+        assert!((sv.sv - sv.sf * 0.93).abs() < 1e-9);
+        assert!((sv.dsv - sv.sv / (0.08 * 0.55)).abs() < 1e-6);
     }
 }

--- a/tests/ExampleCases/hcm/Weaving/case4a.json
+++ b/tests/ExampleCases/hcm/Weaving/case4a.json
@@ -1,0 +1,22 @@
+{
+    "weaving_type": "OneSided",
+    "facility_type": "Freeway",
+    "length_short": 1000.0,
+    "num_lanes": 5,
+    "num_weaving_lanes": 2,
+    "ffs": 75.0,
+    "v_ff": 2000.0,
+    "v_fr": 1450.0,
+    "v_rf": 1500.0,
+    "v_rr": 2000.0,
+    "phf": 1.0,
+    "heavy_vehicle_pct": 0.0,
+    "terrain": "Level",
+    "lc_rf": 0,
+    "lc_fr": 2,
+    "lc_rr": 0,
+    "interchange_density": 1.0,
+    "basic_freeway_capacity": 2400.0,
+    "caf": 1.0,
+    "saf": 1.0
+}

--- a/tests/ExampleCases/hcm/Weaving/case4b.json
+++ b/tests/ExampleCases/hcm/Weaving/case4b.json
@@ -1,0 +1,22 @@
+{
+    "weaving_type": "OneSided",
+    "facility_type": "Freeway",
+    "length_short": 1000.0,
+    "num_lanes": 5,
+    "num_weaving_lanes": 3,
+    "ffs": 75.0,
+    "v_ff": 2000.0,
+    "v_fr": 1450.0,
+    "v_rf": 1500.0,
+    "v_rr": 2000.0,
+    "phf": 1.0,
+    "heavy_vehicle_pct": 0.0,
+    "terrain": "Level",
+    "lc_rf": 0,
+    "lc_fr": 1,
+    "lc_rr": 0,
+    "interchange_density": 1.0,
+    "basic_freeway_capacity": 2400.0,
+    "caf": 1.0,
+    "saf": 1.0
+}

--- a/tests/ExampleCases/hcm/Weaving/case6.json
+++ b/tests/ExampleCases/hcm/Weaving/case6.json
@@ -1,0 +1,22 @@
+{
+    "weaving_type": "OneSided",
+    "facility_type": "Freeway",
+    "length_short": 1500.0,
+    "num_lanes": 4,
+    "num_weaving_lanes": 2,
+    "ffs": 65.0,
+    "v_ff": 3060.0,
+    "v_fr": 540.0,
+    "v_rf": 270.0,
+    "v_rr": 270.0,
+    "phf": 0.9,
+    "heavy_vehicle_pct": 0.0,
+    "terrain": "Level",
+    "lc_rf": 1,
+    "lc_fr": 1,
+    "lc_rr": 0,
+    "interchange_density": 1.0,
+    "basic_freeway_capacity": 2350.0,
+    "caf": 1.0,
+    "saf": 1.0
+}

--- a/tests/ExampleCases/hcm/Weaving/case7.json
+++ b/tests/ExampleCases/hcm/Weaving/case7.json
@@ -1,0 +1,22 @@
+{
+    "weaving_type": "OneSided",
+    "facility_type": "MultilaneOrCD",
+    "length_short": 1000.0,
+    "num_lanes": 3,
+    "num_weaving_lanes": 2,
+    "ffs": 70.0,
+    "v_ff": 3100.0,
+    "v_fr": 200.0,
+    "v_rf": 100.0,
+    "v_rr": 900.0,
+    "phf": 1.0,
+    "heavy_vehicle_pct": 0.0,
+    "terrain": "Level",
+    "lc_rf": 1,
+    "lc_fr": 1,
+    "lc_rr": 0,
+    "interchange_density": 1.0,
+    "basic_freeway_capacity": 2400.0,
+    "caf": 1.0,
+    "saf": 1.0
+}

--- a/tests/chapter13_integration.rs
+++ b/tests/chapter13_integration.rs
@@ -10,7 +10,9 @@ use std::fs::File;
 use std::io::BufReader;
 use std::path::PathBuf;
 
-use transportations_library::hcm::weaving::weaving::WeavingSegment;
+use transportations_library::hcm::weaving::weaving::{
+    cross_weave_gp_capacity, service_flow_rate_ideal, service_volumes, DemandSplit, WeavingSegment,
+};
 use transportations_library::hcm::common::LevelOfService;
 
 fn load_case(name: &str) -> WeavingSegment {
@@ -137,4 +139,198 @@ fn example_problem_3_two_sided_weave() {
 
     assert_approx(seg.get_density(), 39.2, 0.5, "D (pc/mi/ln)");
     assert_eq!(los, LevelOfService::E);
+}
+
+/// HCM Chapter 27, Example Problem 4 (Trial 1): design of a major weaving
+/// segment. A direct five-lane connection forces the freeway-to-ramp movement
+/// to make two lane changes (N_WL = 2), so the weaving-flow capacity of 2,400 /
+/// VR = 5,654 pc/h falls below the 6,950 pc/h demand and the segment fails.
+#[test]
+fn example_problem_4_trial1_design_los_f() {
+    let mut seg = load_case("case4a.json");
+    let los = seg.run_analysis();
+
+    assert_approx(seg.get_flow_weaving(), 2950.0, 1.0, "v_W (pc/h)");
+    assert_approx(seg.get_flow_nonweaving(), 4000.0, 1.0, "v_NW (pc/h)");
+    assert_approx(seg.get_flow_total(), 6950.0, 1.0, "v (pc/h)");
+    assert_approx(seg.get_volume_ratio(), 0.424, 0.001, "VR");
+
+    assert_approx(seg.get_lc_min(), 2900.0, 1.0, "LC_MIN (lc/h)");
+    assert_approx(seg.c_iwl.unwrap(), 1944.0, 5.0, "c_IWL (pc/h/ln)");
+    // Weaving-flow criterion (Eq. 13-7/13-8) governs and is below demand.
+    assert_approx(seg.capacity_weaving.unwrap(), 5654.0, 15.0, "c_W weaving (pc/h)");
+    assert_approx(seg.get_capacity(), 5654.0, 15.0, "c_W (pc/h)");
+    assert!(seg.get_vc_ratio() > 1.0, "demand should exceed capacity");
+    assert_eq!(los, LevelOfService::F);
+}
+
+/// HCM Chapter 27, Example Problem 4 (Trial 2): adding a lane to the exit leg
+/// drops the freeway-to-ramp movement to a single lane change and raises N_WL
+/// to 3. The weaving-flow capacity climbs to 3,500 / VR = 8,255 pc/h and the
+/// segment delivers the target LOS C.
+#[test]
+fn example_problem_4_trial2_design_los_c() {
+    let mut seg = load_case("case4b.json");
+    let los = seg.run_analysis();
+
+    assert_approx(seg.get_lc_min(), 1450.0, 1.0, "LC_MIN (lc/h)");
+    assert_approx(seg.get_l_max(), 5391.0, 5.0, "L_MAX (ft)");
+    assert!(seg.is_weaving_segment());
+
+    assert_approx(seg.c_iwl.unwrap(), 2064.0, 5.0, "c_IWL (pc/h/ln)");
+    assert_approx(seg.get_capacity(), 8255.0, 15.0, "c_W (pc/h)");
+    assert!(seg.get_vc_ratio() < 1.0, "demand should be below capacity");
+
+    assert_approx(seg.lc_w.unwrap(), 1899.0, 5.0, "LC_W (lc/h)");
+    assert_approx(seg.lc_nw.unwrap(), 403.0, 5.0, "LC_NW (lc/h)");
+    assert_approx(seg.get_lc_all(), 2302.0, 8.0, "LC_ALL (lc/h)");
+
+    assert_approx(seg.get_speed_weaving(), 56.8, 0.5, "S_W (mi/h)");
+    assert_approx(seg.get_speed_nonweaving(), 57.9, 0.5, "S_NW (mi/h)");
+    assert_approx(seg.get_speed_avg(), 57.4, 0.5, "S (mi/h)");
+
+    assert_approx(seg.get_density(), 24.2, 0.5, "D (pc/mi/ln)");
+    assert_eq!(los, LevelOfService::C);
+}
+
+/// HCM Chapter 27, Example Problem 5: constructing a service volume table.
+/// The chapter method does not yield service flow rates directly; they are
+/// found by raising demand until each LOS threshold density is reached. The
+/// published SFI values (Exhibit 27-15) are rounded down to the nearest 100
+/// pc/h, so the reconstructed values are checked to within one rounding bucket.
+#[test]
+fn example_problem_5_service_volume_table() {
+    // Case geometry (one-sided major weave, FFS = 65, ID = 1, level terrain).
+    // The ramp-to-freeway movement needs no lane change (LC_RF = 0); the
+    // freeway-to-ramp movement needs two for N_WL = 2.
+    let template = WeavingSegment {
+        weaving_type:
+            transportations_library::hcm::weaving::weaving::WeavingType::OneSided,
+        facility_type:
+            transportations_library::hcm::weaving::weaving::FacilityType::Freeway,
+        num_lanes: 3,
+        num_weaving_lanes: 2,
+        ffs: 65.0,
+        interchange_density: 1.0,
+        lc_rf: 0,
+        lc_fr: 2,
+        lc_rr: 0,
+        basic_freeway_capacity: 2350.0,
+        ..Default::default()
+    };
+    let split = DemandSplit { ff: 0.65, rf: 0.15, fr: 0.12, rr: 0.08 };
+
+    // Exhibit 27-15, N = 3, N_WL = 2, L_S = 1,500 ft.
+    let mut seg = WeavingSegment { length_short: 1500.0, ..template.clone() };
+    // LOS A (D = 10) -> 1,700 pc/h; B (D = 20) -> 3,200; C (D = 28) -> 4,300.
+    let sfi_a = service_flow_rate_ideal(&seg, &split, 10.0);
+    let sfi_b = service_flow_rate_ideal(&seg, &split, 20.0);
+    let sfi_c = service_flow_rate_ideal(&seg, &split, 28.0);
+    assert_approx(round_down_100(sfi_a), 1700.0, 100.0, "SFI LOS A");
+    assert_approx(round_down_100(sfi_b), 3200.0, 100.0, "SFI LOS B");
+    assert_approx(round_down_100(sfi_c), 4300.0, 100.0, "SFI LOS C");
+
+    // The SFI at LOS E is the segment capacity (ideal). Confirm the segment
+    // capacity sits in the published 6,100 pc/h neighbourhood for this cell.
+    seg.phf = 1.0;
+    seg.heavy_vehicle_pct = 0.0;
+    seg.v_ff = split.ff * 6100.0;
+    seg.v_rf = split.rf * 6100.0;
+    seg.v_fr = split.fr * 6100.0;
+    seg.v_rr = split.rr * 6100.0;
+    seg.run_analysis();
+    assert_approx(round_down_100(seg.get_capacity()), 6100.0, 100.0, "SFI LOS E (capacity)");
+
+    // Prevailing-condition chain (Exhibits 27-16 through 27-18): 5% trucks on
+    // level terrain (E_T = 2.0 -> f_HV = 0.952), PHF = 0.93, K = 0.08, D = 0.55.
+    let f_hv = 1.0 / (1.0 + 0.05 * (2.0 - 1.0));
+    let sv = service_volumes(4300.0, f_hv, 0.93, 0.08, 0.55);
+    assert_approx(sv.sf, 4300.0 * f_hv, 0.01, "SF = SFI x f_HV");
+    assert_approx(sv.sv, 4300.0 * f_hv * 0.93, 0.01, "SV = SF x PHF");
+    assert_approx(sv.dsv, sv.sv / (0.08 * 0.55), 0.01, "DSV = SV / (K x D)");
+}
+
+/// HCM Chapter 27, Example Problem 6: an ML access segment with cross-weaving.
+/// The access segment itself is analyzed as a one-sided ramp weave (LOS C),
+/// while the adjacent GP merge segment loses capacity to the cross-weave
+/// movement (Equation 13-24).
+#[test]
+fn example_problem_6_ml_access_cross_weave() {
+    let mut seg = load_case("case6.json");
+    let los = seg.run_analysis();
+
+    assert_approx(seg.get_flow_weaving(), 900.0, 1.0, "v_W (pc/h)");
+    assert_approx(seg.get_flow_nonweaving(), 3700.0, 1.0, "v_NW (pc/h)");
+    assert_approx(seg.get_flow_total(), 4600.0, 1.0, "v (pc/h)");
+    assert_approx(seg.get_volume_ratio(), 0.196, 0.001, "VR");
+
+    assert_approx(seg.get_lc_min(), 900.0, 1.0, "LC_MIN (lc/h)");
+    assert_approx(seg.get_l_max(), 4495.0, 5.0, "L_MAX (ft)");
+    assert_approx(seg.c_iwl.unwrap(), 2121.0, 5.0, "c_IWL (pc/h/ln)");
+    assert_approx(seg.get_capacity(), 8483.0, 10.0, "c_W (pc/h)");
+
+    assert_approx(seg.lc_w.unwrap(), 1276.0, 5.0, "LC_W (lc/h)");
+    assert_approx(seg.lc_nw.unwrap(), 805.0, 5.0, "LC_NW (lc/h)");
+    assert_approx(seg.get_lc_all(), 2081.0, 8.0, "LC_ALL (lc/h)");
+
+    assert_approx(seg.get_speed_weaving(), 53.7, 0.5, "S_W (mi/h)");
+    assert_approx(seg.get_speed_nonweaving(), 53.0, 0.5, "S_NW (mi/h)");
+    assert_approx(seg.get_speed_avg(), 53.1, 0.5, "S (mi/h)");
+
+    assert_approx(seg.get_density(), 21.7, 0.5, "D (pc/mi/ln)");
+    assert_eq!(los, LevelOfService::C);
+
+    // Cross-weave capacity reduction on the GP merge segment (Lane Group Pair 1):
+    // CW = 360/0.9 = 400 pc/h, L_cw-min = 1,000 ft, N_GP = 3.
+    let cw = cross_weave_gp_capacity(400.0, 1000.0, 3, 7050.0).unwrap();
+    assert_approx(cw.crf, 0.056, 0.001, "CRF");
+}
+
+/// HCM Chapter 27, Example Problem 7: an ML access segment with a downstream
+/// off-ramp. Part 1 analyzes the access segment as a three-lane ramp weave
+/// (LOS B); Part 2 applies the cross-weave capacity adjustment to the two GP
+/// lanes feeding the off-ramp.
+#[test]
+fn example_problem_7_ml_access_downstream_offramp() {
+    let mut seg = load_case("case7.json");
+    let los = seg.run_analysis();
+
+    assert_approx(seg.get_flow_weaving(), 300.0, 1.0, "v_W (pc/h)");
+    assert_approx(seg.get_flow_total(), 4300.0, 1.0, "v (pc/h)");
+    assert_approx(seg.get_volume_ratio(), 0.070, 0.001, "VR");
+
+    assert_approx(seg.get_lc_min(), 300.0, 1.0, "LC_MIN (lc/h)");
+    assert_approx(seg.get_l_max(), 3251.0, 5.0, "L_MAX (ft)");
+    assert_approx(seg.c_iwl.unwrap(), 2228.0, 5.0, "c_IWL (pc/h/ln)");
+    assert_approx(seg.get_capacity(), 6684.0, 10.0, "c_W (pc/h)");
+
+    assert_approx(seg.lc_w.unwrap(), 462.0, 5.0, "LC_W (lc/h)");
+    assert_approx(seg.lc_nw.unwrap(), 788.0, 5.0, "LC_NW (lc/h)");
+    assert_approx(seg.get_lc_all(), 1250.0, 8.0, "LC_ALL (lc/h)");
+
+    assert_approx(seg.get_speed_weaving(), 58.3, 0.5, "S_W (mi/h)");
+    assert_approx(seg.get_speed_nonweaving(), 61.0, 0.5, "S_NW (mi/h)");
+    assert_approx(seg.get_speed_avg(), 60.8, 0.5, "S (mi/h)");
+
+    assert_approx(seg.get_density(), 23.6, 0.5, "D (pc/mi/ln)");
+    // The published solution reports LOS B, citing a B/C boundary of 24
+    // pc/mi/ln (Exhibit 13-6, multilane/C-D row: A<=12, B<=24, C<=32). Note the
+    // manual applies the multilane/C-D thresholds to this ML access segment,
+    // unlike Example Problem 6, which used the freeway thresholds (B<=20).
+    // case7.json therefore sets facility_type = "multilane" to reproduce the
+    // published result; see VERIFY-HCM note in the PR description.
+    assert_eq!(los, LevelOfService::B);
+
+    // Part 2: cross-weave on the GP lanes. CW = 100 pc/h, L_cw-min = 1,500 ft,
+    // N_GP = 2, c_GP = 2,400 x 2 = 4,800 pc/h.
+    let cw = cross_weave_gp_capacity(100.0, 1500.0, 2, 4800.0).unwrap();
+    assert_approx(cw.crf, 0.0105, 0.0005, "CRF");
+    assert_approx(cw.caf, 0.9895, 0.0005, "CAF");
+    assert_approx(cw.c_gpa, 4750.0, 5.0, "c_GPA (pc/h)");
+}
+
+/// Round a flow rate down to the nearest 100, matching the HCM's service-volume
+/// presentation convention (Chapter 27, Example Problem 5).
+fn round_down_100(x: f64) -> f64 {
+    (x / 100.0).floor() * 100.0
 }

--- a/tests/test_chapter13_integration.py
+++ b/tests/test_chapter13_integration.py
@@ -14,7 +14,8 @@ import pytest
 
 tl = pytest.importorskip("transportations_library")
 
-CASE1 = Path(__file__).parent / "ExampleCases" / "hcm" / "Weaving" / "case1.json"
+CASES = Path(__file__).parent / "ExampleCases" / "hcm" / "Weaving"
+CASE1 = CASES / "case1.json"
 
 WEAVING_TYPE_MAP = {"OneSided": "one_sided", "TwoSided": "two_sided"}
 FACILITY_TYPE_MAP = {"Freeway": "freeway", "MultilaneOrCD": "multilane"}
@@ -92,3 +93,72 @@ class TestWeavingExampleProblem1:
     def test_repr(self):
         seg = load_segment(CASE1)
         assert "WeavingSegment" in repr(seg)
+
+
+class TestWeavingExampleProblems4to7:
+    """HCM Chapter 27, Example Problems 4-7 through the PyO3 bindings."""
+
+    def test_ep4_trial2_design_los_c(self):
+        # Trial 2 adds an exit lane (N_WL = 3) to reach the target LOS C.
+        seg = load_segment(CASES / "case4b.json")
+        assert seg.run_analysis() == "C"
+        assert seg.capacity == pytest.approx(8255.0, abs=15.0)
+        assert seg.density == pytest.approx(24.2, abs=0.5)
+
+    def test_ep4_trial1_design_los_f(self):
+        # Trial 1 (N_WL = 2) fails: weaving-flow capacity below demand.
+        seg = load_segment(CASES / "case4a.json")
+        assert seg.run_analysis() == "F"
+        assert seg.vc_ratio > 1.0
+
+    def test_ep6_ml_access_los_c(self):
+        seg = load_segment(CASES / "case6.json")
+        assert seg.run_analysis() == "C"
+        assert seg.density == pytest.approx(21.7, abs=0.5)
+
+    def test_ep7_ml_access_los_b(self):
+        # Multilane/C-D LOS thresholds (B <= 24) per the published solution.
+        seg = load_segment(CASES / "case7.json")
+        assert seg.run_analysis() == "B"
+        assert seg.density == pytest.approx(23.6, abs=0.5)
+
+
+class TestCrossWeaveAndServiceVolumes:
+    """Managed-lane cross-weave (Eq. 13-24/25) and EP 5 service volumes."""
+
+    def test_cross_weave_ep6(self):
+        crf, caf, c_gpa = tl.cross_weave_gp_capacity(400.0, 1000.0, 3, 7050.0)
+        assert crf == pytest.approx(0.056, abs=0.001)
+        assert caf == pytest.approx(1.0 - crf, abs=1e-12)
+
+    def test_cross_weave_ep7(self):
+        crf, caf, c_gpa = tl.cross_weave_gp_capacity(100.0, 1500.0, 2, 4800.0)
+        assert crf == pytest.approx(0.0105, abs=0.0005)
+        assert c_gpa == pytest.approx(4750.0, abs=5.0)
+
+    def test_cross_weave_requires_positive_demand(self):
+        with pytest.raises(ValueError):
+            tl.cross_weave_gp_capacity(0.0, 1000.0, 2, 4800.0)
+
+    def test_service_flow_rate_and_volumes(self):
+        # EP 5 cell: N = 3, N_WL = 2, L_S = 1,500, LOS C (D = 28) -> ~4,300 pc/h.
+        seg = tl.WeavingSegment(
+            weaving_type="one_sided",
+            facility_type="freeway",
+            length_short=1500.0,
+            num_lanes=3,
+            num_weaving_lanes=2,
+            ffs=65.0,
+            interchange_density=1.0,
+            lc_rf=0,
+            lc_fr=2,
+            lc_rr=0,
+            basic_freeway_capacity=2350.0,
+        )
+        sfi = tl.service_flow_rate_ideal(seg, (0.65, 0.15, 0.12, 0.08), 28.0)
+        assert (sfi // 100) * 100 == pytest.approx(4300.0, abs=100.0)
+
+        sfi_out, sf, sv, dsv = tl.service_volumes(4300.0, 0.952, 0.93, 0.08, 0.55)
+        assert sf == pytest.approx(4300.0 * 0.952, abs=0.01)
+        assert sv == pytest.approx(sf * 0.93, abs=0.01)
+        assert dsv == pytest.approx(sv / (0.08 * 0.55), abs=0.01)


### PR DESCRIPTION
Brings HCM Chapter 13 (Freeway Weaving Segments) to full example-problem coverage by adding **Ch.27 Example Problems 4–7** on top of the existing EP1–3, all validated against the manual's published values.

## What's covered

| EP | Topic | Approach | Result |
|----|-------|----------|--------|
| 4 | Design of a major weaving segment | Two operational analyses (Trials 1 & 2) | Trial 1 → LOS F (weaving-flow capacity 2,400/VR = 5,654 < demand); Trial 2 → LOS C |
| 5 | Service-volume table | `service_flow_rate_ideal` inversion + `service_volumes` chain | SFI matches Exhibit 27-15 within the manual's round-down-to-100 bucket |
| 6 | ML access segment with cross-weaving | Ramp-weave operational method + Eq 13-24 CRF | LOS C; CRF = 0.056 |
| 7 | ML access segment with downstream off-ramp | Ramp-weave method + Eq 13-24/13-25 | LOS B; CRF = 0.0105, CAF = 0.9895, c_GPA = 4,750 |

## New methodology

The only genuinely new equations are the managed-lane cross-weave capacity effect (**Eqs 13-24/13-25**), added as `cross_weave_gp_capacity`:

```
CRF   = -0.0897 + 0.0252·ln(CW) - 0.00001453·L_cw_min + 0.002967·N_GP
CAF   = 1 - CRF
c_GPA = c_GP · CAF
```

Verified against both EP6 (→0.056) and EP7 (→0.0105). Returns `None` when `CW ≤ 0` (the model takes a natural log). The raw CRF is **not** silently clamped when it goes negative for small CW — the domain is documented instead.

EP4/EP6/EP7 otherwise reuse the existing operational method unchanged (hand-verified to reproduce the book's lane-change rates, speeds, and density exactly). EP5 adds an SFI inversion (bisection to the LOS threshold density) plus the SF/SV/DSV chain. All three new functions are exposed through PyO3.

## ⚠️ VERIFY-HCM: EP6/EP7 LOS-table inconsistency

The manual is internally inconsistent on which LOS table applies to an ML access segment:

- **EP6** uses the **freeway** table (Exhibit 13-6, B ≤ 20) → D = 21.7 = **LOS C**
- **EP7** uses the **multilane/C-D** table (B ≤ 24, the book explicitly cites the "B/C boundary of 24") → D = 23.6 = **LOS B**

Same segment type, two different tables in the HCM's own worked examples. Reproduced faithfully — `case7.json` sets `facility_type = "MultilaneOrCD"` and the test documents why. Please confirm you're comfortable with this reading.

## Validation

- **621 Rust tests** + **124 pytest** pass (EP1–7 integration + cross-weave/service-volume unit tests, through both the Rust API and PyO3 bindings).
- **River Falls facility follower density = 5.223 gate intact** (no facility-path code touched).
- New fixtures: `case4a`, `case4b`, `case6`, `case7` under `tests/ExampleCases/hcm/Weaving/`.