### PR TITLE
feat(ch14): full example-problem coverage — merge/diverge service flow rates and volumes

### DIFF
--- a/src/copython/merge_diverge.rs
+++ b/src/copython/merge_diverge.rs
@@ -1,7 +1,9 @@
 //! Python bindings for HCM Chapter 14 (Freeway Merge and Diverge Segments).
 
 use crate::hcm::merge_diverge::merge_diverge::{
-    AdjacentRampType, RampLanes, RampSegment as LibRampSegment, RampSide, RampType, TerrainType,
+    ramp_service_flow_rate_ideal as lib_ramp_sfi, ramp_service_volumes as lib_ramp_sv,
+    AdjacentRampType, RampLanes, RampSegment as LibRampSegment, RampSide, RampType,
+    ServiceDemandBasis, TerrainType,
 };
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
@@ -321,7 +323,61 @@ impl RampSegment {
     }
 }
 
+/// Service flow rate under ideal conditions (pc/h) at a target ramp-influence
+/// density - HCM Chapter 28, Example Problem 5.
+///
+/// Provide exactly one of:
+///   - `ramp_fraction`: ramp demand as a fraction of freeway demand; the
+///     returned SFI is the approaching freeway flow v_F (Case 1).
+///   - `fixed_freeway_vf`: fixed approaching freeway flow (pc/h, ideal); the
+///     returned SFI is the ramp flow v_R (Case 2).
+///
+/// Args:
+///     segment: a RampSegment holding the fixed geometry.
+///     target_density: LOS threshold density (pc/mi/ln); 10/20/28/35 for A-D.
+///     ramp_fraction: Case 1 basis (mutually exclusive with fixed_freeway_vf).
+///     fixed_freeway_vf: Case 2 basis (mutually exclusive with ramp_fraction).
+///
+/// Returns:
+///     The SFI (pc/h), or None if that LOS is unachievable (the minimum density
+///     already exceeds the target).
+#[pyfunction]
+#[pyo3(
+    name = "ramp_service_flow_rate_ideal",
+    signature = (segment, target_density, ramp_fraction=None, fixed_freeway_vf=None)
+)]
+pub fn py_ramp_service_flow_rate_ideal(
+    segment: &RampSegment,
+    target_density: f64,
+    ramp_fraction: Option<f64>,
+    fixed_freeway_vf: Option<f64>,
+) -> PyResult<Option<f64>> {
+    let basis = match (ramp_fraction, fixed_freeway_vf) {
+        (Some(f), None) => ServiceDemandBasis::ApproachingFreeway { ramp_fraction: f },
+        (None, Some(vf)) => ServiceDemandBasis::FixedFreeway { v_f: vf },
+        _ => {
+            return Err(PyValueError::new_err(
+                "provide exactly one of ramp_fraction (Case 1) or fixed_freeway_vf (Case 2)",
+            ))
+        }
+    };
+    Ok(lib_ramp_sfi(&segment.inner, &basis, target_density))
+}
+
+/// Convert an ideal-conditions service flow rate (pc/h) to a prevailing-
+/// condition service flow rate and service volume - HCM Chapter 28, EP 5.
+///
+/// Returns:
+///     (sf, sv) in veh/h, where SF = SFI x f_HV x f_p and SV = SF x PHF.
+#[pyfunction]
+#[pyo3(name = "ramp_service_volumes")]
+pub fn py_ramp_service_volumes(sfi: f64, f_hv: f64, f_p: f64, phf: f64) -> (f64, f64) {
+    lib_ramp_sv(sfi, f_hv, f_p, phf)
+}
+
 pub(crate) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<RampSegment>()?;
+    m.add_function(wrap_pyfunction!(py_ramp_service_flow_rate_ideal, m)?)?;
+    m.add_function(wrap_pyfunction!(py_ramp_service_volumes, m)?)?;
     Ok(())
 }

--- a/src/hcm/merge_diverge/merge_diverge.rs
+++ b/src/hcm/merge_diverge/merge_diverge.rs
@@ -946,6 +946,103 @@ impl RampSegment {
 }
 
 // =============================================================================
