### PR TITLE
feat(ch16): facility multimodal LOS aggregation (pedestrian, bicycle, transit)

### DIFF
--- a/src/copython/urban_facilities.rs
+++ b/src/copython/urban_facilities.rs
@@ -1,8 +1,17 @@
 //! Python bindings for HCM Chapter 16 (Urban Street Facilities).
 
-use crate::hcm::urban_facilities::urban_facilities::UrbanFacility as LibUrbanFacility;
+use crate::hcm::urban_facilities::urban_facilities::{
+    facility_bicycle_los as lib_bike_los, facility_pedestrian_los as lib_ped_los,
+    facility_transit_los as lib_transit_los, facility_transit_los_score,
+    facility_weighted_los_score, UrbanFacility as LibUrbanFacility,
+};
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
+
+fn los_char(l: crate::hcm::common::LevelOfService) -> String {
+    let c: char = l.into();
+    c.to_string()
+}
 
 /// HCM Chapter 16 urban street facility analysis (motorized vehicle
 /// methodology, one direction of travel).
@@ -138,7 +147,54 @@ impl UrbanFacility {
     }
 }
 
+/// HCM Equations 16-7/16-8 (pedestrian) or 16-10/16-11 (bicycle): facility LOS
+/// score as a travel-time-weighted generalized mean of the segment scores.
+///
+/// Args:
+///     segments: list of (length_ft, segment_travel_speed, segment_los_score).
+///
+/// Returns:
+///     The facility LOS score.
+#[pyfunction]
+pub fn facility_pedestrian_or_bicycle_los_score(segments: Vec<(f64, f64, f64)>) -> f64 {
+    facility_weighted_los_score(&segments)
+}
+
+/// HCM Equation 16-13: transit facility LOS score (length-weighted average of
+/// the segment transit scores).
+///
+/// Args:
+///     segments: list of (length_ft, segment_transit_los_score).
+#[pyfunction]
+pub fn facility_transit_los_score_py(segments: Vec<(f64, f64)>) -> f64 {
+    facility_transit_los_score(&segments)
+}
+
+/// Facility pedestrian LOS letter - Exhibit 16-4 (worse of the score-based and
+/// average-pedestrian-space LOS).
+#[pyfunction]
+pub fn facility_pedestrian_los(score: f64, pedestrian_space: f64) -> String {
+    los_char(lib_ped_los(score, pedestrian_space))
+}
+
+/// Facility bicycle LOS letter - Exhibit 16-5, from the bicycle LOS score.
+#[pyfunction]
+pub fn facility_bicycle_los(score: f64) -> String {
+    los_char(lib_bike_los(score))
+}
+
+/// Facility transit LOS letter - Exhibit 16-5, from the transit LOS score.
+#[pyfunction]
+pub fn facility_transit_los(score: f64) -> String {
+    los_char(lib_transit_los(score))
+}
+
 pub(crate) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<UrbanFacility>()?;
+    m.add_function(wrap_pyfunction!(facility_pedestrian_or_bicycle_los_score, m)?)?;
+    m.add_function(wrap_pyfunction!(facility_transit_los_score_py, m)?)?;
+    m.add_function(wrap_pyfunction!(facility_pedestrian_los, m)?)?;
+    m.add_function(wrap_pyfunction!(facility_bicycle_los, m)?)?;
+    m.add_function(wrap_pyfunction!(facility_transit_los, m)?)?;
     Ok(())
 }

--- a/src/hcm/urban_facilities/urban_facilities.rs
+++ b/src/hcm/urban_facilities/urban_facilities.rs
@@ -17,7 +17,8 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::hcm::urban_segments::exhibits::exhibit_18_1_los;
+use crate::hcm::urban_segments::exhibits::{exhibit_18_1_los, segment_los_from_score};
+use crate::hcm::urban_segments::pedestrian::pedestrian_space_los;
 use crate::hcm::urban_segments::urban_segments::{traveler_perception_score, UrbanSegment};
 use crate::hcm::common::LevelOfService;
 
