### PR TITLE
A/A/A decisions on #62/#63/#65 and the 0.3.0 version roll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.3.0 — 2026-08
 
 ### Added
 
@@ -12,6 +12,8 @@
 ### Breaking
 
 - **`RampSegment::determine_los` and `RampSegment::run_analysis` now return `Option<LevelOfService>`**, and the PyO3 `RampSegment.run_analysis()` returns `None` instead of a letter. A major merge operating under capacity has no 7th Edition level of service; the previous code set `self.los = None` but returned `LevelOfService::E`, so a caller reading the return value got a letter the HCM does not sanction. Under Edition 7.1 this case always yields a letter, because Exhibit 14-2 extends its criteria to major merges and diverges.
+- **The Python step methods raise on a `version="7.1"` segment.** `determine_demand_flow()`, `determine_capacity()`, `estimate_speed()`, `determine_los()`, and the other stepwise methods implement the 7th Edition's numbered steps, which Edition 7.1 replaced with a different structure that has no one-to-one equivalents. They previously ran 7th Edition math silently regardless of the segment's version; they now raise `ValueError` pointing at `run_analysis()` / `analysis_v7_1()`. The two editions disagree on speeds, capacities, and LOS bands, so a silent wrong-edition number was the worst available behavior.
+- **`speed_avg` in the Edition 7.1 analysis results is optional.** When demand is so far past capacity that the speed impedance consumes the whole equivalent-basic-segment speed, Equations 13-7 and 14-2/14-3 have no physical meaning; the serialized `speed_avg` is now `null` there instead of a negative number. Density is infinite and LOS reads F in that regime, as before.
 - **`BasicFreeways::lc_r` and `lc_l` are `f64`, not `u32`.** The Exhibit 12-21 note says "Interpolate for noninteger values of right-side lateral clearance", which an integer field cannot express, and the previously dead interpolating lookup is now the implementation. Integer clearances read exactly the exhibit values, so existing results do not move; Python callers can pass ints or floats.
 
 ### Fixed
@@ -22,6 +24,7 @@
 - **Eight-lane P_FM could go negative.** The Exhibit 14-8 regression `0.2178 - 0.000125 v_R` falls below zero past roughly 1,742 pc/h of ramp demand, putting a negative flow in Lanes 1 and 2 and a negative density downstream. Both eight-lane forms and the Exhibit 14-9 base form are now clamped to a proportion, with a VERIFY-HCM note that a clamp signals an input outside the regression's fitted range.
 - Verified that Exhibit 25-17 and Exhibit 10-6 are identical value for value, closing an open question about whether `planning.rs` reusing `los_freeway_facility` was a mismatch. It is not; the module doc now records the check.
 - **The Edition 7.1 capacity quadratics refuse off-domain inputs instead of returning the wrong root.** Below FFS_adj = C_b,adj/45 (roughly SAF under 0.71 at 75 mi/h) the leading coefficient goes non-positive and `(-b + sqrt)/(2a)` is no longer the larger root; both solvers now return `None` there, consistent with their None-not-NaN design.
+- **Every Chapter 14 P_FM/P_FD selection is clamped to a proportion.** The eight-lane forms and the P_FD base form were already clamped; the six-lane adjacent-ramp candidates were not, and the Equation 14-5 form exceeds 1 once v_D/L_DOWN passes about 1.72, putting more flow into Lanes 1 and 2 than exists on the mainline. A clamp firing still means the input left the regression's fitted range.
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transportations_library"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Rei Tamaru <tamaru@wisc.edu>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/src/copython/merge_diverge.rs
+++ b/src/copython/merge_diverge.rs
@@ -26,6 +26,21 @@ pub struct RampSegment {
     pub inner: LibRampSegment,
 }
 