+// Service flow rates and service volumes (HCM Chapter 28, Example Problem 5)
+// =============================================================================
+
+/// Basis for a ramp-junction service-flow-rate computation - HCM Chapter 28,
+/// Example Problem 5.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub enum ServiceDemandBasis {
+    /// Vary the approaching freeway demand v_F, with ramp demand tracking it as
+    /// `ramp_fraction * v_F` (Case 1). The returned SFI is expressed as v_F.
+    ApproachingFreeway { ramp_fraction: f64 },
+    /// Hold the approaching freeway demand fixed at `v_f` (pc/h, ideal) and vary
+    /// the ramp demand v_R (Case 2). The returned SFI is expressed as v_R.
+    FixedFreeway { v_f: f64 },
+}
+
+/// Service flow rate under ideal conditions (pc/h) at a target ramp-influence
+/// density - HCM Chapter 28, Example Problem 5.
+///
+/// Holds the segment geometry (`template`) fixed and searches, under equivalent
+/// ideal conditions (PHF = 1, no heavy vehicles, CAF = SAF = 1), for the demand
+/// that drives the ramp-influence density (Equation 14-22) to `target_density`.
+/// The quantity returned is the one the basis varies: approaching freeway flow
+/// v_F for `ApproachingFreeway`, ramp flow v_R for `FixedFreeway`. This is the
+/// SFI for LOS A-D (density thresholds 10/20/28/35 pc/mi/ln).
+///
+/// The LOS E service flow rate is a capacity limit rather than a density and is
+/// found separately from the downstream-freeway and ramp capacities
+/// ([`RampSegment::get_capacity_freeway`] / [`RampSegment::get_capacity_ramp`]).
+///
+/// Returns `None` when the target density cannot be reached because the density
+/// at zero varied demand already exceeds it - i.e. that LOS is unachievable at
+/// this location (as with LOS A and B in Example Problem 5, Case 2).
+pub fn ramp_service_flow_rate_ideal(
+    template: &RampSegment,
+    basis: &ServiceDemandBasis,
+    target_density: f64,
+) -> Option<f64> {
+    let density_at = |vary: f64| -> f64 {
+        let mut seg = template.clone();
+        seg.phf = 1.0;
+        seg.heavy_vehicle_pct = 0.0;
+        seg.ramp_heavy_vehicle_pct = Some(0.0);
+        seg.caf = 1.0;
+        seg.saf = 1.0;
+        match *basis {
+            ServiceDemandBasis::ApproachingFreeway { ramp_fraction } => {
+                seg.freeway_demand = vary;
+                seg.ramp_demand = ramp_fraction * vary;
+            }
+            ServiceDemandBasis::FixedFreeway { v_f } => {
+                seg.freeway_demand = v_f;
+                seg.ramp_demand = vary;
+            }
+        }
+        seg.run_analysis();
+        seg.get_density()
+    };
+
+    // If even zero varied demand already exceeds the target, that LOS cannot be
+    // achieved at this location.
+    if density_at(0.0) > target_density {
+        return None;
+    }
+    let mut lo = 0.0_f64;
+    let mut hi = 1000.0_f64;
+    let mut guard = 0;
+    while density_at(hi) < target_density && guard < 60 {
+        lo = hi;
+        hi *= 2.0;
+        guard += 1;
+    }
+    for _ in 0..50 {
+        let mid = 0.5 * (lo + hi);
+        if density_at(mid) < target_density {
+            lo = mid;
+        } else {
+            hi = mid;
+        }
+    }
+    Some(0.5 * (lo + hi))
+}
+
+/// Convert an ideal-conditions service flow rate (pc/h) to a prevailing-
+/// condition service flow rate and service volume - HCM Chapter 28, EP 5.
+///
+/// - `f_hv`: heavy-vehicle adjustment factor (SF = SFI x f_HV x f_p).
+/// - `f_p`: driver-population factor (1.0 for regular commuters).
+/// - `phf`: peak hour factor (SV = SF x PHF).
+///
+/// Returns `(SF, SV)` in veh/h.
+pub fn ramp_service_volumes(sfi: f64, f_hv: f64, f_p: f64, phf: f64) -> (f64, f64) {
+    let sf = sfi * f_hv * f_p;
+    let sv = sf * phf;
+    (sf, sv)
+}
+
+// =============================================================================
 // Tests
 // =============================================================================
 