@@ -87,6 +88,106 @@ fn length_weighted_harmonic_mean(segments: &[(f64, f64)]) -> f64 {
         return 0.0;
     }
     total_length / total_time
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Multimodal facility aggregation (pedestrian, bicycle, transit)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// HCM Equation 16-5: pedestrian space for the facility,
+/// `A_p,F = Σ L_i / Σ (L_i / A_p,i)` (ft^2/p) — the length-weighted harmonic
+/// mean of the segment pedestrian spaces.
+///
+/// * `segments` — `(L_i, A_p,i)` pairs: segment length (ft) and segment
+///   average pedestrian space (ft^2/p)
+pub fn facility_pedestrian_space(segments: &[(f64, f64)]) -> f64 {
+    length_weighted_harmonic_mean(segments)
+}
+
+/// HCM Equation 16-6: pedestrian travel speed for the facility,
+/// `S_Tp,F = Σ L_i / Σ (L_i / S_Tp,seg,i)` (ft/s).
+///
+/// * `segments` — `(L_i, S_Tp,seg,i)` pairs: segment length (ft) and segment
+///   pedestrian travel speed (ft/s)
+pub fn facility_pedestrian_travel_speed(segments: &[(f64, f64)]) -> f64 {
+    length_weighted_harmonic_mean(segments)
+}
+
+/// HCM Equation 16-9: bicycle travel speed for the facility,
+/// `S_Tb,F = Σ L_i / Σ (L_i / S_Tb,seg,i)` (mi/h).
+pub fn facility_bicycle_travel_speed(segments: &[(f64, f64)]) -> f64 {
+    length_weighted_harmonic_mean(segments)
+}
+
+/// HCM Equation 16-12: transit travel speed for the facility,
+/// `S_Tt,F = Σ L_i / Σ (L_i / S_Tt,seg,i)` (mi/h).
+pub fn facility_transit_travel_speed(segments: &[(f64, f64)]) -> f64 {
+    length_weighted_harmonic_mean(segments)
+}
+
+/// HCM Equations 16-7/16-8 (pedestrian) and 16-10/16-11 (bicycle): the
+/// facility LOS score as a travel-time-weighted generalized mean of the
+/// segment LOS scores:
+///
+/// ```text
+/// WTT_i = (L_i / S_seg,i) × ((I_seg,i − 0.125) / 0.75)^3
+/// I_F   = 0.75 × [ Σ WTT_i / Σ (L_i / S_seg,i) ]^(1/3) + 0.125
+/// ```
+///
+/// The denominator `Σ (L_i / S_seg,i)` is the total facility travel time for
+/// the mode. This form (unlike the transit score) preserves the cube-root
+/// weighting used by the segment score equations.
+///
+/// * `segments` — `(L_i, S_seg,i, I_seg,i)` triples: segment length (ft),
+///   the segment travel speed for the mode, and the segment LOS score
+pub fn facility_weighted_los_score(segments: &[(f64, f64, f64)]) -> f64 {
+    let total_time: f64 = segments
+        .iter()
+        .map(|(l, s, _)| if *s > 0.0 { l / s } else { 0.0 })
+        .sum();
+    if total_time <= 0.0 {
+        return 0.0;
+    }
+    let weighted: f64 = segments
+        .iter()
+        .map(|(l, s, i)| {
+            let t = if *s > 0.0 { l / s } else { 0.0 };
+            let inner = (i - 0.125) / 0.75;
+            t * inner.powi(3)
+        })
+        .sum();
+    0.75 * (weighted / total_time).cbrt() + 0.125
+}
+
+/// HCM Equation 16-13: transit LOS score for the facility,
+/// `I_t,F = Σ (I_t,seg,i L_i) / Σ L_i` — the length-weighted arithmetic mean
+/// of the segment transit LOS scores.
+///
+/// * `segments` — `(L_i, I_t,seg,i)` pairs: segment length (ft) and segment
+///   transit LOS score
+pub fn facility_transit_los_score(segments: &[(f64, f64)]) -> f64 {
+    let total_length: f64 = segments.iter().map(|(l, _)| l).sum();
+    if total_length <= 0.0 {
+        return 0.0;
+    }
+    segments.iter().map(|(l, i)| l * i).sum::<f64>() / total_length
+}
+
+/// Facility pedestrian LOS - Exhibit 16-4 (identical bands to Exhibit 18-2):
+/// the worse of the score-based LOS and the average-pedestrian-space LOS.
+pub fn facility_pedestrian_los(score: f64, space: f64) -> LevelOfService {
+    segment_los_from_score(score).max(pedestrian_space_los(space))
+}
+
+/// Facility bicycle LOS - Exhibit 16-5 (identical bands to Exhibit 18-3),
+/// from the segment-based bicycle LOS score.
+pub fn facility_bicycle_los(score: f64) -> LevelOfService {
+    segment_los_from_score(score)
+}
+
+/// Facility transit LOS - Exhibit 16-5, from the transit LOS score.
+pub fn facility_transit_los(score: f64) -> LevelOfService {
+    segment_los_from_score(score)
 }
 
 /// HCM Exhibit 16-3: LOS Criteria: Motorized Vehicle Mode.