+impl RampSegment {
+    /// The stepwise methods implement the 7th Edition's numbered steps, which Edition 7.1
+    /// replaced with a different structure. Guard them so a "7.1" segment cannot silently
+    /// produce 7th Edition numbers.
+    fn require_v7(&self, method: &str) -> PyResult<()> {
+        if self.inner.version == HcmVersion::V7_1 {
+            return Err(PyValueError::new_err(format!(
+                "{method}() implements the 7th Edition step structure, but this segment is \
+                 version \"7.1\". Use run_analysis() or analysis_v7_1() instead."
+            )));
+        }
+        Ok(())
+    }
+}
+
 #[pymethods]
 impl RampSegment {
     /// Create an HCM Chapter 14 ramp-freeway junction.
@@ -197,44 +212,61 @@ impl RampSegment {
     }
 
     // ── HCM Ch.14 step methods (stateful; call in analysis order) ──────────
+    //
+    // These implement the 7th Edition's numbered steps. Edition 7.1 has a different step
+    // structure (equivalent basic segment, speed impedance, capacity quadratic) with no
+    // one-to-one equivalents, so on a version "7.1" segment they raise instead of silently
+    // returning 7th Edition numbers.
 
     /// Step 1: demand flows (v_F, v_R) in pc/h - Eq. 14-1.
-    pub fn determine_demand_flow(&mut self) -> (f64, f64) {
-        self.inner.determine_demand_flow()
+    /// 7th Edition only; raises on a "7.1" segment.
+    pub fn determine_demand_flow(&mut self) -> PyResult<(f64, f64)> {
+        self.require_v7("determine_demand_flow")?;
+        Ok(self.inner.determine_demand_flow())
     }
 
     /// Step 2: flow in Lanes 1 and 2, v_12 (pc/h) - Eqs. 14-2..14-19.
-    pub fn estimate_v12(&mut self) -> f64 {
-        self.inner.estimate_v12()
+    /// 7th Edition only; raises on a "7.1" segment.
+    pub fn estimate_v12(&mut self) -> PyResult<f64> {
+        self.require_v7("estimate_v12")?;
+        Ok(self.inner.estimate_v12())
     }
 
     /// Step 3: adjusted freeway capacity (pc/h) and capacity checks
     /// (Exhibits 14-10/14-12, Eq. 14-21).
-    pub fn determine_capacity(&mut self) -> f64 {
-        self.inner.determine_capacity()
+    /// 7th Edition only; raises on a "7.1" segment.
+    pub fn determine_capacity(&mut self) -> PyResult<f64> {
+        self.require_v7("determine_capacity")?;
+        Ok(self.inner.determine_capacity())
     }
 
     /// Step 4: density in the ramp influence area (pc/mi/ln)
     /// - Eqs. 14-22/14-23/14-28.
-    pub fn determine_density(&mut self) -> f64 {
-        self.inner.determine_density()
+    /// 7th Edition only; raises on a "7.1" segment.
+    pub fn determine_density(&mut self) -> PyResult<f64> {
+        self.require_v7("determine_density")?;
+        Ok(self.inner.determine_density())
     }
 
-    /// Level of service letter - Exhibit 14-3 (7th Edition) or Exhibit 14-2 (Edition 7.1).
+    /// Level of service letter - Exhibit 14-3 (7th Edition).
     ///
     /// Returns None for a major merge under capacity, where the 7th Edition defines no level of
-    /// service and only the capacity checks apply.
-    pub fn determine_los(&mut self) -> Option<String> {
-        self.inner.determine_los().map(|los| {
+    /// service and only the capacity checks apply. 7th Edition only; raises on a "7.1" segment
+    /// (use run_analysis() or analysis_v7_1(), whose Exhibit 14-2 criteria always yield a letter).
+    pub fn determine_los(&mut self) -> PyResult<Option<String>> {
+        self.require_v7("determine_los")?;
+        Ok(self.inner.determine_los().map(|los| {
             let c: char = los.into();
             c.to_string()
-        })
+        }))
     }
 
     /// Step 5: speeds (S_R, S_O or None, S) in mi/h
     /// - Exhibits 14-13/14-14/14-15.
-    pub fn estimate_speed(&mut self) -> (f64, Option<f64>, f64) {
-        self.inner.estimate_speed()
+    /// 7th Edition only; raises on a "7.1" segment.
+    pub fn estimate_speed(&mut self) -> PyResult<(f64, Option<f64>, f64)> {
+        self.require_v7("estimate_speed")?;
+        Ok(self.inner.estimate_speed())
     }
 
     /// Run the full Chapter 14 analysis for the junction's selected HCM edition; returns the LOS

--- a/src/copython/weaving.rs
+++ b/src/copython/weaving.rs
@@ -15,6 +15,21 @@ pub struct WeavingSegment {
     pub inner: LibWeavingSegment,
 }
 
+impl WeavingSegment {
+    /// The stepwise methods implement the 7th Edition's numbered steps, which Edition 7.1
+    /// replaced with a different structure. Guard them so a "7.1" segment cannot silently
+    /// produce 7th Edition numbers.
+    fn require_v7(&self, method: &str) -> PyResult<()> {
+        if self.inner.version == HcmVersion::V7_1 {
+            return Err(PyValueError::new_err(format!(
+                "{method}() implements the 7th Edition step structure, but this segment is \
+                 version \"7.1\". Use run_analysis() or analysis_v7_1() instead."
+            )));
+        }
+        Ok(())
+    }
+}
+
 #[pymethods]
 impl WeavingSegment {
     /// Create an HCM Chapter 13 weaving segment.
@@ -175,47 +190,67 @@ impl WeavingSegment {
     }
 
     // ── HCM Ch.13 step methods (stateful; call in analysis order) ──────────
+    //
+    // These implement the 7th Edition's numbered steps. Edition 7.1 has a different step
+    // structure (equivalent basic segment, speed impedance, capacity quadratic) with no
+    // one-to-one equivalents, so on a version "7.1" segment they raise instead of silently
+    // returning 7th Edition numbers.
 
     /// Step 2: demand flows under equivalent ideal conditions (Eq. 13-1).
-    /// Returns (v_W, v_NW, v) in pc/h.
-    pub fn determine_demand_flow(&mut self) -> (f64, f64, f64) {
-        self.inner.determine_demand_flow()
+    /// Returns (v_W, v_NW, v) in pc/h. 7th Edition only; raises on a "7.1" segment.
+    pub fn determine_demand_flow(&mut self) -> PyResult<(f64, f64, f64)> {
+        self.require_v7("determine_demand_flow")?;
+        Ok(self.inner.determine_demand_flow())
     }
 
     /// Step 3: minimum lane-changing rate LC_MIN (lc/h) - Eqs. 13-2/13-3.
-    pub fn determine_configuration_characteristics(&mut self) -> f64 {
-        self.inner.determine_configuration_characteristics()
+    /// 7th Edition only; raises on a "7.1" segment.
+    pub fn determine_configuration_characteristics(&mut self) -> PyResult<f64> {
+        self.require_v7("determine_configuration_characteristics")?;
+        Ok(self.inner.determine_configuration_characteristics())
     }
 
     /// Step 4: maximum weaving length L_MAX (ft) - Eq. 13-4.
-    pub fn determine_max_weaving_length(&mut self) -> f64 {
-        self.inner.determine_max_weaving_length()
+    /// 7th Edition only; raises on a "7.1" segment.
+    pub fn determine_max_weaving_length(&mut self) -> PyResult<f64> {
+        self.require_v7("determine_max_weaving_length")?;
+        Ok(self.inner.determine_max_weaving_length())
     }
 
     /// Step 5: weaving segment capacity (veh/h) - Eqs. 13-5..13-10.
-    pub fn determine_capacity(&mut self) -> f64 {
-        self.inner.determine_capacity()
+    /// 7th Edition only; raises on a "7.1" segment.
+    pub fn determine_capacity(&mut self) -> PyResult<f64> {
+        self.require_v7("determine_capacity")?;
+        Ok(self.inner.determine_capacity())
     }
 
     /// Step 6: total lane-changing rate LC_ALL (lc/h) - Eqs. 13-11..13-17.
-    pub fn determine_lane_changing_rates(&mut self) -> f64 {
-        self.inner.determine_lane_changing_rates()
+    /// 7th Edition only; raises on a "7.1" segment.
+    pub fn determine_lane_changing_rates(&mut self) -> PyResult<f64> {
+        self.require_v7("determine_lane_changing_rates")?;
+        Ok(self.inner.determine_lane_changing_rates())
     }
 
     /// Step 7: speeds (S_W, S_NW, S) in mi/h - Eqs. 13-18..13-22.
-    pub fn estimate_speed(&mut self) -> (f64, f64, f64) {
-        self.inner.estimate_speed()
+    /// 7th Edition only; raises on a "7.1" segment.
+    pub fn estimate_speed(&mut self) -> PyResult<(f64, f64, f64)> {
+        self.require_v7("estimate_speed")?;
+        Ok(self.inner.estimate_speed())
     }
 
     /// Step 8a: density (pc/mi/ln) - Eq. 13-23.
-    pub fn determine_density(&mut self) -> f64 {
-        self.inner.determine_density()
+    /// 7th Edition only; raises on a "7.1" segment.
+    pub fn determine_density(&mut self) -> PyResult<f64> {
+        self.require_v7("determine_density")?;
+        Ok(self.inner.determine_density())
     }
 
     /// Step 8b: level of service letter - Exhibit 13-6.
-    pub fn determine_los(&mut self) -> String {
+    /// 7th Edition only; raises on a "7.1" segment.
+    pub fn determine_los(&mut self) -> PyResult<String> {
+        self.require_v7("determine_los")?;
         let los: char = self.inner.determine_los().into();
-        los.to_string()
+        Ok(los.to_string())
     }
 
     /// Run the full Chapter 13 analysis for the segment's selected HCM edition; returns the LOS

--- a/src/hcm/merge_diverge/merge_diverge.rs
+++ b/src/hcm/merge_diverge/merge_diverge.rs
@@ -517,9 +517,12 @@ impl RampSegment {
     /// Clamp a modeled proportion into [0, 1].
     ///
     /// The Exhibit 14-8 and 14-9 regressions are unbounded polynomials; outside the conditions
-    /// they were fitted on they can return values that are not proportions at all. Clamping keeps
-    /// a non-physical intermediate from propagating into flows and densities that still look
-    /// plausible.
+    /// they were fitted on they can return values that are not proportions at all (the Equation
+    /// 14-5 form exceeds 1 at v_D/L_DOWN above about 1.7, the eight-lane forms go negative past
+    /// roughly 1,742 pc/h of ramp demand). Every P_FM/P_FD selection passes through this clamp
+    /// before it becomes a flow, so a non-physical intermediate cannot propagate into flows and
+    /// densities that still look plausible. A clamp firing means the input is outside the range
+    /// the regression was fitted on; treat the result as an extrapolation.
     fn clamp_proportion(x: f64) -> f64 {
         x.clamp(0.0, 1.0)
     }
@@ -574,13 +577,16 @@ impl RampSegment {
                 }
 
                 // When both adjacent off-ramps apply, the larger P_FM governs
-                // (Chapter 14, Exhibit 14-8 discussion).
-                candidates
-                    .into_iter()
-                    .fold(None, |acc: Option<f64>, c| {
-                        Some(acc.map_or(c, |cur| cur.max(c)))
-                    })
-                    .unwrap_or(pfm_base)
+                // (Chapter 14, Exhibit 14-8 discussion). Clamped because the adjacent-ramp
+                // regressions are unbounded (Equation 14-5 passes 1 at v_D/L_DOWN ≈ 1.72).
+                Self::clamp_proportion(
+                    candidates
+                        .into_iter()
+                        .fold(None, |acc: Option<f64>, c| {
+                            Some(acc.map_or(c, |cur| cur.max(c)))
+                        })
+                        .unwrap_or(pfm_base),
+                )
             }
             _ => {
                 // 8-lane freeway (Exhibit 14-8):
@@ -654,13 +660,16 @@ impl RampSegment {
                     }
                 }
 
-                // When both adjacent ramps apply, the larger P_FD governs.
-                candidates
-                    .into_iter()
-                    .fold(None, |acc: Option<f64>, c| {
-                        Some(acc.map_or(c, |cur| cur.max(c)))
-                    })
-                    .unwrap_or(pfd_base)
+                // When both adjacent ramps apply, the larger P_FD governs. Clamped because the
+                // adjacent-ramp regressions are unbounded polynomials.
+                Self::clamp_proportion(
+                    candidates
+                        .into_iter()
+                        .fold(None, |acc: Option<f64>, c| {
+                            Some(acc.map_or(c, |cur| cur.max(c)))
+                        })
+                        .unwrap_or(pfd_base),
+                )
             }
             // 8-lane freeway: P_FD = 0.436 (constant) - Exhibit 14-9
             _ => 0.436,
@@ -1221,5 +1230,38 @@ mod tests {
         );
         // A non-negative proportion keeps the derived flow non-negative too.
         assert!(seg.v_12.unwrap() >= 0.0, "v_12 {:?}", seg.v_12);
+    }
+
+    /// The Equation 14-5 adjacent-off-ramp form `0.5487 + 0.2628 (v_D/L_DOWN)` passes 1 once
+    /// v_D/L_DOWN exceeds about 1.72 (here 1,000/400 gives 1.21 unclamped), which would put more
+    /// flow into Lanes 1 and 2 than exists on the mainline. The selection is clamped.
+    #[test]
+    fn six_lane_adjacent_ramp_pfm_stays_a_proportion() {
+        let mut seg = RampSegment {
+            ramp_type: RampType::OnRamp,
+            ramp_side: RampSide::Right,
+            ramp_lanes: RampLanes::OneLane,
+            freeway_lanes: 3,
+            freeway_ffs: 70.0,
+            ramp_ffs: 45.0,
+            accel_lane_length: Some(500.0),
+            freeway_demand: 4000.0,
+            ramp_demand: 500.0,
+            phf: 1.0,
+            heavy_vehicle_pct: 0.0,
+            terrain: TerrainType::Level,
+            adjacent_downstream: AdjacentRampType::OffRamp,
+            downstream_distance: Some(400.0),
+            downstream_ramp_flow: Some(1000.0),
+            ..Default::default()
+        };
+        seg.determine_demand_flow();
+        seg.estimate_v12();
+
+        let p_f = seg.p_f.expect("P_FM computed");
+        assert!(
+            (0.0..=1.0).contains(&p_f),
+            "P_FM {p_f} is not a proportion"
+        );
     }
 }

--- a/src/hcm/merge_diverge/v7_1.rs
+++ b/src/hcm/merge_diverge/v7_1.rs
@@ -198,7 +198,10 @@ pub struct RampAnalysis {
     /// Speed impedance SIM or SID (mi/h) - Equations 14-4/14-5.
     pub speed_impedance: f64,
     /// Average speed in the ramp influence area S_M or S_D (mi/h) - Equations 14-2/14-3.
-    pub speed_avg: f64,
+    /// `None` when the impedance consumes the whole basic-segment speed (demand far past
+    /// capacity, where the equation has no physical meaning); density is infinite and LOS
+    /// reads F there.
+    pub speed_avg: Option<f64>,
     /// Ramp influence area capacity C_M or C_D (pc/h/ln) - Equation 14-8.
     pub capacity_per_lane: Option<f64>,
     /// Demand-to-capacity ratio of the ramp influence area.
@@ -293,8 +296,12 @@ impl RampSegment {
                 DIVERGE_IMPEDANCE_COEFFICIENT,
             )
         };
-        // Equations 14-2 / 14-3.
-        let speed_avg = speed_basic - speed_impedance;
+        // Equations 14-2 / 14-3. None rather than a negative "speed" once the impedance
+        // consumes the whole basic-segment speed; consumers read null, not a number below zero.
+        let speed_avg = match speed_basic - speed_impedance {
+            s if s > 0.0 => Some(s),
+            _ => None,
+        };
 
         // Step 3: the three capacity checks.
         let capacity_per_lane = ramp_capacity_per_lane(
@@ -325,10 +332,9 @@ impl RampSegment {
             || flow_ramp > capacity_ramp_roadway;
 
         // Step 4: Equations 14-15 / 14-16.
-        let density = if speed_avg > 0.0 {
-            flow_per_lane / speed_avg
-        } else {
-            f64::INFINITY
+        let density = match speed_avg {
+            Some(s) => flow_per_lane / s,
+            None => f64::INFINITY,
         };
         let los = los_merge_diverge_v7_1(density, demand_exceeds_capacity);
 
@@ -364,8 +370,8 @@ impl RampSegment {
 
         self.flow_freeway = Some(a.flow_freeway);
         self.flow_ramp = Some(a.flow_ramp);
-        self.speed_ramp = Some(a.speed_avg);
-        self.speed_avg = Some(a.speed_avg);
+        self.speed_ramp = a.speed_avg;
+        self.speed_avg = a.speed_avg;
         self.density = Some(a.density);
         self.capacity_ramp = Some(a.capacity_ramp_roadway);
         self.capacity_freeway = Some(a.capacity_neighboring_freeway);

--- a/src/hcm/weaving/v7_1.rs
+++ b/src/hcm/weaving/v7_1.rs
@@ -317,8 +317,10 @@ pub struct WeavingAnalysis {
     pub weaving_intensity: f64,
     /// Speed impedance SIW (mi/h) - Equation 13-10.
     pub speed_impedance: f64,
-    /// Overall mean speed of all vehicles S_o (mi/h) - Equation 13-7.
-    pub speed_avg: f64,
+    /// Overall mean speed of all vehicles S_o (mi/h) - Equation 13-7. `None` when the speed
+    /// impedance consumes the whole basic-segment speed (demand far past capacity, where
+    /// Equation 13-7 has no physical meaning); density is infinite and LOS reads F there.
+    pub speed_avg: Option<f64>,
     /// Weaving segment capacity C_W (pc/h/ln) - Equation 13-16.
     pub capacity_per_lane: Option<f64>,
     /// Weaving segment capacity across all lanes (pc/h).
@@ -402,8 +404,12 @@ impl WeavingSegment {
             class.coefficients(),
         );
         let siw = speed_impedance(w, flow_per_lane);
-        // Equation 13-7.
-        let speed_avg = speed_basic - siw;
+        // Equation 13-7. None rather than a negative "speed" once the impedance consumes the
+        // whole basic-segment speed; consumers read null, not a number below zero.
+        let speed_avg = match speed_basic - siw {
+            s if s > 0.0 => Some(s),
+            _ => None,
+        };
 
         // Step 4: capacity and d/c.
         let capacity_per_lane =
@@ -420,10 +426,9 @@ impl WeavingSegment {
 
         // Step 5: density and LOS. Above capacity the speed from Step 3 is discarded and LOS F is
         // assigned, per the Level of Service F discussion in Step 4.
-        let density = if speed_avg > 0.0 {
-            flow_per_lane / speed_avg
-        } else {
-            f64::INFINITY
+        let density = match speed_avg {
+            Some(s) => flow_per_lane / s,
+            None => f64::INFINITY,
         };
         let los = determine_weaving_los(density, demand_exceeds_capacity);
 
@@ -465,7 +470,7 @@ impl WeavingSegment {
         self.f_hv = Some(a.f_hv);
         self.flow_total = Some(a.flow_total);
         self.weaving_intensity = Some(a.weaving_intensity);
-        self.speed_avg = Some(a.speed_avg);
+        self.speed_avg = a.speed_avg;
         self.density = Some(a.density);
         self.demand_exceeds_capacity = Some(a.demand_exceeds_capacity);
         self.los = Some(a.los);
@@ -575,7 +580,7 @@ mod tests {
             "SIW {}",
             a.speed_impedance
         );
-        assert!((a.speed_avg - 59.32).abs() < 0.02, "S_o {}", a.speed_avg);
+        assert!((a.speed_avg.unwrap() - 59.32).abs() < 0.02, "S_o {:?}", a.speed_avg);
 
         let cw = a.capacity_per_lane.expect("capacity");
         assert!((cw - 1866.0).abs() < 2.0, "C_W {cw}");

--- a/tests/chapter13_v7_1_integration.rs
+++ b/tests/chapter13_v7_1_integration.rs
@@ -59,7 +59,7 @@ fn example_problem_1_complex_weave() {
     approx(a.speed_basic, 65.0, 1e-9, "S_b");
     approx(a.weaving_intensity, 0.006336, 5e-6, "W");
     approx(a.speed_impedance, 5.68, 0.02, "SIW");
-    approx(a.speed_avg, 59.32, 0.02, "S_o");
+    approx(a.speed_avg.unwrap(), 59.32, 0.02, "S_o");
     approx(a.capacity_per_lane.unwrap(), 1866.0, 2.0, "C_W");
     approx(a.dc_ratio.unwrap(), 0.75, 0.005, "d/c");
     approx(a.density, 23.6, 0.1, "D");
@@ -110,7 +110,7 @@ fn example_problem_2_simple_weave() {
     approx(a.speed_basic, 74.31, 0.01, "S_b");
     approx(a.weaving_intensity, 0.004814, 5e-6, "W");
     approx(a.speed_impedance, 3.61, 0.01, "SIW");
-    approx(a.speed_avg, 70.70, 0.01, "S_o");
+    approx(a.speed_avg.unwrap(), 70.70, 0.01, "S_o");
     approx(a.capacity_per_lane.unwrap(), 1992.0, 2.0, "C_W");
     approx(a.dc_ratio.unwrap(), 0.63, 0.005, "d/c");
     approx(a.density, 17.7, 0.05, "D");
@@ -155,7 +155,7 @@ fn example_problem_3_two_sided_weave() {
     approx(a.speed_basic, 59.31, 0.02, "S_b");
     approx(a.weaving_intensity, 0.005199, 5e-6, "W");
     approx(a.speed_impedance, 6.73, 0.02, "SIW");
-    approx(a.speed_avg, 52.58, 0.03, "S_o");
+    approx(a.speed_avg.unwrap(), 52.58, 0.03, "S_o");
     approx(a.capacity_per_lane.unwrap(), 1827.0, 3.0, "C_W");
     approx(a.dc_ratio.unwrap(), 0.98, 0.005, "d/c");
     approx(a.density, 34.1, 0.1, "D");

--- a/tests/chapter14_v7_1_integration.rs
+++ b/tests/chapter14_v7_1_integration.rs
@@ -51,7 +51,7 @@ fn example_problem_1_isolated_on_ramp() {
     approx(a.capacity_basic_adj, 2300.0, 1e-9, "C_b,adj");
     approx(a.speed_basic, 59.47, 0.02, "S_b");
     approx(a.speed_impedance, 4.37, 0.02, "SIM");
-    approx(a.speed_avg, 55.10, 0.03, "S_M");
+    approx(a.speed_avg.unwrap(), 55.10, 0.03, "S_M");
     approx(a.capacity_per_lane.unwrap(), 1882.0, 3.0, "C_M");
     approx(a.dc_ratio.unwrap(), 0.94, 0.005, "d/c");
 
@@ -99,7 +99,7 @@ fn example_problem_2_first_off_ramp() {
     approx(a.flow_per_lane, 1698.0, 2.0, "v_1/N");
     approx(a.speed_basic, 59.83, 0.02, "S_b");
     approx(a.speed_impedance, 2.04, 0.02, "SID");
-    approx(a.speed_avg, 57.79, 0.03, "S_D");
+    approx(a.speed_avg.unwrap(), 57.79, 0.03, "S_D");
     approx(a.capacity_per_lane.unwrap(), 1940.0, 3.0, "C_D");
     approx(a.capacity_neighboring_freeway, 6900.0, 1e-9, "upstream freeway capacity");
     approx(a.capacity_ramp_roadway, 2000.0, 1e-9, "ramp roadway capacity");
@@ -141,7 +141,7 @@ fn example_problem_2_second_off_ramp() {
     // Below the breakpoint, so the basic segment runs at the adjusted FFS.
     approx(a.speed_basic, 60.0, 1e-9, "S_b");
     approx(a.speed_impedance, 4.04, 0.02, "SID");
-    approx(a.speed_avg, 55.96, 0.03, "S_D");
+    approx(a.speed_avg.unwrap(), 55.96, 0.03, "S_D");
     approx(a.capacity_per_lane.unwrap(), 1874.0, 3.0, "C_D");
     approx(a.capacity_ramp_roadway, 1900.0, 1e-9, "ramp roadway capacity");
     assert!(!a.demand_exceeds_capacity);

--- a/tests/test_hcm_7_1_integration.py
+++ b/tests/test_hcm_7_1_integration.py
@@ -181,3 +181,65 @@ def test_version_is_settable_after_construction():
     assert seg.version == "7.1"
     with pytest.raises(ValueError):
         seg.version = "nonsense"
+
+
+def test_v7_step_methods_raise_on_a_7_1_segment():
+    """The stepwise methods implement the 7th Edition's numbered steps; a "7.1" segment must
+    raise rather than silently return 7th Edition numbers (the two editions disagree on speeds,
+    capacities, and LOS bands)."""
+    weave = tl.WeavingSegment(version="7.1")
+    for method in (
+        "determine_demand_flow",
+        "determine_configuration_characteristics",
+        "determine_max_weaving_length",
+        "determine_capacity",
+        "determine_lane_changing_rates",
+        "estimate_speed",
+        "determine_density",
+        "determine_los",
+    ):
+        with pytest.raises(ValueError, match="7th Edition step structure"):
+            getattr(weave, method)()
+
+    ramp = tl.RampSegment(version="7.1")
+    for method in (
+        "determine_demand_flow",
+        "estimate_v12",
+        "determine_capacity",
+        "determine_density",
+        "determine_los",
+        "estimate_speed",
+    ):
+        with pytest.raises(ValueError, match="7th Edition step structure"):
+            getattr(ramp, method)()
+
+    # run_analysis and analysis_v7_1 remain the sanctioned 7.1 entry points.
+    assert weave.run_analysis() is not None
+
+
+def test_7_1_speed_avg_is_none_far_past_capacity():
+    """Past the point where the speed impedance consumes the whole basic-segment speed, the
+    serialized speed_avg is null rather than a negative number; density is infinite and LOS
+    reads F."""
+    seg = tl.WeavingSegment(
+        version="7.1",
+        weaving_type="one_sided",
+        length_short=300.0,
+        num_lanes=2,
+        num_weaving_lanes=2,
+        ffs=75.0,
+        v_ff=6000.0,
+        v_fr=4000.0,
+        v_rf=4000.0,
+        v_rr=2000.0,
+        phf=1.0,
+        heavy_vehicle_pct=0.0,
+        lc_rf=2,
+        lc_fr=2,
+        nw_rf=1,
+        nw_fr=1,
+    )
+    assert seg.run_analysis() == "F"
+    a = json.loads(seg.analysis_v7_1())
+    assert a["speed_avg"] is None
+    assert a["los"] == "F"


### PR DESCRIPTION
Closes #62, closes #63, closes #65 - implementing the agreed option A on each.

- **#62**: the PyO3 stepwise methods on `WeavingSegment` and `RampSegment` raise `ValueError` on a `version="7.1"` segment instead of silently running 7th Edition math. The message points at `run_analysis()` / `analysis_v7_1()`. Pinned by a Python test covering all fourteen step methods.
- **#63**: `speed_avg` in both 7.1 analysis structs is `Option<f64>`, `null` in the JSON once the speed impedance consumes the whole equivalent-basic-segment speed. Density stays infinite and LOS stays F there. Pinned by a far-past-capacity Python test.
- **#65**: every Chapter 14 P_FM/P_FD selection now passes through `clamp_proportion`, closing the six-lane adjacent-ramp gap (Equation 14-5 exceeds 1 at v_D/L_DOWN above about 1.72). Pinned by a six-lane adjacent-off-ramp test. No published example moves.
- **Version rolls to 0.3.0** and the changelog's Unreleased section becomes the 0.3.0 entry. Breaking since 0.2.0: `Option<LevelOfService>` returns, `f64` lateral clearances, raising 7.1 step methods, optional 7.1 `speed_avg`.

Gates: cargo test 0 failures, clippy exit 0, maturin + pytest 151 passed, middleware compiles against the branch. Tag `v0.3.0` after this merges and reconciles to main.