--- a/tests/chapter14_integration.rs
+++ b/tests/chapter14_integration.rs
@@ -1,5 +1,5 @@
 //! Integration tests for HCM Chapter 14 (Freeway Merge and Diverge Segments)
-//! against the published results of HCM Chapter 28 Example Problems 1-4.
+//! against the published results of HCM Chapter 28 Example Problems 1-5.
 //!
 //! Tolerances: flows +-5 pc/h (published values are rounded to whole numbers
 //! and the book carries rounded intermediates); speeds +-0.5 mi/h; densities
@@ -9,7 +9,10 @@ use std::fs::File;
 use std::io::BufReader;
 use std::path::PathBuf;
 
-use transportations_library::hcm::merge_diverge::merge_diverge::RampSegment;
+use transportations_library::hcm::merge_diverge::merge_diverge::{
+    ramp_service_flow_rate_ideal, ramp_service_volumes, AdjacentRampType, RampLanes, RampSegment,
+    RampSide, RampType, ServiceDemandBasis, TerrainType,
+};
 use transportations_library::hcm::common::LevelOfService;
 
 fn load_case(name: &str) -> RampSegment {
@@ -158,4 +161,120 @@ fn example_problem_4_left_hand_on_ramp() {
     assert_approx(seg.get_speed_ramp(), 54.8, 0.5, "S_R (mi/h)");
     assert_approx(seg.get_speed_outer().unwrap(), 61.2, 0.5, "S_O (mi/h)");
     assert_approx(seg.get_speed_avg(), 56.5, 0.5, "S (mi/h)");
+}
+
+/// Build the HCM Chapter 28, Example Problem 5 geometry: an isolated single-lane
+/// right-hand on-ramp on a six-lane freeway (FFS 70), ramp FFS 40, 1,000-ft
+/// acceleration lane. Demands are supplied by the service-flow-rate search.
+fn ep5_template() -> RampSegment {
+    RampSegment {
+        ramp_type: RampType::OnRamp,
+        ramp_side: RampSide::Right,
+        ramp_lanes: RampLanes::OneLane,
+        freeway_lanes: 3,
+        freeway_ffs: 70.0,
+        ramp_ffs: 40.0,
+        accel_lane_length: Some(1000.0),
+        terrain: TerrainType::Level,
+        adjacent_upstream: AdjacentRampType::None,
+        adjacent_downstream: AdjacentRampType::None,
+        ..Default::default()
+    }
+}
+
+/// HCM Chapter 28, Example Problem 5, Case 1: ramp demand fixed at 10% of the
+/// approaching freeway demand; service flow rates expressed as approaching
+/// freeway flows (Exhibit 28-4). f_HV = 0.939 (6.5% trucks), f_p = 1, PHF = 0.87.
+#[test]
+fn example_problem_5_case1_approaching_freeway_demand() {
+    let template = ep5_template();
+    let basis = ServiceDemandBasis::ApproachingFreeway { ramp_fraction: 0.10 };
+    let f_hv = 1.0 / (1.0 + 0.065 * (2.0 - 1.0)); // = 0.939
+    let phf = 0.87;
+
+    // LOS A-C: solve v_F at the threshold densities (Equation 14-22). The book
+    // solves the linearized equation with a rounded slope (0.005454 vs. the
+    // exact 0.0054569), so its published values run a few pc/h high at the
+    // larger flows (e.g. LOS C: 5,280 published vs. 5,277 exact); tolerance is
+    // widened to +-6 pc/h to absorb that rounded intermediate.
+    let sfi_a = ramp_service_flow_rate_ideal(&template, &basis, 10.0).unwrap();
+    let sfi_b = ramp_service_flow_rate_ideal(&template, &basis, 20.0).unwrap();
+    let sfi_c = ramp_service_flow_rate_ideal(&template, &basis, 28.0).unwrap();
+    assert_approx(sfi_a, 1979.0, 6.0, "v_F SFI LOS A (pc/h)");
+    assert_approx(sfi_b, 3813.0, 6.0, "v_F SFI LOS B (pc/h)");
+    assert_approx(sfi_c, 5280.0, 6.0, "v_F SFI LOS C (pc/h)");
+
+    // Prevailing SF and SV for LOS A (Exhibit 28-4: 1,858 veh/h, 1,616 veh/h).
+    let (sf_a, sv_a) = ramp_service_volumes(sfi_a, f_hv, 1.0, phf);
+    assert_approx(sf_a, 1858.0, 3.0, "SF LOS A (veh/h)");
+    assert_approx(sv_a, 1616.0, 3.0, "SV LOS A (veh/h)");
+    let (_, sv_c) = ramp_service_volumes(sfi_c, f_hv, 1.0, phf);
+    assert_approx(sv_c, 4313.0, 3.0, "SV LOS C (veh/h)");
+
+    // LOS E is a capacity limit: downstream freeway reaches 7,200 pc/h, so with
+    // v_R = 0.10 v_F, v_F = 7,200 / 1.10 = 6,545 pc/h (ramp 655 < 2,000 cap).
+    let mut probe = template.clone();
+    probe.phf = 1.0;
+    probe.heavy_vehicle_pct = 0.0;
+    probe.run_analysis();
+    let cap_freeway = probe.get_capacity_freeway();
+    let cap_ramp = probe.get_capacity_ramp();
+    assert_approx(cap_freeway, 7200.0, 1.0, "downstream freeway capacity (pc/h)");
+    assert_approx(cap_ramp, 2000.0, 1.0, "ramp capacity (pc/h)");
+    let sfi_e = cap_freeway / 1.10;
+    assert_approx(sfi_e, 6545.0, 2.0, "v_F SFI LOS E (pc/h)");
+    assert!(0.10 * sfi_e < cap_ramp, "ramp flow at LOS E must stay under capacity");
+
+    // LOS D is unachievable: its threshold flow (v_F ~ 6,563) exceeds the LOS E
+    // capacity, so capacity is reached before density 35 pc/mi/ln (Exhibit 28-4
+    // reports NA for LOS D).
+    let sfi_d = ramp_service_flow_rate_ideal(&template, &basis, 35.0).unwrap();
+    assert!(
+        sfi_d > sfi_e,
+        "LOS D threshold ({sfi_d}) should exceed the LOS E capacity ({sfi_e}), making D unachievable"
+    );
+}
+
+/// HCM Chapter 28, Example Problem 5, Case 2: approaching freeway demand held at
+/// 4,000 veh/h; service flow rates expressed as ramp demands (Exhibit 28-5).
+#[test]
+fn example_problem_5_case2_fixed_freeway_demand() {
+    let template = ep5_template();
+    let f_hv = 1.0 / (1.0 + 0.065 * (2.0 - 1.0)); // = 0.939
+    let phf = 0.87;
+    // Convert the fixed 4,000 veh/h freeway demand to pc/h under ideal conditions.
+    let v_f = 4000.0 / (phf * f_hv); // = 4,896 pc/h
+    assert_approx(v_f, 4896.0, 2.0, "v_F ideal (pc/h)");
+    let basis = ServiceDemandBasis::FixedFreeway { v_f };
+
+    // LOS A and B are unachievable: the minimum density (at zero ramp flow) is
+    // already 22.33 pc/mi/ln, above the 10 and 20 thresholds (Exhibit 28-5 NA).
+    assert!(ramp_service_flow_rate_ideal(&template, &basis, 10.0).is_none());
+    assert!(ramp_service_flow_rate_ideal(&template, &basis, 20.0).is_none());
+
+    // LOS C and D: solve for the ramp flow at the threshold densities.
+    let sfi_c = ramp_service_flow_rate_ideal(&template, &basis, 28.0).unwrap();
+    let sfi_d = ramp_service_flow_rate_ideal(&template, &basis, 35.0).unwrap();
+    assert_approx(sfi_c, 772.0, 3.0, "v_R SFI LOS C (pc/h)");
+    assert_approx(sfi_d, 1726.0, 3.0, "v_R SFI LOS D (pc/h)");
+
+    let (sf_c, sv_c) = ramp_service_volumes(sfi_c, f_hv, 1.0, phf);
+    assert_approx(sf_c, 725.0, 3.0, "SF LOS C (veh/h)");
+    assert_approx(sv_c, 631.0, 3.0, "SV LOS C (veh/h)");
+    let (sf_d, sv_d) = ramp_service_volumes(sfi_d, f_hv, 1.0, phf);
+    assert_approx(sf_d, 1621.0, 3.0, "SF LOS D (veh/h)");
+    assert_approx(sv_d, 1410.0, 3.0, "SV LOS D (veh/h)");
+
+    // LOS E: the downstream-capacity ramp flow (7,200 - 4,896 = 2,304 pc/h)
+    // exceeds the 2,000 pc/h ramp capacity, so LOS E is capped at the ramp
+    // capacity (Exhibit 28-5: SFI 2,000 -> SF 1,878 -> SV 1,633 veh/h).
+    let mut probe = template.clone();
+    probe.phf = 1.0;
+    probe.heavy_vehicle_pct = 0.0;
+    probe.run_analysis();
+    let sfi_e = (probe.get_capacity_freeway() - v_f).min(probe.get_capacity_ramp());
+    assert_approx(sfi_e, 2000.0, 1.0, "v_R SFI LOS E (pc/h)");
+    let (sf_e, sv_e) = ramp_service_volumes(sfi_e, f_hv, 1.0, phf);
+    assert_approx(sf_e, 1878.0, 3.0, "SF LOS E (veh/h)");
+    assert_approx(sv_e, 1633.0, 3.0, "SV LOS E (veh/h)");
 }

--- a/tests/test_chapter14_integration.py
+++ b/tests/test_chapter14_integration.py
@@ -95,3 +95,58 @@ class TestMergeDivergeExampleProblem2:
     def test_repr(self):
         seg = load_segment(CASE2)
         assert "RampSegment" in repr(seg)
+
+
+class TestMergeDivergeServiceVolumes:
+    """HCM Chapter 28, Example Problem 5 (service flow rates / service volumes)."""
+
+    def _ep5_segment(self):
+        return tl.RampSegment(
+            ramp_type="on_ramp",
+            ramp_side="right",
+            ramp_lanes=1,
+            freeway_lanes=3,
+            freeway_ffs=70.0,
+            ramp_ffs=40.0,
+            accel_lane_length=1000.0,
+            freeway_demand=4000.0,
+            ramp_demand=400.0,
+            phf=0.87,
+            heavy_vehicle_pct=0.065,
+            terrain="level",
+            adjacent_upstream="none",
+            adjacent_downstream="none",
+            caf=1.0,
+            saf=1.0,
+        )
+
+    def test_case1_approaching_freeway_demand(self):
+        seg = self._ep5_segment()
+        f_hv = 1.0 / (1.0 + 0.065 * (2.0 - 1.0))
+        # Case 1: ramp = 10% of freeway; solve v_F at each LOS density.
+        sfi_a = tl.ramp_service_flow_rate_ideal(seg, 10.0, ramp_fraction=0.10)
+        sfi_c = tl.ramp_service_flow_rate_ideal(seg, 28.0, ramp_fraction=0.10)
+        assert sfi_a == pytest.approx(1979.0, abs=6.0)
+        assert sfi_c == pytest.approx(5280.0, abs=6.0)
+        sf_a, sv_a = tl.ramp_service_volumes(sfi_a, f_hv, 1.0, 0.87)
+        assert sf_a == pytest.approx(1858.0, abs=3.0)
+        assert sv_a == pytest.approx(1616.0, abs=3.0)
+
+    def test_case2_fixed_freeway_demand(self):
+        seg = self._ep5_segment()
+        f_hv = 1.0 / (1.0 + 0.065 * (2.0 - 1.0))
+        v_f = 4000.0 / (0.87 * f_hv)  # 4,896 pc/h ideal
+        # LOS A/B unachievable at this fixed freeway demand (min density 22.33).
+        assert tl.ramp_service_flow_rate_ideal(seg, 20.0, fixed_freeway_vf=v_f) is None
+        sfi_c = tl.ramp_service_flow_rate_ideal(seg, 28.0, fixed_freeway_vf=v_f)
+        sfi_d = tl.ramp_service_flow_rate_ideal(seg, 35.0, fixed_freeway_vf=v_f)
+        assert sfi_c == pytest.approx(772.0, abs=3.0)
+        assert sfi_d == pytest.approx(1726.0, abs=3.0)
+        sf_c, sv_c = tl.ramp_service_volumes(sfi_c, f_hv, 1.0, 0.87)
+        assert sf_c == pytest.approx(725.0, abs=3.0)
+        assert sv_c == pytest.approx(631.0, abs=3.0)
+
+    def test_basis_requires_exactly_one(self):
+        seg = self._ep5_segment()
+        with pytest.raises(ValueError):
+            tl.ramp_service_flow_rate_ideal(seg, 28.0)


### PR DESCRIPTION
Brings HCM Chapter 14 (Freeway Merge and Diverge Segments) to full example-problem coverage by adding **Ch.28 Example Problem 5** on top of the existing EP1–4.

## What's new

EP5 illustrates service flow rates and service volumes for an isolated on-ramp on a six-lane freeway, in two cases — both reproduced against the published exhibits:

| Case | Basis | LOS A | B | C | D | E |
|------|-------|-------|---|---|---|---|
| 1 (Exhibit 28-4) | ramp = 10% of freeway, solve v_F | 1,979 | 3,813 | 5,280 | **NA** | 6,545 |
| 2 (Exhibit 28-5) | freeway fixed at 4,000 veh/h, solve v_R | **NA** | **NA** | 772 | 1,726 | 2,000 |

(pc/h under ideal conditions; the tests also check the SF/SV conversions in veh/h)

The `NA` cases are meaningful and reproduced:
- **Case 1 LOS D** — the LOS D threshold flow (v_F ≈ 6,563) exceeds the LOS E *capacity* (6,545 pc/h, downstream freeway 7,200 / 1.10), so capacity is reached before density 35 pc/mi/ln.
- **Case 2 LOS A/B** — at the fixed freeway demand the minimum ramp-influence density (22.33 pc/mi/ln) already exceeds the 10 and 20 thresholds.
- **Case 2 LOS E** — the downstream-capacity ramp flow (2,304 pc/h) exceeds the 2,000 pc/h ramp capacity, so E is capped at the ramp capacity.

## New methodology

```rust
ramp_service_flow_rate_ideal(template, basis, target_density) -> Option<f64>
ramp_service_volumes(sfi, f_hv, f_p, phf) -> (sf, sv)
```

`ramp_service_flow_rate_ideal` bisects the varied demand until the ramp-influence density (Eq 14-22) hits the target, under equivalent ideal conditions, and returns `None` when the target density is unreachable (LOS unachievable). `ServiceDemandBasis` selects Case 1 (`ApproachingFreeway { ramp_fraction }`) or Case 2 (`FixedFreeway { v_f }`). LOS E is a capacity limit, computed from the existing `get_capacity_freeway` / `get_capacity_ramp` getters rather than a density. Both functions are exposed through PyO3.

## Minor note

The manual solves the linearized Eq 14-22 with a rounded slope (0.005454 vs. the exact 0.0054569), so its published SFI values run a few pc/h high at the larger flows (LOS C: 5,280 published vs. 5,277 exact). The test tolerance is widened to ±6 pc/h; our computed value is the more precise one. This mirrors the existing EP3 note in the same file.

## Validation

- **616 Rust tests** + **119 pytest** pass (EP1–5 integration + service-volume cases, through the Rust API and PyO3 bindings).
- **River Falls facility follower density = 5.223 gate intact.**