--- a/tests/chapter16_multimodal_integration.rs
+++ b/tests/chapter16_multimodal_integration.rs
@@ -1,0 +1,136 @@
+//! Integration tests for the HCM Chapter 16 (Urban Street Facilities)
+//! multimodal facility LOS aggregation (Equations 16-5 through 16-13),
+//! anchored to Chapter 29, Example Problem 2 (Pedestrian and Bicycle
+//! Improvements; Exhibits 29-53, 29-54, 29-55).
+//!
+//! The facility scores are travel-time-weighted (pedestrian/bicycle) or
+//! length-weighted (transit) aggregations of the Chapter 18 segment scores.
+//! Example Problem 2 publishes only two representative segment evaluations
+//! (Segment 1 and Segment 5) plus the facility summary, and its total facility
+//! length (5,280 ft) does not decompose uniquely into the two published
+//! segments, so an exact all-segment reproduction is not possible from the
+//! published data. These tests therefore (a) validate the aggregation
+//! equations exactly on controlled inputs and known invariants, and (b) anchor
+//! to Example Problem 2 by confirming that a facility built from its two
+//! published segments reproduces the composition-insensitive facility scores
+//! (pedestrian ~2.91, bicycle 3.02) and the C/C/C facility LOS letters.
+
+use transportations_library::hcm::common::LevelOfService;
+use transportations_library::hcm::urban_facilities::urban_facilities::{
+    facility_bicycle_los, facility_pedestrian_los, facility_pedestrian_space,
+    facility_transit_los, facility_transit_los_score, facility_transit_travel_speed,
+    facility_weighted_los_score,
+};
+
+fn approx(a: f64, b: f64, tol: f64, label: &str) {
+    assert!((a - b).abs() <= tol, "{label}: got {a}, expected {b} (+-{tol})");
+}
+
+// ── Aggregation invariants ─────────────────────────────────────────────────
+
+/// A single-segment facility must return that segment's own value for every
+/// aggregation (the facility is the segment).
+#[test]
+fn single_segment_facility_equals_segment() {
+    // (length, travel speed, score)
+    let one = [(1320.0, 3.55, 2.93)];
+    approx(facility_weighted_los_score(&one), 2.93, 1e-9, "ped/bike weighted score");
+    approx(facility_transit_los_score(&[(1320.0, 3.43)]), 3.43, 1e-9, "transit score");
+    approx(facility_transit_travel_speed(&[(1320.0, 10.3)]), 10.3, 1e-9, "transit speed");
+    approx(facility_pedestrian_space(&[(1320.0, 809.9)]), 809.9, 1e-9, "pedestrian space");
+}
+
+/// A facility of identical segments returns the common segment value,
+/// independent of how many segments or their (equal) lengths.
+#[test]
+fn identical_segments_return_common_value() {
+    let segs = [(1000.0, 12.0, 3.02), (500.0, 12.0, 3.02), (750.0, 12.0, 3.02)];
+    approx(facility_weighted_los_score(&segs), 3.02, 1e-9, "weighted score");
+    let tr = [(1000.0, 3.02), (500.0, 3.02), (750.0, 3.02)];
+    approx(facility_transit_los_score(&tr), 3.02, 1e-9, "transit score");
+}
+
+/// Hand-computed two-segment example checks the exact Equation 16-7/16-8 /
+/// 16-10/16-11 arithmetic (travel-time-weighted generalized mean) and the
+/// Equation 16-13 length-weighted transit mean.
+#[test]
+fn hand_computed_two_segment_aggregation() {
+    // Segment A: L=1000 ft, S=10 ft/s, I=3.0 -> t=100 s, inner=(3-0.125)/0.75=3.8333
+    // Segment B: L=2000 ft, S=20 ft/s, I=4.0 -> t=100 s, inner=(4-0.125)/0.75=5.1667
+    // I_F = 0.75*[ (100*3.8333^3 + 100*5.1667^3)/200 ]^(1/3) + 0.125
+    //     = 0.75*[ (5632.9 + 13792.4)/200 ]^(1/3) + 0.125
+    //     = 0.75*[97.126]^(1/3) + 0.125 = 0.75*4.5987 + 0.125 = 3.574
+    let segs = [(1000.0, 10.0, 3.0), (2000.0, 20.0, 4.0)];
+    approx(facility_weighted_los_score(&segs), 3.574, 0.01, "Eq 16-7 weighted score");
+
+    // Transit Eq 16-13: (1000*3.0 + 2000*4.0)/3000 = 11000/3000 = 3.667
+    approx(facility_transit_los_score(&[(1000.0, 3.0), (2000.0, 4.0)]), 3.667, 0.001, "Eq 16-13");
+}
+
+// ── Example Problem 2 anchor ────────────────────────────────────────────────
+
+/// Example Problem 2 (eastbound): a facility built from the two published
+/// segment evaluations reproduces the composition-insensitive facility scores
+/// (pedestrian ~2.91, bicycle 3.02) and the published C/C/C facility LOS.
+///
+/// Published segment inputs (Exhibits 29-53 / 29-54, eastbound):
+/// * Segment 1 (L = 1,320 ft): ped speed 3.55 ft/s, ped score 2.93, ped space
+///   809.9; bike speed 13.16 mi/h, bike score 3.02; transit speed 10.3 mi/h,
+///   transit score 3.43.
+/// * Segment 5 (shorter): ped speed 3.18 ft/s, ped score 2.85, ped space
+///   225.4; bike speed 11.67 mi/h, bike score 3.01; transit speed 5.3 mi/h,
+///   transit score 3.99.
+///
+/// Because both published segments carry nearly identical bicycle and
+/// pedestrian scores, the aggregated facility scores are insensitive to the
+/// (unpublished) exact segment composition, so they reproduce the Exhibit
+/// 29-55 facility scores. The facility pedestrian space, travel speeds, and
+/// transit score depend on the full composition and are not asserted here.
+#[test]
+fn example_problem_2_facility_scores() {
+    // Interior segments follow Segment 1; the two downstream segments follow
+    // Segment 5 (per the book's "dominance of platoon flow for Segments 4 and
+    // 5"): three 1,320-ft Segment-1 segments and two 660-ft Segment-5 segments
+    // (total 5,280 ft, the published facility length).
+    let ped = [
+        (1320.0, 3.55, 2.93), (1320.0, 3.55, 2.93), (1320.0, 3.55, 2.93),
+        (660.0, 3.18, 2.85), (660.0, 3.18, 2.85),
+    ];
+    let bike = [
+        (1320.0, 13.16, 3.02), (1320.0, 13.16, 3.02), (1320.0, 13.16, 3.02),
+        (660.0, 11.67, 3.01), (660.0, 11.67, 3.01),
+    ];
+    let ped_score = facility_weighted_los_score(&ped);
+    let bike_score = facility_weighted_los_score(&bike);
+    approx(ped_score, 2.91, 0.03, "facility pedestrian score (published 2.91)");
+    approx(bike_score, 3.02, 0.02, "facility bicycle score (published 3.02)");
+
+    // Facility LOS from the aggregated scores (Exhibits 16-4/16-5, identical to
+    // the Chapter 18 segment thresholds). Facility pedestrian space is a full-
+    // composition measure; the published 422.2 ft^2/p is well inside the LOS-C
+    // band (>24-40 ... >60 → all >= C at this score), so the space cannot
+    // improve the score-based C.
+    assert_eq!(facility_bicycle_los(bike_score), LevelOfService::C, "bicycle LOS");
+    assert_eq!(
+        facility_pedestrian_los(ped_score, 422.2),
+        LevelOfService::C,
+        "pedestrian LOS"
+    );
+    // Transit is the one composition-sensitive score here (Segment 5's
+    // transit score, 3.99, is far from Segment 1's 3.43), so the published
+    // facility transit score of 3.48 cannot be reproduced without the exact
+    // segment set. The length-weighted aggregate is instead checked to lie
+    // between the two published segment scores, as any weighted average must.
+    let transit = [
+        (1320.0, 3.43), (1320.0, 3.43), (1320.0, 3.43),
+        (660.0, 3.99), (660.0, 3.99),
+    ];
+    let transit_score = facility_transit_los_score(&transit);
+    assert!(
+        (3.43..=3.99).contains(&transit_score),
+        "transit facility score {transit_score} must lie between the segment scores (published 3.48)"
+    );
+    // Sanity: the transit facility LOS letter comes from the same threshold as
+    // the segments (Exhibit 16-5 == 18-3).
+    let _ = facility_transit_los(transit_score);
+}

--- a/tests/test_chapter16_integration.py
+++ b/tests/test_chapter16_integration.py
@@ -85,3 +85,30 @@ class TestUrbanFacilityChapter18Pipeline:
     def test_json_round_trip(self, facility):
         restored = tl.UrbanFacility(facility.to_json())
         assert restored.num_segments == facility.num_segments
+
+
+class TestFacilityMultimodalAggregation:
+    """HCM Chapter 16 facility multimodal LOS aggregation (Eqs 16-7 to 16-13),
+    anchored to Chapter 29 Example Problem 2."""
+
+    def test_single_segment_identity(self):
+        # A one-segment facility returns the segment's own score.
+        assert tl.facility_pedestrian_or_bicycle_los_score([(1320.0, 3.55, 2.93)]) == pytest.approx(2.93, abs=1e-9)
+        assert tl.facility_transit_los_score_py([(1320.0, 3.43)]) == pytest.approx(3.43, abs=1e-9)
+
+    def test_hand_computed_two_segment(self):
+        # Eq 16-7: 0.75*[(100*3.8333^3 + 100*5.1667^3)/200]^(1/3)+0.125 = 3.574
+        score = tl.facility_pedestrian_or_bicycle_los_score([(1000.0, 10.0, 3.0), (2000.0, 20.0, 4.0)])
+        assert score == pytest.approx(3.574, abs=0.01)
+        # Eq 16-13: (1000*3 + 2000*4)/3000 = 3.667
+        assert tl.facility_transit_los_score_py([(1000.0, 3.0), (2000.0, 4.0)]) == pytest.approx(3.667, abs=0.001)
+
+    def test_example_problem_2_facility_scores(self):
+        ped = [(1320.0, 3.55, 2.93)] * 3 + [(660.0, 3.18, 2.85)] * 2
+        bike = [(1320.0, 13.16, 3.02)] * 3 + [(660.0, 11.67, 3.01)] * 2
+        ped_score = tl.facility_pedestrian_or_bicycle_los_score(ped)
+        bike_score = tl.facility_pedestrian_or_bicycle_los_score(bike)
+        assert ped_score == pytest.approx(2.91, abs=0.03)   # published 2.91
+        assert bike_score == pytest.approx(3.02, abs=0.02)  # published 3.02
+        assert tl.facility_pedestrian_los(ped_score, 422.2) == "C"
+        assert tl.facility_bicycle_los(bike_score) == "C"


### PR DESCRIPTION
Completes HCM Chapter 16 (Urban Street Facilities) by adding the facility-level **pedestrian, bicycle, and transit** LOS aggregation. Ch.16 EP1 (auto facility) and Ch.17 EP4/EP5 (reliability) were already covered; the gap was the multimodal facility method that Ch.29 Example Problems 2 and 3 exercise. This builds directly on the Ch.18 segment multimodal work merged in #55.

## What's implemented (Equations 16-5 through 16-13)

- **Facility travel speeds** (ped/bike/transit) and **pedestrian space** — length-weighted harmonic means (reuse the existing `length_weighted_harmonic_mean`).
- **`facility_weighted_los_score`** — the cube-root travel-time-weighted generalized mean of segment scores: `WTT_i = (L_i/S_i)·((I_i−0.125)/0.75)³`, then `I_F = 0.75·[ΣWTT_i / Σ(L_i/S_i)]^(1/3) + 0.125` (pedestrian Eq 16-7/16-8, bicycle Eq 16-10/16-11).
- **`facility_transit_los_score`** — the length-weighted average (Eq 16-13).
- **Facility LOS letters** reuse the Chapter 18 shared thresholds — Exhibit 16-4 == 18-2 (pedestrian, worse-of-score-and-space via `LevelOfService::max`) and Exhibit 16-5 == 18-3 (bicycle/transit), verified value-for-value identical.

All exposed to Python.

## Reproduction scope (honest note)

Chapter 29 Example Problem 2 publishes only **two representative segment evaluations** (Segment 1 and Segment 5) plus the facility summary, and its total facility length (5,280 ft) does not decompose uniquely into those segments — so an exact all-segment reproduction is not possible from the published data. The tests therefore:

1. **Validate the aggregation equations exactly** — single-segment identity, identical-segments identity, and a hand-computed two-segment example.
2. **Anchor to Example Problem 2** — a facility built from its two published segments reproduces the *composition-insensitive* facility scores (pedestrian ~2.91, bicycle 3.02) and the published **C / C** facility LOS, because both published segments score alike.

The facility **transit** score (3.48) and **pedestrian space** (422.2) are genuinely composition-sensitive (Segment 5's transit score 3.99 vs Segment 1's 3.43), so they are not asserted to the published value — the transit aggregate is instead checked to lie between the two segment scores, as any weighted average must. Example Problem 3 (pedestrian + parking improvements) uses the identical aggregation methodology and the same data limitation.

## Validation

- **640 Rust tests** + **137 pytest** pass (aggregation invariants + hand-computed + EP2 anchor, through the Rust API and PyO3 bindings).